### PR TITLE
Add requires opt in annotation

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -7,6 +7,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/ClockAdapter : io/embrace
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
 	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;)V
+	public synthetic fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
@@ -1,9 +1,11 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 
+@OptIn(ExperimentalApi::class)
 internal class AttributeContainerImpl : AttributeContainer {
 
     private val attrs = Attributes.builder()

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/LinkImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/LinkImpl.kt
@@ -1,9 +1,11 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.Link
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 
+@OptIn(ExperimentalApi::class)
 internal class LinkImpl(
     override val spanContext: SpanContext,
     private val attributes: AttributeContainer

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
@@ -12,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 internal class SpanAdapter(
     val impl: io.opentelemetry.api.trace.Span,
     private val clock: ClockAdapter,

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanEventImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanEventImpl.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
 
+@OptIn(ExperimentalApi::class)
 internal class SpanEventImpl(
     override val name: String,
     override val timestamp: Long,

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
@@ -8,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 internal class TracerAdapter(
     private val tracer: io.opentelemetry.api.trace.Tracer,
     private val clock: ClockAdapter

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -1,12 +1,14 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
+@ExperimentalApi
 public class TracerProviderAdapter(
     private val tracerProvider: io.opentelemetry.api.trace.TracerProvider,
-    private val clock: ClockAdapter
+    private val clock: ClockAdapter = ClockAdapter()
 ) : TracerProvider {
 
     override fun getTracer(name: String, version: String?): Tracer {

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.framework.OtelKotlinHarness
@@ -16,6 +17,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalApi::class)
 internal class SpanExportTest {
 
     private lateinit var harness: OtelKotlinHarness

--- a/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanAdapter.kt
+++ b/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -7,6 +8,7 @@ import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 internal class SpanAdapter(private val span: io.embrace.opentelemetry.kotlin.tracing.Span) : Span {
 
     override fun <T : Any?> setAttribute(key: AttributeKey<T>, value: T): Span {

--- a/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanBuilderAdapter.kt
+++ b/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanBuilderAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -11,6 +12,7 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 internal class SpanBuilderAdapter(
     private val tracer: io.embrace.opentelemetry.kotlin.tracing.Tracer,
     private val spanName: String

--- a/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/TracerAdapter.kt
+++ b/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/TracerAdapter.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.Tracer
 
+@OptIn(ExperimentalApi::class)
 internal class TracerAdapter(
     private val tracer: io.embrace.opentelemetry.kotlin.tracing.Tracer
 ) : Tracer {

--- a/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/TracerProviderAdapter.kt
+++ b/compat-official-to-kotlin/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/TracerProviderAdapter.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.api.trace.TracerProvider
 
+@OptIn(ExperimentalApi::class)
 internal class TracerProviderAdapter(
     private val tracerProvider: io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 ) : TracerProvider {

--- a/compat-official-to-kotlin/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelJavaHarness.kt
+++ b/compat-official-to-kotlin/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelJavaHarness.kt
@@ -1,7 +1,9 @@
 package io.embrace.opentelemetry.kotlin.framework
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
+@OptIn(ExperimentalApi::class)
 internal class OtelJavaHarness {
 
     val tracerProvider: TracerProvider = TODO("Not implemented yet")

--- a/compat-official-to-kotlin/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanExportTest.kt
+++ b/compat-official-to-kotlin/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/SpanExportTest.kt
@@ -1,10 +1,12 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.framework.OtelJavaHarness
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.api.trace.TracerProvider
 import kotlin.test.Test
 
+@OptIn(ExperimentalApi::class)
 internal class SpanExportTest {
 
     private lateinit var harness: OtelJavaHarness

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinApi.kt
@@ -2,12 +2,14 @@ package io.embrace.opentelemetry.example.kotlin
 
 import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 
+@OptIn(ExperimentalApi::class)
 class OtelKotlinApi {
 
     private val otel: OpenTelemetrySdk = OpenTelemetrySdk.builder()

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -1,5 +1,8 @@
 package io.embrace.opentelemetry.example.kotlin
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
 fun createInstrumentationWithOtelKotlin() {
     val api = OtelKotlinApi()
     val tracer = api.tracer.getTracer(

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
@@ -1,5 +1,7 @@
 package io.embrace.opentelemetry.kotlin.attributes
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * Sets attributes on an [AttributeContainer] from a [Map]. Only values in the map of a type supported by the
  * OpenTelemetry API will be set. Other values will be ignored.
@@ -7,6 +9,7 @@ package io.embrace.opentelemetry.kotlin.attributes
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
 @Suppress("UNUSED_PARAMETER")
+@ExperimentalApi
 public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
     TODO("Implement me")
 }

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
@@ -1,11 +1,15 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * Gets the trace ID as a byte array.
  */
+@ExperimentalApi
 public val SpanContext.traceIdBytes: ByteArray get() = traceId.encodeToByteArray()
 
 /**
  * Gets the span ID as a byte array.
  */
+@ExperimentalApi
 public val SpanContext.spanIdBytes: ByteArray get() = spanId.encodeToByteArray()

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -1,9 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * Record an exception on the span as an event.
  */
 @Suppress("UNUSED_PARAMETER")
+@ExperimentalApi
 public fun Span.recordException(exception: Throwable, action: SpanEvent.() -> Unit) {
     TODO()
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -2,6 +2,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 	public abstract fun now ()J
 }
 
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -2,6 +2,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 	public abstract fun now ()J
 }
 
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExperimentalApi.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExperimentalApi.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Marks APIs that are experimental and therefore subject to breaking change without any warning between versions.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+public annotation class ExperimentalApi

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -1,10 +1,13 @@
 package io.embrace.opentelemetry.kotlin.attributes
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * Implementations of this interface hold 'attributes' as described in the OTel specification.
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
+@ExperimentalApi
 public interface AttributeContainer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
@@ -1,10 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
  * Represents a link to a [SpanContext] and optional attributes further describing the link.
  */
+@ExperimentalApi
 public interface Link : AttributeContainer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -1,11 +1,13 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
 
 /**
  * A span represents a single operation within a trace.
  */
 @TracingDsl
+@ExperimentalApi
 public interface Span : SpanRelationshipContainer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
@@ -1,11 +1,13 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
  * Represents an event that happened on a span
  */
 @TracingDsl
+@ExperimentalApi
 public interface SpanEvent : AttributeContainer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
@@ -1,10 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
  * Provides operations that add relationships (events + links) to a span
  */
+@ExperimentalApi
 public interface SpanRelationshipContainer : AttributeContainer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -1,8 +1,11 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * A Tracer is responsible for creating spans.
  */
+@ExperimentalApi
 public interface Tracer {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -1,8 +1,11 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
 /**
  * TracerProvider is a factory for retrieving instances of [Tracer].
  */
+@ExperimentalApi
 public interface TracerProvider {
 
     /**


### PR DESCRIPTION
## Goal

Adds a `RequiresOptIn` annotation to all the public API. This emits a warning (although could be configured to emit an error) when included in a consuming project, that requires  `@OptIn(ExperimentalApi::class)` to suppress.


