### PR TITLE
MVP for binding our Kotlin API to the official Tracing API

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
@@ -1,5 +1,6 @@
 package io.embrace.otel
 
+import org.gradle.kotlin.dsl.exclude
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -21,7 +22,10 @@ fun configureKotlin(kotlin: KotlinMultiplatformExtension) {
             }
             getByName("commonTest").apply {
                 dependencies {
-                    implementation("org.jetbrains.kotlin:kotlin-test")
+                    implementation("org.jetbrains.kotlin:kotlin-test") {
+                        exclude(group = "junit")
+                        exclude(group = "org.junit")
+                    }
                 }
             }
         }

--- a/compat-kotlin-to-official/build.gradle.kts
+++ b/compat-kotlin-to-official/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
                 api(project(":opentelemetry-kotlin-api"))
                 api(project.dependencies.platform(libs.opentelemetry.bom))
                 api(libs.opentelemetry.api)
+                implementation(libs.opentelemetry.sdk)
             }
         }
     }

--- a/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -1,0 +1,93 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.Link
+import io.embrace.opentelemetry.kotlin.tracing.Span
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+import java.util.concurrent.TimeUnit
+
+internal class SpanAdapter(private val impl: io.opentelemetry.api.trace.Span) : Span {
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override var name: String
+        get() = TODO()
+        set(value) {
+            impl.updateName(value)
+        }
+
+    override var status: StatusCode
+        get() = TODO()
+        set(value) {
+            impl.setStatus(value.convertToOtelJava())
+        }
+
+    override var spanKind: SpanKind
+        get() = TODO("Not yet implemented")
+        set(value) {
+            TODO("$value")
+        }
+
+    override var parent: SpanContext?
+        get() = TODO("Not yet implemented")
+        set(value) {
+            TODO("$value")
+        }
+
+    override fun updateStartTimestamp(timestamp: Long, unit: TimeUnit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun end(timestamp: Long?, unit: TimeUnit) {
+        if (timestamp != null) {
+            impl.end(timestamp, unit)
+        } else {
+            impl.end()
+        }
+    }
+
+    override val isRecording: Boolean
+        get() = impl.isRecording
+
+    override fun addLink(spanContext: SpanContext, action: Link.() -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, timestamp: Long?, action: SpanEvent.() -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun close() = end()
+}

--- a/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
+++ b/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.StatusCode
+
+internal fun StatusCode.convertToOtelJava(): io.opentelemetry.api.trace.StatusCode {
+    TODO()
+}

--- a/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.tracing.Span
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipContainer
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+
+internal class TracerAdapter(private val tracer: io.opentelemetry.api.trace.Tracer) : Tracer {
+    override fun createSpan(
+        name: String,
+        parent: SpanContext?,
+        spanKind: SpanKind,
+        startTimestamp: Long,
+        action: SpanRelationshipContainer.() -> Unit
+    ): Span {
+        val builder = tracer.spanBuilder(name)
+        // TODO: populate other fields
+        val span = builder.startSpan()
+        return SpanAdapter(span)
+    }
+}

--- a/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+import io.opentelemetry.api.OpenTelemetry
+
+internal class TracerProviderAdapter(private val otel: OpenTelemetry) : TracerProvider {
+    override fun getTracer(name: String, version: String?): Tracer {
+        val tracerProvider = otel.tracerProvider
+        val tracer = when (version) {
+            null -> tracerProvider.get(name)
+            else -> tracerProvider.get(name, version)
+        }
+        return TracerAdapter(tracer)
+    }
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/InMemorySpanExporter.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/InMemorySpanExporter.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+
+internal class InMemorySpanExporter : SpanExporter {
+
+    private val impl = mutableListOf<SpanData>()
+
+    val exportedSpans: List<SpanData>
+        get() = impl
+
+    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+        impl.addAll(spans)
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/InMemorySpanProcessor.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/InMemorySpanProcessor.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+
+internal class InMemorySpanProcessor(private val exporter: InMemorySpanExporter) : SpanProcessor {
+    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+    }
+
+    override fun isStartRequired(): Boolean = true
+
+    override fun onEnd(span: ReadableSpan) {
+        exporter.export(mutableListOf(span.toSpanData()))
+    }
+
+    override fun isEndRequired(): Boolean = true
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OtelJavaHarness.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OtelJavaHarness.kt
@@ -1,0 +1,37 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+internal class OtelJavaHarness {
+
+    private val exporter = InMemorySpanExporter()
+
+    val sdk: OpenTelemetry = OpenTelemetrySdk.builder().setTracerProvider(
+        SdkTracerProvider.builder().addSpanProcessor(InMemorySpanProcessor(exporter)).build()
+    ).build()
+
+
+    fun awaitSpans(expectedCount: Int, filter: (SpanData) -> Boolean = { true }): List<SpanData> {
+        val supplier = { exporter.exportedSpans.filter(filter) }
+        val tries = 1000
+        val countDownLatch = CountDownLatch(1)
+        repeat(tries) {
+            if (supplier().size != expectedCount) {
+                countDownLatch.await(1.toLong(), TimeUnit.MILLISECONDS)
+            } else {
+                return supplier()
+            }
+        }
+        val spans = supplier()
+        throw TimeoutException(
+            "Timeout. Expected $expectedCount spans, but got ${spans.size}. " +
+                    "Found spans: ${spans.joinToString { it.name }}"
+        )
+    }
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaHarness
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class SpanExportTest {
+
+    private lateinit var harness: OtelJavaHarness
+
+    @BeforeTest
+    fun setUp() {
+        harness = OtelJavaHarness()
+    }
+
+    @Test
+    fun `test span export`() {
+        val tracerProvider = TracerProviderAdapter(harness.sdk)
+        val tracer = tracerProvider.getTracer("name", "version")
+        val spanName = "my_span"
+        tracer.createSpan(spanName).end()
+        val observedSpan = harness.awaitSpans(1).single()
+        assertEquals(spanName, observedSpan.name)
+    }
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -13,6 +13,6 @@ public interface Tracer {
         parent: SpanContext? = null,
         spanKind: SpanKind = SpanKind.INTERNAL,
         startTimestamp: Long = 0, // TODO: supply via clock
-        action: SpanRelationshipContainer.() -> Unit
+        action: SpanRelationshipContainer.() -> Unit = {}
     ): Span
 }


### PR DESCRIPTION
## Goal

This changeset contains an MVP for binding our Kotlin API to the official OTel Java tracing API. This changeset creates an 'adapter' implementation of our Kotlin API that calls the necessary function on the OTel Java API. Function calls are specified as `convertToOtelJava`.

In addition, I've tweaked the dependencies so that the OTel Java SDK is available at compile-time for the compatibility module only. kotlin-test was also bringing in a transitive dependency on JUnit by default which got quite annoying with IDE auto-imports in the `commonTest` sourceSet, so I've removed that in favour of using the kotlin-test annotations entirely.

I've created a test that instantiates the OTel Java SDK and verifies that when our Kotlin API is called, a span is exported. The binding of our API is incomplete and will be addressed in future PRs.

