### PR TITLE
Enhance integration test for span export

### DIFF
--- a/compat-kotlin-to-official/build.gradle.kts
+++ b/compat-kotlin-to-official/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 group = "io.embrace.opentelemetry.kotlin"
@@ -23,6 +24,11 @@ kotlin {
                 api(project.dependencies.platform(libs.opentelemetry.bom))
                 api(libs.opentelemetry.api)
                 implementation(libs.opentelemetry.sdk)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.serialization)
             }
         }
     }

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/FakeClock.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/FakeClock.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework
+
+import io.opentelemetry.sdk.common.Clock
+
+internal class FakeClock : Clock {
+    var nanoseconds = 0L
+    override fun now(): Long = nanoseconds
+    override fun nanoTime(): Long = nanoseconds
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelJavaHarness.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelJavaHarness.kt
@@ -1,5 +1,7 @@
-package io.embrace.opentelemetry.kotlin.k2j
+package io.embrace.opentelemetry.kotlin.k2j.framework
 
+import io.embrace.opentelemetry.kotlin.k2j.InMemorySpanExporter
+import io.embrace.opentelemetry.kotlin.k2j.InMemorySpanProcessor
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -12,10 +14,14 @@ internal class OtelJavaHarness {
 
     private val exporter = InMemorySpanExporter()
 
-    val sdk: OpenTelemetry = OpenTelemetrySdk.builder().setTracerProvider(
-        SdkTracerProvider.builder().addSpanProcessor(InMemorySpanProcessor(exporter)).build()
-    ).build()
+    private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(InMemorySpanProcessor(exporter))
+        .setClock(FakeClock())
+        .build()
 
+    val sdk: OpenTelemetry = OpenTelemetrySdk.builder().setTracerProvider(
+        tracerProvider
+    ).build()
 
     fun awaitSpans(expectedCount: Int, filter: (SpanData) -> Boolean = { true }): List<SpanData> {
         val supplier = { exporter.exportedSpans.filter(filter) }

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataAssertions.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataAssertions.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework
+
+import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.toSerializable
+import io.opentelemetry.sdk.trace.data.SpanData
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+
+internal fun OtelJavaHarness.assertSpans(
+    expectedCount: Int,
+    goldenFileName: String? = null,
+    spanDataAssertions: List<SpanData>.() -> Unit = {},
+    spanDataFilter: (SpanData) -> Boolean = { true },
+) {
+    val observedSpans: List<SpanData> = awaitSpans(expectedCount, spanDataFilter)
+    spanDataAssertions(observedSpans)
+
+    if (goldenFileName != null) {
+        val observed = observedSpans.map(SpanData::toSerializable)
+        val expected = loadSpanData(goldenFileName)
+        assertEquals(
+            expected,
+            observed,
+            "Span data does not match expected data. Observed=${Json.encodeToString(observed)}"
+        )
+    }
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataLoader.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataLoader.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework
+
+import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.SerializableSpanData
+import java.io.File
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun loadSpanData(resName: String): List<SerializableSpanData> {
+    val dir = System.getProperty("user.dir")
+    val file = File(dir, "src/fixtures/$resName")
+    return file.inputStream().buffered().use {
+        Json.decodeFromStream<List<SerializableSpanData>>(it)
+    }
+}

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableAttributes.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableAttributes.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.api.common.Attributes
+
+internal fun Attributes.toSerializable(): Map<String, String> = asMap().map { Pair(it.key.key, it.value.toString()) }.toMap()

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableEventData.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableEventData.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.trace.data.EventData
+import kotlinx.serialization.Serializable
+
+internal fun EventData.toSerializable() = SerializableEventData(
+    name = name,
+    attributes = attributes.toSerializable(),
+    timestampNs = epochNanos,
+    totalAttributesCount = attributes.size(),
+)
+
+@Serializable
+internal data class SerializableEventData(
+    val name: String,
+    val attributes: Map<String, String>,
+    val timestampNs: Long,
+    val totalAttributesCount: Int,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableInstrumentationScopeInfo.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableInstrumentationScopeInfo.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import kotlinx.serialization.Serializable
+
+internal fun InstrumentationScopeInfo.toSerializable() = SerializableInstrumentationScopeInfo(
+    name = name,
+    version = version.toString(),
+    schemaUrl = schemaUrl.toString(),
+    attributes = attributes.toSerializable(),
+)
+
+@Serializable
+internal data class SerializableInstrumentationScopeInfo(
+    val name: String,
+    val version: String,
+    val schemaUrl: String,
+    val attributes: Map<String, String>,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableLinkData.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableLinkData.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.trace.data.LinkData
+import kotlinx.serialization.Serializable
+
+internal fun LinkData.toSerializable() = SerializableLinkData(
+    spanContext = spanContext.toSerializable(),
+    attributes = attributes.toSerializable(),
+    totalAttributeCount = attributes.size(),
+)
+
+@Serializable
+internal data class SerializableLinkData(
+    val spanContext: SerializableSpanContext,
+    val attributes: Map<String, String>,
+    val totalAttributeCount: Int,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableResource.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableResource.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.resources.Resource
+import kotlinx.serialization.Serializable
+
+internal fun Resource.toSerializable() = SerializableResource(
+    schemaUrl = schemaUrl.toString(),
+    attributes = attributes.toSerializable(),
+)
+
+@Serializable
+internal data class SerializableResource(
+    val schemaUrl: String,
+    val attributes: Map<String, String>,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanContext.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanContext.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.api.trace.SpanContext
+import kotlinx.serialization.Serializable
+
+internal fun SpanContext.toSerializable() = SerializableSpanContext(
+    traceId = SpanContext.getInvalid().traceId, // set to 0 for predictable tests
+    spanId = SpanContext.getInvalid().spanId, // set to 0 for predictable tests
+    traceFlags = traceFlags.asHex(),
+    traceState = traceState.asMap(),
+)
+
+@Serializable
+internal data class SerializableSpanContext(
+    val traceId: String,
+    val spanId: String,
+    val traceFlags: String,
+    val traceState: Map<String, String>,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanData.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanData.kt
@@ -1,0 +1,43 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.trace.data.EventData
+import io.opentelemetry.sdk.trace.data.LinkData
+import io.opentelemetry.sdk.trace.data.SpanData
+import kotlinx.serialization.Serializable
+
+internal fun SpanData.toSerializable() = SerializableSpanData(
+    name = name,
+    kind = kind.name,
+    statusData = status.toSerializable(),
+    spanContext = spanContext.toSerializable(),
+    parentSpanContext = parentSpanContext.toSerializable(),
+    startTimestampNs = startEpochNanos,
+    attributes = attributes.toSerializable(),
+    events = events.map(EventData::toSerializable),
+    links = links.map(LinkData::toSerializable),
+    endTimestampNs = endEpochNanos,
+    ended = hasEnded(),
+    totalRecordedEvents = totalRecordedEvents,
+    totalRecordedLinks = totalRecordedLinks,
+    totalAttributeCount = totalAttributeCount,
+    resource = resource.toSerializable(),
+)
+
+@Serializable
+internal data class SerializableSpanData(
+    val name: String,
+    val kind: String,
+    val statusData: SerializableSpanStatusData,
+    val spanContext: SerializableSpanContext,
+    val parentSpanContext: SerializableSpanContext,
+    val startTimestampNs: Long,
+    val attributes: Map<String, String>,
+    val events: List<SerializableEventData>,
+    val links: List<SerializableLinkData>,
+    val endTimestampNs: Long,
+    val ended: Boolean,
+    val totalRecordedEvents: Int,
+    val totalRecordedLinks: Int,
+    val totalAttributeCount: Int,
+    val resource: SerializableResource,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanStatusData.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanStatusData.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
+
+import io.opentelemetry.sdk.trace.data.StatusData
+import kotlinx.serialization.Serializable
+
+internal fun StatusData.toSerializable() = SerializableSpanStatusData(
+    code = statusCode.ordinal,
+    description = description,
+)
+
+@Serializable
+internal data class SerializableSpanStatusData(
+    val code: Int,
+    val description: String,
+)

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -1,6 +1,9 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
-import io.embrace.opentelemetry.kotlin.k2j.OtelJavaHarness
+import io.embrace.opentelemetry.kotlin.k2j.framework.OtelJavaHarness
+import io.embrace.opentelemetry.kotlin.k2j.framework.assertSpans
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,19 +11,27 @@ import kotlin.test.assertEquals
 internal class SpanExportTest {
 
     private lateinit var harness: OtelJavaHarness
+    private lateinit var tracerProvider: TracerProvider
+    private lateinit var tracer: Tracer
 
     @BeforeTest
     fun setUp() {
         harness = OtelJavaHarness()
+        tracerProvider = TracerProviderAdapter(harness.sdk)
+        tracer = tracerProvider.getTracer("name", "version")
     }
 
     @Test
-    fun `test span export`() {
-        val tracerProvider = TracerProviderAdapter(harness.sdk)
-        val tracer = tracerProvider.getTracer("name", "version")
+    fun `test basic span export`() {
         val spanName = "my_span"
         tracer.createSpan(spanName).end()
-        val observedSpan = harness.awaitSpans(1).single()
-        assertEquals(spanName, observedSpan.name)
+
+        harness.assertSpans(
+            expectedCount = 1,
+            goldenFileName = "basic_span.json",
+            spanDataAssertions = {
+                assertEquals(spanName, single().name)
+            }
+        )
     }
 }

--- a/compat-kotlin-to-official/src/fixtures/basic_span.json
+++ b/compat-kotlin-to-official/src/fixtures/basic_span.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "my_span",
+    "kind": "INTERNAL",
+    "statusData": {
+      "code": 0,
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "startTimestampNs": 0,
+    "attributes": {},
+    "events": [],
+    "links": [],
+    "endTimestampNs": 0,
+    "ended": true,
+    "totalRecordedEvents": 0,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 0,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.48.0"
+      }
+    }
+  }
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ android-compileSdk = "35"
 detekt = "1.23.8"
 binaryCompatibilityValidator = "0.17.0"
 otel = "1.48.0"
+kotlinSerialization = "1.8.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -17,9 +18,11 @@ binary-compatibility-validator = { module = "org.jetbrains.kotlinx:binary-compat
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}
+kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
## Goal

Enhances the integration test for span export by comparing the exported span against a known output stored in a test fixture. This will help catch regressions or changes in the span output. I've achieved this by:

- Transforming `SpanData` into serializable data classes
- Adding kotlinx-serialization for JSON encoding/decoding
- Loading data from a test fixture
- Setting a fake clock on the OTel instance & setting predictable spanIds/traceIds to avoid unique values poisoning comparisons

