### PR TITLE
Propagate the clock throughout compat layer

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -1,5 +1,12 @@
+public final class io/embrace/opentelemetry/kotlin/k2j/ClockAdapter : io/embrace/opentelemetry/kotlin/Clock {
+	public fun <init> ()V
+	public fun <init> (Lio/opentelemetry/sdk/common/Clock;)V
+	public synthetic fun <init> (Lio/opentelemetry/sdk/common/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun now ()J
+}
+
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
-	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;)V
+	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;)V
 	public fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.embrace.opentelemetry.kotlin.Clock
+
+public class ClockAdapter(
+    private val clock: io.opentelemetry.sdk.common.Clock = io.opentelemetry.sdk.common.Clock.getDefault()
+) : Clock {
+    override fun now(): Long = clock.now()
+}

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Link
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
@@ -13,6 +14,7 @@ import java.util.concurrent.TimeUnit
 
 internal class SpanAdapter(
     private val impl: io.opentelemetry.api.trace.Span,
+    private val clock: ClockAdapter,
 ) : Span {
 
     private val attrs: MutableMap<String, Any> = ConcurrentHashMap()
@@ -58,7 +60,7 @@ internal class SpanAdapter(
     override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
         val container = AttributeContainerImpl()
         action(container)
-        val time = timestamp ?: 0 // FIXME: future: pass in clock
+        val time = timestamp ?: clock.now()
         events.add(SpanEventImpl(name, time, container))
         impl.addEvent(name, container.otelJavaAttributes(), time, TimeUnit.NANOSECONDS)
     }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
@@ -7,7 +8,11 @@ import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipContainer
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import java.util.concurrent.TimeUnit
 
-internal class TracerAdapter(private val tracer: io.opentelemetry.api.trace.Tracer) : Tracer {
+internal class TracerAdapter(
+    private val tracer: io.opentelemetry.api.trace.Tracer,
+    private val clock: ClockAdapter
+) : Tracer {
+
     override fun createSpan(
         name: String,
         parent: SpanContext?,
@@ -17,13 +22,12 @@ internal class TracerAdapter(private val tracer: io.opentelemetry.api.trace.Trac
     ): Span {
         val builder = tracer.spanBuilder(name)
             .setSpanKind(spanKind.convertToOtelJava())
-            .setStartTimestamp(startTimestamp ?: 0, TimeUnit.NANOSECONDS) // TODO: use clock if not provided
+            .setStartTimestamp(startTimestamp ?: clock.now(), TimeUnit.NANOSECONDS)
 
         val span = builder.startSpan()
-        return SpanAdapter(span).apply {
+        return SpanAdapter(span, clock).apply {
             this.name = name
             action(this)
-            // TODO: populate other fields
         }
     }
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -1,10 +1,12 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 public class TracerProviderAdapter(
-    private val tracerProvider: io.opentelemetry.api.trace.TracerProvider
+    private val tracerProvider: io.opentelemetry.api.trace.TracerProvider,
+    private val clock: ClockAdapter
 ) : TracerProvider {
 
     override fun getTracer(name: String, version: String?): Tracer {
@@ -12,6 +14,6 @@ public class TracerProviderAdapter(
             null -> tracerProvider.get(name)
             else -> tracerProvider.get(name, version)
         }
-        return TracerAdapter(tracer)
+        return TracerAdapter(tracer, clock)
     }
 }

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelKotlinHarness.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/OtelKotlinHarness.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.k2j.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.k2j.InMemorySpanProcessor
 import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.toSerializable
@@ -23,6 +24,8 @@ internal class OtelKotlinHarness {
     val sdk: OpenTelemetry = OpenTelemetrySdk.builder().setTracerProvider(
         tracerProvider
     ).build()
+
+    val clock: ClockAdapter = ClockAdapter(FakeClock())
 
     private fun awaitSpans(expectedCount: Int, filter: (SpanData) -> Boolean = { true }): List<SpanData> {
         val supplier = { exporter.exportedSpans.filter(filter) }

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -20,7 +20,7 @@ internal class SpanExportTest {
     @BeforeTest
     fun setUp() {
         harness = OtelKotlinHarness()
-        tracerProvider = TracerProviderAdapter(harness.sdk.tracerProvider)
+        tracerProvider = TracerProviderAdapter(harness.sdk.tracerProvider, harness.clock)
         tracer = tracerProvider.getTracer("name", "version")
     }
 

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.example.kotlin
 
 import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
@@ -15,6 +16,6 @@ class OtelKotlinApi {
         .build()
     private val instrumentationScopeName = "com.example.app"
 
-    val tracer = TracerProviderAdapter(otel.tracerProvider)
+    val tracer = TracerProviderAdapter(otel.tracerProvider, ClockAdapter())
     val logger = otel.sdkLoggerProvider.get(instrumentationScopeName)
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -1,3 +1,7 @@
+public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
+	public abstract fun now ()J
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -1,3 +1,7 @@
+public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
+	public abstract fun now ()J
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Clock.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Clock.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * A clock that provides the current time in nanoseconds.
+ */
+public interface Clock {
+
+    /**
+     * Returns the current time in nanoseconds.
+     */
+    public fun now(): Long
+}


### PR DESCRIPTION
## Goal

Propagates a `Clock` type through the compatibility layer so we can set the time if no timestamp is supplied.
