### PR TITLE
Additional tracing api additions

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/android/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/android/opentelemetry-kotlin-api-ext.api
@@ -2,3 +2,12 @@ public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer
 	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {
+	public static final fun getSpanIdBytes (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)[B
+	public static final fun getTraceIdBytes (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)[B
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
+	public static final fun recordException (Lio/embrace/opentelemetry/kotlin/tracing/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/opentelemetry-kotlin-api-ext/api/jvm/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/jvm/opentelemetry-kotlin-api-ext.api
@@ -2,3 +2,12 @@ public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer
 	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {
+	public static final fun getSpanIdBytes (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)[B
+	public static final fun getTraceIdBytes (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)[B
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
+	public static final fun recordException (Lio/embrace/opentelemetry/kotlin/tracing/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Gets the trace ID as a byte array.
+ */
+public val SpanContext.traceIdBytes: ByteArray get() = traceId.toByteArray()
+
+/**
+ * Gets the span ID as a byte array.
+ */
+public val SpanContext.spanIdBytes: ByteArray get() = spanId.toByteArray()

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Record an exception on the span as an event.
+ */
+@Suppress("UNUSED_PARAMETER")
+public fun Span.recordException(exception: Throwable, action: SpanEvent.() -> Unit) {
+    TODO()
+}

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -42,9 +42,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
 	public abstract fun getSpanId ()Ljava/lang/String;
+	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
+	public abstract fun getTraceState ()Lio/embrace/opentelemetry/kotlin/tracing/TraceState;
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
+	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -61,10 +64,17 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceFlags {
+	public abstract fun isRandom ()Z
 	public abstract fun isSampled ()Z
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceState {
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceStateMutator {
+	public abstract fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun remove (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -42,9 +42,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
 	public abstract fun getSpanId ()Ljava/lang/String;
+	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
+	public abstract fun getTraceState ()Lio/embrace/opentelemetry/kotlin/tracing/TraceState;
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
+	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -61,10 +64,17 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceFlags {
+	public abstract fun isRandom ()Z
 	public abstract fun isSampled ()Z
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceState {
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceStateMutator {
+	public abstract fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun remove (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -20,6 +20,11 @@ public interface SpanContext {
     public val spanId: String
 
     /**
+     * Contains details about the trace.
+     */
+    public val traceFlags: TraceFlags
+
+    /**
      * True if the SpanContext has a valid trace ID and span ID.
      */
     public val isValid: Boolean
@@ -28,4 +33,15 @@ public interface SpanContext {
      * True if the SpanContext was propagated from a remote parent.
      */
     public val isRemote: Boolean
+
+    /**
+     * Contains state about the trace.
+     */
+    public fun getTraceState(): TraceState
+
+    /**
+     * Mutates the trace state with the given action and replaces [traceState] with a new immutable object
+     * containing the changes.
+     */
+    public fun updateTraceState(action: TraceStateMutator.() -> Unit)
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceFlags.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceFlags.kt
@@ -11,4 +11,9 @@ public interface TraceFlags {
      * True if the trace is sampled.
      */
     public val isSampled: Boolean
+
+    /**
+     * True if the trace is random.
+     */
+    public val isRandom: Boolean
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceState.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceState.kt
@@ -5,4 +5,10 @@ package io.embrace.opentelemetry.kotlin.tracing
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate
  */
-public interface TraceState // TODO: stub interface
+public interface TraceState {
+
+    /**
+     * Returns the value associated with the given key, or null if the key is not present.
+     */
+    public fun get(key: String): String?
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceStateMutator.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceStateMutator.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+/**
+ * Mutates [TraceState].
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate
+ */
+public interface TraceStateMutator {
+
+    /**
+     * Removes the key and its associated value from this TraceState.
+     */
+    public fun remove(key: String): String?
+
+    /**
+     * Adds a key-value pair to this TraceState.
+     */
+    public fun put(key: String, value: String)
+}


### PR DESCRIPTION
## Goal

Adds some additional interfaces to the Tracing API, namely:

- extension functions on `Span` and `SpanContext` that implement requirements in the OTel spec that we consider syntactic sugar
- `TraceFlags`
- `TraceState`

