### PR TITLE
Create initial parts of tracing api

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -1,3 +1,19 @@
+public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Error : io/embrace/opentelemetry/kotlin/StatusCode {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getDescription ()Ljava/lang/String;
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Ok : io/embrace/opentelemetry/kotlin/StatusCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Ok;
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace/opentelemetry/kotlin/StatusCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Unset;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
@@ -19,5 +35,37 @@ public final class io/embrace/opentelemetry/kotlin/print/CustomPrintAndroidKt {
 
 public final class io/embrace/opentelemetry/kotlin/print/CustomPrintKt {
 	public static final fun printPlatformString ()V
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/Enum {
+	public static final field CLIENT Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field CONSUMER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field INTERNAL Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field PRODUCER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field SERVER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {
+	public abstract fun createSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public abstract fun getEnabled ()Z
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
+	public abstract fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/TracerProvider$DefaultImpls {
+	public static synthetic fun getTracer$default (Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -1,3 +1,19 @@
+public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Error : io/embrace/opentelemetry/kotlin/StatusCode {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getDescription ()Ljava/lang/String;
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Ok : io/embrace/opentelemetry/kotlin/StatusCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Ok;
+}
+
+public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace/opentelemetry/kotlin/StatusCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Unset;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
@@ -19,5 +35,37 @@ public final class io/embrace/opentelemetry/kotlin/print/CustomFibiJvmKt {
 
 public final class io/embrace/opentelemetry/kotlin/print/CustomPrintKt {
 	public static final fun printPlatformString ()V
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/Enum {
+	public static final field CLIENT Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field CONSUMER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field INTERNAL Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field PRODUCER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static final field SERVER Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {
+	public abstract fun createSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public abstract fun getEnabled ()Z
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
+	public abstract fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/TracerProvider$DefaultImpls {
+	public static synthetic fun getTracer$default (Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/StatusCode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/StatusCode.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Represents the status of an operation.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#set-status
+ */
+public sealed class StatusCode {
+
+    /**
+     * Default status.
+     */
+    public object Unset : StatusCode()
+
+    /**
+     * The operation completed successfully.
+     */
+    public object Ok : StatusCode()
+
+    /**
+     * The operation completed with an error. An optional description of the error may be provided.
+     */
+    public class Error(public val description: String) : StatusCode()
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Represents a link to a [SpanContext] and optional attributes further describing the link.
+ */
+public interface Link // TODO: stub interface

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -1,0 +1,8 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+/**
+ * A span represents a single operation within a trace.
+ */
+public interface Span : AttributeContainer // TODO: stub interface

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Represents the state of a Span that must be serialized & propagated along a distributed context.
+ */
+public interface SpanContext // TODO: stub interface

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanKind.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanKind.kt
@@ -1,0 +1,32 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Clarifies the relationship between spans correlated via parent/child relationship or span links.
+ */
+public enum class SpanKind {
+
+    /**
+     * A server handling a remote request
+     */
+    SERVER,
+
+    /**
+     * A client handling a remote request
+     */
+    CLIENT,
+
+    /**
+     * Represents the scheduling/initiation of a local/remote operation
+     */
+    PRODUCER,
+
+    /**
+     * Represents the processing of an operation initiated by a [PRODUCER] span
+     */
+    CONSUMER,
+
+    /**
+     * Default value indicating an internal operation within an application.
+     */
+    INTERNAL,
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -1,0 +1,20 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * A Tracer is responsible for creating spans.
+ */
+public interface Tracer {
+
+    /**
+     * Returns true if the Tracer is enabled. This value may change over time.
+     */
+    public val enabled: Boolean
+
+    /**
+     * Creates a new span.
+     */
+    public fun createSpan(
+        name: String,
+        action: Span.() -> Unit
+    ): Span
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * TracerProvider is a factory for retrieving instances of [Tracer].
+ */
+public interface TracerProvider {
+
+    /**
+     * Returns a [Tracer] matching the given name and (optional) version.
+     *
+     * The name must document the instrumentation scope: https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope
+     */
+    public fun getTracer(name: String, version: String? = null): Tracer
+}


### PR DESCRIPTION
## Goal

Creates the initial parts of the OTel Tracing API. I've attempted to include the non-controversial parts of the spec that are fairly prescriptive in how the API should be designed. This includes `SpanKind` and `StatusCode` (represented as enums/sealed classes), `Tracer/TracerProvider`, and stub interfaces.
