### PR TITLE
Tweak tracing api

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -5,12 +5,10 @@ import io.embrace.opentelemetry.kotlin.tracing.Link
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
-import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import java.util.concurrent.TimeUnit
 
 internal class SpanAdapter(
     private val impl: io.opentelemetry.api.trace.Span,
-    override var spanKind: SpanKind,
 ) : Span {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
@@ -40,10 +38,6 @@ internal class SpanAdapter(
             TODO("$value")
         }
 
-    override fun updateStartTimestamp(timestamp: Long) {
-        TODO("Not yet implemented")
-    }
-
     override fun end(timestamp: Long?) {
         if (timestamp != null) {
             impl.end(timestamp, TimeUnit.NANOSECONDS)
@@ -52,8 +46,7 @@ internal class SpanAdapter(
         }
     }
 
-    override val isRecording: Boolean
-        get() = impl.isRecording
+    override fun isRecording(): Boolean = impl.isRecording
 
     override fun addLink(spanContext: SpanContext, action: Link.() -> Unit) {
         TODO("Not yet implemented")
@@ -88,6 +81,18 @@ internal class SpanAdapter(
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun attributes(): Map<String, Any> {
+        TODO("Not yet implemented")
+    }
+
+    override fun events(): List<SpanEvent> {
+        TODO("Not yet implemented")
+    }
+
+    override fun links(): List<Link> {
         TODO("Not yet implemented")
     }
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -20,7 +20,7 @@ internal class TracerAdapter(private val tracer: io.opentelemetry.api.trace.Trac
             .setStartTimestamp(startTimestamp, TimeUnit.NANOSECONDS)
 
         val span = builder.startSpan()
-        return SpanAdapter(span, spanKind).apply {
+        return SpanAdapter(span).apply {
             this.name = name
             action(this)
             // TODO: populate other fields

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -2,7 +2,6 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.k2j.framework.OtelJavaHarness
-import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import org.junit.Assert.assertFalse
@@ -49,13 +48,9 @@ internal class SpanExportTest {
         span.status = StatusCode.Ok
         assertEquals(StatusCode.Ok, span.status)
 
-        assertEquals(SpanKind.INTERNAL, span.spanKind)
-        span.spanKind = SpanKind.CLIENT // FIXME: future: not respected in exported spans
-        assertEquals(SpanKind.CLIENT, span.spanKind)
-
-        assertTrue(span.isRecording)
+        assertTrue(span.isRecording())
         span.end()
-        assertFalse(span.isRecording)
+        assertFalse(span.isRecording())
 
         harness.assertSpans(
             expectedCount = 1,

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -15,6 +15,7 @@ public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun attributes ()Ljava/util/Map;
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -33,14 +34,10 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun end (Ljava/lang/Long;)V
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
-	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
 	public abstract fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V
-	public abstract fun setParent (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)V
-	public abstract fun setSpanKind (Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;)V
 	public abstract fun setStatus (Lio/embrace/opentelemetry/kotlin/StatusCode;)V
-	public abstract fun updateStartTimestamp (J)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
@@ -58,6 +55,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getTimestamp ()J
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/Enum {
@@ -73,6 +72,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun events ()Ljava/util/List;
+	public abstract fun links ()Ljava/util/List;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer$DefaultImpls {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -15,6 +15,7 @@ public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun attributes ()Ljava/util/Map;
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -33,14 +34,10 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun end (Ljava/lang/Long;)V
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
-	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
 	public abstract fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V
-	public abstract fun setParent (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)V
-	public abstract fun setSpanKind (Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;)V
 	public abstract fun setStatus (Lio/embrace/opentelemetry/kotlin/StatusCode;)V
-	public abstract fun updateStartTimestamp (J)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
@@ -58,6 +55,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getTimestamp ()J
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/Enum {
@@ -73,6 +72,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun events ()Ljava/util/List;
+	public abstract fun links ()Ljava/util/List;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer$DefaultImpls {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -46,4 +46,9 @@ public interface AttributeContainer {
      * Sets an attribute with a list of double values.
      */
     public fun setDoubleListAttribute(key: String, value: List<Double>)
+
+    /**
+     * Returns a snapshot of the attributes as a map.
+     */
+    public fun attributes(): Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -19,19 +19,9 @@ public interface Span : SpanRelationshipContainer {
     public var status: StatusCode
 
     /**
-     * Sets the kind of the span. This defaults to [SpanKind.INTERNAL].
+     * Gets the parent span context. This defaults to null.
      */
-    public var spanKind: SpanKind
-
-    /**
-     * Sets the parent span context. This defaults to null.
-     */
-    public var parent: SpanContext?
-
-    /**
-     * Sets the start timestamp of the span. In span creation this defaults to the current time.
-     */
-    public fun updateStartTimestamp(timestamp: Long)
+    public val parent: SpanContext?
 
     /**
      * Ends the span. An optional timestamp in nanoseconds can be supplied.
@@ -41,5 +31,5 @@ public interface Span : SpanRelationshipContainer {
     /**
      * Returns true if the span is currently recording.
      */
-    public val isRecording: Boolean
+    public fun isRecording(): Boolean
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
@@ -6,4 +6,15 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  * Represents an event that happened on a span
  */
 @TracingDsl
-public interface SpanEvent : AttributeContainer
+public interface SpanEvent : AttributeContainer {
+
+    /**
+     * The name of the event
+     */
+    public val name: String
+
+    /**
+     * The timestamp of the event in nanoseconds
+     */
+    public val timestamp: Long
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
@@ -20,4 +20,14 @@ public interface SpanRelationshipContainer : AttributeContainer {
         timestamp: Long? = null,
         action: SpanEvent.() -> Unit
     )
+
+    /**
+     * Returns a snapshot of the events on this span.
+     */
+    public fun events(): List<SpanEvent>
+
+    /**
+     * Returns a snapshot of the links on this span.
+     */
+    public fun links(): List<Link>
 }


### PR DESCRIPTION
## Goal

Tweaks the Tracing API as discussed synchronously:

- `isRecording` converted to a function as its state can change over time
- Ability to snapshot attributes/links/events added
- `spanKind/startTimestamp` are supplied as constructor parameters only
