### PR TITLE
Initial attributes API

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -1,3 +1,18 @@
+public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
+	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
+	public abstract fun setDoubleListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setLongAttribute (Ljava/lang/String;J)V
+	public abstract fun setLongListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setStringAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtKt {
+	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
+}
+
 public final class io/embrace/opentelemetry/kotlin/print/CustomPrintAndroidKt {
 	public static final fun getMessage ()Ljava/lang/String;
 }

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -1,3 +1,18 @@
+public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
+	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
+	public abstract fun setDoubleListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setLongAttribute (Ljava/lang/String;J)V
+	public abstract fun setLongListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun setStringAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtKt {
+	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
+}
+
 public final class io/embrace/opentelemetry/kotlin/print/CustomFibiJvmKt {
 	public static final fun getMessage ()Ljava/lang/String;
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -1,0 +1,49 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+/**
+ * Implementations of this interface hold 'attributes' as described in the OTel specification.
+ *
+ * https://opentelemetry.io/docs/specs/otel/common/#attribute
+ */
+public interface AttributeContainer {
+
+    /**
+     * Sets an attribute with a boolean value.
+     */
+    public fun setBooleanAttribute(key: String, value: Boolean)
+
+    /**
+     * Sets an attribute with a string value.
+     */
+    public fun setStringAttribute(key: String, value: String)
+
+    /**
+     * Sets an attribute with a long value.
+     */
+    public fun setLongAttribute(key: String, value: Long)
+
+    /**
+     * Sets an attribute with a double value.
+     */
+    public fun setDoubleAttribute(key: String, value: Double)
+
+    /**
+     * Sets an attribute with a list of boolean values.
+     */
+    public fun setBooleanListAttribute(key: String, value: List<Boolean>)
+
+    /**
+     * Sets an attribute with a list of string values.
+     */
+    public fun setStringListAttribute(key: String, value: List<String>)
+
+    /**
+     * Sets an attribute with a list of long values.
+     */
+    public fun setLongListAttribute(key: String, value: List<Long>)
+
+    /**
+     * Sets an attribute with a list of double values.
+     */
+    public fun setDoubleListAttribute(key: String, value: List<Double>)
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+/**
+ * Sets attributes on an [AttributeContainer] from a [Map]. Only values in the map of a type supported by the
+ * OpenTelemetry API will be set. Other values will be ignored.
+ *
+ * https://opentelemetry.io/docs/specs/otel/common/#attribute
+ */
+@Suppress("UNUSED_PARAMETER")
+public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
+    TODO("Implement me")
+}


### PR DESCRIPTION
# Goal

An initial attempt at an API for `Attributes` that we would like to expose to consumers of this library. After reading through the [OTel spec](https://opentelemetry.io/docs/specs/otel/common/#attribute) I found the following requirements were essential:

- Key should be a string
- Value should be string/bool/long/double or collection of these primitives
- It should be possible to set attributes [on various types](https://opentelemetry.io/docs/specs/otel/common/#attribute-collections) in the API
- The API _may_ have a method [named `SetAttribute`](https://opentelemetry.io/docs/specs/otel/trace/api/#set-attributes)

## Discussion of chosen approach

I've created an interface named `AttributeAware` that Spans/Resources etc should implement and maintain consistency in both API signatures + behavior. This interface is write-only as there is no requirement in the OTel spec for reading attributes. A potential deviation is the [`SetAttribute` method](https://opentelemetry.io/docs/specs/otel/trace/api/#set-attributes) - I've chosen to offer separate APIs as suggested in the spec, as this avoids unnecessary heap allocations that could plausibly affect JVM performance.

This approach avoids exposing the concept of an `Attribute` interface/class that would contain information such as `value: Any` and the type of value. This is almost certainly something we want as part of our implementation but we don't need to tie ourselves to a specific API or worry about how consumers should construct those objects.

I have included syntactic sugar in a top-level extension function that sets attributes on a container given a map. Generally speaking I do think it's worth considering a separate module for these type of functions: they're not mandatory in our API, and they do require an implementation within an API module which seems like a design smell. We can reassess this as more APIs are added to the codebase.

## Alternative approaches

An alternative approach would be to expose an `Attribute` interface that contains the key, value, and type. This exposes substantially more complexity onto the library consumer than just adding primitive values, and means we have to create top-level functions to avoid exposing constructors for whatever implements `Attribute`.

Thought was also given to exposing a sealed class hierarchy that allows only attribute values of the given type. This would work but suffers the same downsides as the `Attribute` interface approach. I also explored the use of inline value classes which is promising, but these cannot be extended to form a sealed hierarchy.