### PR TITLE
Setup build script to publish modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
     id("com.android.library") apply false
     id("org.jetbrains.kotlin.multiplatform") apply false
-    alias(libs.plugins.vanniktech.mavenPublish) apply false
+    id("com.vanniktech.maven.publish") apply false
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,11 +10,14 @@ repositories {
     mavenCentral()
 }
 
+version = project.properties["version"] as String
+
 dependencies {
     implementation(gradleApi())
     implementation(libs.kotlinMultiplatform)
     implementation(libs.agp)
     implementation(libs.detekt.gradle.plugin)
+    implementation(libs.mavenPublish)
     implementation(libs.binary.compatibility.validator)
 }
 

--- a/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
@@ -14,5 +14,6 @@ class BuildPlugin : Plugin<Project> {
         project.configureDetekt()
         project.configureBinaryCompatValidation(buildLogic)
         project.configureExplicitApiMode(buildLogic, kotlin)
+        project.configurePublishing()
     }
 }

--- a/buildSrc/src/main/kotlin/io/embrace/otel/PublishConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/PublishConfig.kt
@@ -1,0 +1,43 @@
+package io.embrace.otel
+
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.api.Project
+
+fun Project.configurePublishing() {
+    project.pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        val mavenPublishing = project.extensions.getByType(MavenPublishBaseExtension::class.java)
+
+        mavenPublishing.apply {
+            publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+            signAllPublications()
+            coordinates("io.embrace.opentelemetry.kotlin", project.name, project.version.toString())
+
+            pom {
+                name.set("Opentelemetry Kotlin")
+                description.set("An implementation of the OpenTelemetry specification as a Kotlin Multiplatform Library, developed by embrace.io.")
+                inceptionYear.set("2025")
+                url.set("https://github.com/embrace-io/opentelemetry-kotlin")
+
+                licenses {
+                    license {
+                        name.set("Embrace License")
+                        url.set("https://embrace.io/docs/terms-of-service/")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("dev1")
+                        name.set("Embrace")
+                        email.set("support@embrace.io")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:github.com/embrace-io/opentelemetry-kotlin.git")
+                    developerConnection.set("scm:git:ssh://github.com/embrace-io/opentelemetry-kotlin.git")
+                    url.set("https://github.com/embrace-io/opentelemetry-kotlin/tree/main")
+                }
+            }
+        }
+    }
+}

--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -1,5 +1,5 @@
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
-	public fun <init> (Lio/opentelemetry/api/OpenTelemetry;)V
+	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;)V
 	public fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/compat-kotlin-to-official/build.gradle.kts
+++ b/compat-kotlin-to-official/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
     alias(libs.plugins.kotlin.serialization)
 }
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -2,11 +2,12 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
-import io.opentelemetry.api.OpenTelemetry
 
-public class TracerProviderAdapter(private val otel: OpenTelemetry) : TracerProvider {
+public class TracerProviderAdapter(
+    private val tracerProvider: io.opentelemetry.api.trace.TracerProvider
+) : TracerProvider {
+
     override fun getTracer(name: String, version: String?): Tracer {
-        val tracerProvider = otel.tracerProvider
         val tracer = when (version) {
             null -> tracerProvider.get(name)
             else -> tracerProvider.get(name, version)

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -20,7 +20,7 @@ internal class SpanExportTest {
     @BeforeTest
     fun setUp() {
         harness = OtelKotlinHarness()
-        tracerProvider = TracerProviderAdapter(harness.sdk)
+        tracerProvider = TracerProviderAdapter(harness.sdk.tracerProvider)
         tracer = tracerProvider.getTracer("name", "version")
     }
 

--- a/compat-official-to-kotlin/build.gradle.kts
+++ b/compat-official-to-kotlin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
 }
 
 group = "io.embrace.opentelemetry.kotlin"

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
@@ -15,6 +15,6 @@ class OtelKotlinApi {
         .build()
     private val instrumentationScopeName = "com.example.app"
 
-    val tracer = TracerProviderAdapter(otel)
+    val tracer = TracerProviderAdapter(otel.tracerProvider)
     val logger = otel.sdkLoggerProvider.get(instrumentationScopeName)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,6 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+#Custom
+version=0.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ detekt = "1.23.8"
 binaryCompatibilityValidator = "0.17.0"
 otel = "1.48.0"
 kotlinSerialization = "1.8.0"
+mavenPublish = "0.31.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -19,10 +20,11 @@ opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", ve
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
+mavenPublish = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/opentelemetry-kotlin-api-ext/build.gradle.kts
+++ b/opentelemetry-kotlin-api-ext/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
 }
 
 buildLogic {

--- a/opentelemetry-kotlin-api/build.gradle.kts
+++ b/opentelemetry-kotlin-api/build.gradle.kts
@@ -1,12 +1,8 @@
-import com.vanniktech.maven.publish.SonatypeHost
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
-    alias(libs.plugins.vanniktech.mavenPublish)
     id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
 }
 
 group = "io.embrace.opentelemetry.kotlin"
@@ -18,19 +14,4 @@ buildLogic {
 
 android {
     namespace = "io.embrace.opentelemetry.kotlin"
-}
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    signAllPublications()
-
-    coordinates(group.toString(), "library", version.toString())
-
-    pom {
-        name = "Opentelemetry Kotlin"
-        description = "An implementation of the OpenTelemetry specification as a Kotlin Multiplatform Library, developed by embrace.io."
-        inceptionYear = "2025"
-        url = "https://github.com/embrace-io/opentelemetry-kotlin"
-    }
 }


### PR DESCRIPTION
## Goal

Configures the build script so that modules are published locally with the correct metadata if the maven-publish plugin is applied.

