### PR TITLE
Add thread safe annotation

### DIFF
--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.attributes
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * Sets attributes on an [AttributeContainer] from a [Map]. Only values in the map of a type supported by the
@@ -10,6 +11,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  */
 @Suppress("UNUSED_PARAMETER")
 @ExperimentalApi
+@ThreadSafe
 public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
     TODO("Implement me")
 }

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextExt.kt
@@ -1,15 +1,18 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * Gets the trace ID as a byte array.
  */
 @ExperimentalApi
+@ThreadSafe
 public val SpanContext.traceIdBytes: ByteArray get() = traceId.encodeToByteArray()
 
 /**
  * Gets the span ID as a byte array.
  */
 @ExperimentalApi
+@ThreadSafe
 public val SpanContext.spanIdBytes: ByteArray get() = spanId.encodeToByteArray()

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -1,12 +1,14 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * Record an exception on the span as an event.
  */
 @Suppress("UNUSED_PARAMETER")
 @ExperimentalApi
+@ThreadSafe
 public fun Span.recordException(exception: Throwable, action: SpanEvent.() -> Unit) {
     TODO()
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -21,6 +21,9 @@ public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace
 	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Unset;
 }
 
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/ThreadSafe : java/lang/annotation/Annotation {
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun attributes ()Ljava/util/Map;
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -21,6 +21,9 @@ public final class io/embrace/opentelemetry/kotlin/StatusCode$Unset : io/embrace
 	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/StatusCode$Unset;
 }
 
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/ThreadSafe : java/lang/annotation/Annotation {
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun attributes ()Ljava/util/Map;
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/StatusCode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/StatusCode.kt
@@ -5,20 +5,24 @@ package io.embrace.opentelemetry.kotlin
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#set-status
  */
+@ThreadSafe
 public sealed class StatusCode {
 
     /**
      * Default status.
      */
+    @ThreadSafe
     public object Unset : StatusCode()
 
     /**
      * The operation completed successfully.
      */
+    @ThreadSafe
     public object Ok : StatusCode()
 
     /**
      * The operation completed with an error. An optional description of the error may be provided.
      */
+    @ThreadSafe
     public class Error(public val description: String?) : StatusCode()
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafe.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafe.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Marks an API whose functions are all thread-safe & can be called concurrently.
+ *
+ * This annotation is for documentation purposes and does not have any effect on the code.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#concurrency
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ThreadSafe

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.attributes
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * Implementations of this interface hold 'attributes' as described in the OTel specification.
@@ -8,50 +9,60 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
 @ExperimentalApi
+@ThreadSafe
 public interface AttributeContainer {
 
     /**
      * Sets an attribute with a boolean value.
      */
+    @ThreadSafe
     public fun setBooleanAttribute(key: String, value: Boolean)
 
     /**
      * Sets an attribute with a string value.
      */
+    @ThreadSafe
     public fun setStringAttribute(key: String, value: String)
 
     /**
      * Sets an attribute with a long value.
      */
+    @ThreadSafe
     public fun setLongAttribute(key: String, value: Long)
 
     /**
      * Sets an attribute with a double value.
      */
+    @ThreadSafe
     public fun setDoubleAttribute(key: String, value: Double)
 
     /**
      * Sets an attribute with a list of boolean values.
      */
+    @ThreadSafe
     public fun setBooleanListAttribute(key: String, value: List<Boolean>)
 
     /**
      * Sets an attribute with a list of string values.
      */
+    @ThreadSafe
     public fun setStringListAttribute(key: String, value: List<String>)
 
     /**
      * Sets an attribute with a list of long values.
      */
+    @ThreadSafe
     public fun setLongListAttribute(key: String, value: List<Long>)
 
     /**
      * Sets an attribute with a list of double values.
      */
+    @ThreadSafe
     public fun setDoubleListAttribute(key: String, value: List<Double>)
 
     /**
      * Returns a snapshot of the attributes as a map.
      */
+    @ThreadSafe
     public fun attributes(): Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Link.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
@@ -9,10 +10,12 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  * https://opentelemetry.io/docs/specs/otel/trace/api/#link
  */
 @ExperimentalApi
+@ThreadSafe
 public interface Link : AttributeContainer {
 
     /**
      * The [SpanContext] of the linked span.
      */
+    @ThreadSafe
     public val spanContext: SpanContext
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * A span represents a single operation within a trace.
@@ -10,35 +11,42 @@ import io.embrace.opentelemetry.kotlin.StatusCode
  */
 @TracingDsl
 @ExperimentalApi
+@ThreadSafe
 public interface Span : SpanRelationshipContainer {
 
     /**
      * Sets the name of the span. Must be non-empty.
      */
+    @ThreadSafe
     public var name: String
 
     /**
      * Sets the status of the span. This defaults to [StatusCode.Unset].
      */
+    @ThreadSafe
     public var status: StatusCode
 
     /**
      * Gets the parent span context. This defaults to null.
      */
+    @ThreadSafe
     public val parent: SpanContext?
 
     /**
      * Gets the span context that uniquely identifies this span.
      */
+    @ThreadSafe
     public val spanContext: SpanContext
 
     /**
      * Ends the span. An optional timestamp in nanoseconds can be supplied.
      */
+    @ThreadSafe
     public fun end(timestamp: Long? = null)
 
     /**
      * Returns true if the span is currently recording.
      */
+    @ThreadSafe
     public fun isRecording(): Boolean
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -1,5 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
 /**
  * Represents the state of a Span that must be serialized & propagated along a distributed context.
  * This consists of a trace ID (a 16-byte array with at least one non-zero byte) and a span ID
@@ -7,41 +9,49 @@ package io.embrace.opentelemetry.kotlin.tracing
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext
  */
+@ThreadSafe
 public interface SpanContext {
 
     /**
      * Hexadecimal representation of trace ID.
      */
+    @ThreadSafe
     public val traceId: String
 
     /**
      * Hexadecimal representation of span ID.
      */
+    @ThreadSafe
     public val spanId: String
 
     /**
      * Contains details about the trace.
      */
+    @ThreadSafe
     public val traceFlags: TraceFlags
 
     /**
      * True if the SpanContext has a valid trace ID and span ID.
      */
+    @ThreadSafe
     public val isValid: Boolean
 
     /**
      * True if the SpanContext was propagated from a remote parent.
      */
+    @ThreadSafe
     public val isRemote: Boolean
 
     /**
      * Contains state about the trace.
      */
+    @ThreadSafe
     public fun getTraceState(): TraceState
 
     /**
      * Mutates the trace state with the given action and replaces [traceState] with a new immutable object
      * containing the changes.
      */
+    @ThreadSafe
     public fun updateTraceState(action: TraceStateMutator.() -> Unit)
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEvent.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
@@ -10,15 +11,18 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  */
 @TracingDsl
 @ExperimentalApi
+@ThreadSafe
 public interface SpanEvent : AttributeContainer {
 
     /**
      * The name of the event
      */
+    @ThreadSafe
     public val name: String
 
     /**
      * The timestamp of the event in nanoseconds
      */
+    @ThreadSafe
     public val timestamp: Long
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanKind.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanKind.kt
@@ -1,10 +1,13 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
 /**
  * Clarifies the relationship between spans correlated via parent/child relationship or span links.
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#spankind
  */
+@ThreadSafe
 public enum class SpanKind {
 
     /**

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
@@ -14,11 +15,13 @@ public interface SpanRelationshipContainer : AttributeContainer {
     /**
      * Adds a link to the span that associates it with another [SpanContext].
      */
+    @ThreadSafe
     public fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit)
 
     /**
      * Adds an event to the span.
      */
+    @ThreadSafe
     public fun addEvent(
         name: String,
         timestamp: Long? = null,
@@ -28,10 +31,12 @@ public interface SpanRelationshipContainer : AttributeContainer {
     /**
      * Returns a snapshot of the events on this span.
      */
+    @ThreadSafe
     public fun events(): List<SpanEvent>
 
     /**
      * Returns a snapshot of the links on this span.
      */
+    @ThreadSafe
     public fun links(): List<Link>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceFlags.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceFlags.kt
@@ -1,19 +1,24 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
 /**
  * Contains details about the trace.
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext
  */
+@ThreadSafe
 public interface TraceFlags {
 
     /**
      * True if the trace is sampled.
      */
+    @ThreadSafe
     public val isSampled: Boolean
 
     /**
      * True if the trace is random.
      */
+    @ThreadSafe
     public val isRandom: Boolean
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceState.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TraceState.kt
@@ -1,19 +1,24 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
 /**
  * Holds key-pairs that describe vendor-specific information about a given trace.
  *
  * https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate
  */
+@ThreadSafe
 public interface TraceState {
 
     /**
      * Returns the value associated with the given key, or null if the key is not present.
      */
+    @ThreadSafe
     public fun get(key: String): String?
 
     /**
      * Returns the trace state as a map of key-value pairs.
      */
+    @ThreadSafe
     public fun asMap(): Map<String, String>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * A Tracer is responsible for creating spans.
@@ -8,11 +9,13 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  * https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
  */
 @ExperimentalApi
+@ThreadSafe
 public interface Tracer {
 
     /**
      * Creates a new span.
      */
+    @ThreadSafe
     public fun createSpan(
         name: String,
         parent: Span? = null,

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * TracerProvider is a factory for retrieving instances of [Tracer].
@@ -8,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  * https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
  */
 @ExperimentalApi
+@ThreadSafe
 public interface TracerProvider {
 
     /**
@@ -15,5 +17,6 @@ public interface TracerProvider {
      *
      * The name must document the instrumentation scope: https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope
      */
+    @ThreadSafe
     public fun getTracer(name: String, version: String? = null): Tracer
 }


### PR DESCRIPTION
## Goal

Adds a `ThreadSafe` annotation that documents whether an interface is thread-safe or not: https://opentelemetry.io/docs/specs/otel/trace/api/#concurrency

