### PR TITLE
Setup detekt on commonTest

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/otel/DetektConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/DetektConfig.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
 
 fun Project.configureDetekt() {
     project.pluginManager.apply("io.gitlab.arturbosch.detekt")
@@ -20,6 +21,15 @@ fun Project.configureDetekt() {
         config.from(project.files("${project.rootDir}/config/detekt/detekt.yml")) // overwrite default behaviour here
         baseline =
             project.file("${project.projectDir}/config/detekt/baseline.xml") // suppress pre-existing issues
+    }
+
+    // setup custom task to run on commonTest
+    // see https://detekt.dev/docs/gettingstarted/type-resolution/#enabling-on-a-kmp-project
+    tasks.register<Detekt>("detektCommonTest") {
+        source(files("src/commonTest/kotlin"))
+        config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+        autoCorrect = true
+        buildUponDefaultConfig = true
     }
     project.tasks.withType(Detekt::class.java).configureEach {
         jvmTarget = "1.8"

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelJavaHarness.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelJavaHarness.kt
@@ -37,7 +37,7 @@ internal class OtelJavaHarness {
         val spans = supplier()
         throw TimeoutException(
             "Timeout. Expected $expectedCount spans, but got ${spans.size}. " +
-                    "Found spans: ${spans.joinToString { it.name }}"
+                "Found spans: ${spans.joinToString { it.name }}"
         )
     }
 }

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataAssertions.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataAssertions.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.k2j.framework
 
 import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.toSerializable
 import io.opentelemetry.sdk.trace.data.SpanData
-import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json
+import kotlin.test.assertEquals
 
 internal fun OtelJavaHarness.assertSpans(
     expectedCount: Int,

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataLoader.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/SpanDataLoader.kt
@@ -1,10 +1,10 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
 import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.SerializableSpanData
-import java.io.File
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
+import java.io.File
 
 @OptIn(ExperimentalSerializationApi::class)
 internal fun loadSpanData(resName: String): List<SerializableSpanData> {

--- a/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableAttributes.kt
+++ b/compat-kotlin-to-official/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableAttributes.kt
@@ -2,4 +2,6 @@ package io.embrace.opentelemetry.kotlin.k2j.framework.serialization
 
 import io.opentelemetry.api.common.Attributes
 
-internal fun Attributes.toSerializable(): Map<String, String> = asMap().map { Pair(it.key.key, it.value.toString()) }.toMap()
+internal fun Attributes.toSerializable(): Map<String, String> = asMap().map {
+    Pair(it.key.key, it.value.toString())
+}.toMap()


### PR DESCRIPTION
## Goal

Enables detekt on the `commonTest` sourceset as I noticed it hadn't been running.

