### PR TITLE
Add typealiases for otel java classes

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
@@ -1,9 +1,10 @@
 package io.embrace.opentelemetry.kotlin.k2j
 
 import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.k2j.tracing.OtelJavaClock
 
 public class ClockAdapter(
-    private val clock: io.opentelemetry.sdk.common.Clock = io.opentelemetry.sdk.common.Clock.getDefault()
+    private val clock: OtelJavaClock = OtelJavaClock.getDefault()
 ) : Clock {
     override fun now(): Long = clock.now()
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/Aliases.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/Aliases.kt
@@ -1,0 +1,29 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.internal.ImmutableSpanContext
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.TracerProvider
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.common.Clock
+
+internal typealias OtelJavaAttributes = Attributes
+internal typealias OtelJavaAttributeKey<T> = AttributeKey<T>
+internal typealias OtelJavaSpan = Span
+internal typealias OtelJavaSpanContext = SpanContext
+internal typealias OtelJavaTraceFlags = TraceFlags
+internal typealias OtelJavaTraceState = TraceState
+internal typealias OtelJavaSpanKind = SpanKind
+internal typealias OtelJavaStatusCode = StatusCode
+internal typealias OtelJavaContext = Context
+internal typealias OtelJavaTracer = Tracer
+internal typealias OtelJavaTracerProvider = TracerProvider
+internal typealias OtelJavaClock = Clock
+internal typealias OtelJavaImmutableSpanContext = ImmutableSpanContext

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
@@ -2,13 +2,11 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
 
 @OptIn(ExperimentalApi::class)
 internal class AttributeContainerImpl : AttributeContainer {
 
-    private val attrs = Attributes.builder()
+    private val attrs = OtelJavaAttributes.builder()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         attrs.put(key, value)
@@ -27,22 +25,22 @@ internal class AttributeContainerImpl : AttributeContainer {
     }
 
     override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
-        attrs.put(AttributeKey.booleanArrayKey(key), value)
+        attrs.put(OtelJavaAttributeKey.booleanArrayKey(key), value)
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
-        attrs.put(AttributeKey.stringArrayKey(key), value)
+        attrs.put(OtelJavaAttributeKey.stringArrayKey(key), value)
     }
 
     override fun setLongListAttribute(key: String, value: List<Long>) {
-        attrs.put(AttributeKey.longArrayKey(key), value)
+        attrs.put(OtelJavaAttributeKey.longArrayKey(key), value)
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
-        attrs.put(AttributeKey.doubleArrayKey(key), value)
+        attrs.put(OtelJavaAttributeKey.doubleArrayKey(key), value)
     }
 
     override fun attributes(): Map<String, Any> = attrs.build().toMap()
 
-    fun otelJavaAttributes(): Attributes = attrs.build()
+    fun otelJavaAttributes(): OtelJavaAttributes = attrs.build()
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributesExt.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributesExt.kt
@@ -1,7 +1,5 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
-import io.opentelemetry.api.common.Attributes
-
-internal fun Attributes.toMap(): Map<String, Any> {
+internal fun OtelJavaAttributes.toMap(): Map<String, Any> {
     return this.asMap().mapKeys { it.key.key }
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -8,14 +8,13 @@ import io.embrace.opentelemetry.kotlin.tracing.Link
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
 internal class SpanAdapter(
-    val impl: io.opentelemetry.api.trace.Span,
+    val impl: OtelJavaSpan,
     private val clock: ClockAdapter,
     override val parent: SpanContext?,
 ) : Span {
@@ -93,22 +92,22 @@ internal class SpanAdapter(
     }
 
     override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
-        impl.setAttribute(AttributeKey.booleanArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.booleanArrayKey(key), value)
         attrs[key] = value
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
-        impl.setAttribute(AttributeKey.stringArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.stringArrayKey(key), value)
         attrs[key] = value
     }
 
     override fun setLongListAttribute(key: String, value: List<Long>) {
-        impl.setAttribute(AttributeKey.longArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.longArrayKey(key), value)
         attrs[key] = value
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
-        impl.setAttribute(AttributeKey.doubleArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.doubleArrayKey(key), value)
         attrs[key] = value
     }
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -1,17 +1,17 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.TraceStateMutator
-import io.opentelemetry.api.trace.SpanContext
 
 internal class SpanContextAdapter(
-    private val spanContext: SpanContext
-) : io.embrace.opentelemetry.kotlin.tracing.SpanContext {
+    private val spanContext: OtelJavaSpanContext
+) : SpanContext {
 
     override val traceId: String = spanContext.traceId
     override val spanId: String = spanContext.spanId
-    override val traceFlags: io.embrace.opentelemetry.kotlin.tracing.TraceFlags =
-        TraceFlagsAdapter(spanContext.traceFlags)
+    override val traceFlags: TraceFlags = TraceFlagsAdapter(spanContext.traceFlags)
     override val isValid: Boolean = spanContext.isValid
     override val isRemote: Boolean = spanContext.isRemote
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
@@ -3,10 +3,9 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
-import io.opentelemetry.api.internal.ImmutableSpanContext
 
-internal fun SpanContext.convertToOtelJava(): io.opentelemetry.api.trace.SpanContext {
-    return ImmutableSpanContext.create(
+internal fun SpanContext.convertToOtelJava(): OtelJavaSpanContext {
+    return OtelJavaImmutableSpanContext.create(
         traceId,
         spanId,
         traceFlags.convertToOtelJava(),
@@ -16,15 +15,15 @@ internal fun SpanContext.convertToOtelJava(): io.opentelemetry.api.trace.SpanCon
     )
 }
 
-internal fun TraceFlags.convertToOtelJava(): io.opentelemetry.api.trace.TraceFlags {
+internal fun TraceFlags.convertToOtelJava(): OtelJavaTraceFlags {
     val sb = StringBuilder()
     sb.append(if (isRandom) "1" else "0")
     sb.append(if (isSampled) "1" else "0")
-    return io.opentelemetry.api.trace.TraceFlags.fromHex(sb.toString(), 0)
+    return OtelJavaTraceFlags.fromHex(sb.toString(), 0)
 }
 
-internal fun TraceState.convertToOtelJava(): io.opentelemetry.api.trace.TraceState {
-    return io.opentelemetry.api.trace.TraceState.builder().apply {
+internal fun TraceState.convertToOtelJava(): OtelJavaTraceState {
+    return OtelJavaTraceState.builder().apply {
         asMap().entries.forEach {
             put(it.key, it.value)
         }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
@@ -2,10 +2,10 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 
-internal fun SpanKind.convertToOtelJava(): io.opentelemetry.api.trace.SpanKind = when (this) {
-    SpanKind.INTERNAL -> io.opentelemetry.api.trace.SpanKind.INTERNAL
-    SpanKind.CLIENT -> io.opentelemetry.api.trace.SpanKind.CLIENT
-    SpanKind.SERVER -> io.opentelemetry.api.trace.SpanKind.SERVER
-    SpanKind.PRODUCER -> io.opentelemetry.api.trace.SpanKind.PRODUCER
-    SpanKind.CONSUMER -> io.opentelemetry.api.trace.SpanKind.CONSUMER
+internal fun SpanKind.convertToOtelJava(): OtelJavaSpanKind = when (this) {
+    SpanKind.INTERNAL -> OtelJavaSpanKind.INTERNAL
+    SpanKind.CLIENT -> OtelJavaSpanKind.CLIENT
+    SpanKind.SERVER -> OtelJavaSpanKind.SERVER
+    SpanKind.PRODUCER -> OtelJavaSpanKind.PRODUCER
+    SpanKind.CONSUMER -> OtelJavaSpanKind.CONSUMER
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.StatusCode
 
-internal fun StatusCode.convertToOtelJava(): io.opentelemetry.api.trace.StatusCode = when (this) {
-    StatusCode.Unset -> io.opentelemetry.api.trace.StatusCode.UNSET
-    StatusCode.Ok -> io.opentelemetry.api.trace.StatusCode.OK
-    is StatusCode.Error -> io.opentelemetry.api.trace.StatusCode.ERROR
+internal fun StatusCode.convertToOtelJava(): OtelJavaStatusCode = when (this) {
+    StatusCode.Unset -> OtelJavaStatusCode.UNSET
+    StatusCode.Ok -> OtelJavaStatusCode.OK
+    is StatusCode.Error -> OtelJavaStatusCode.ERROR
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsAdapter.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 
 internal class TraceFlagsAdapter(
-    traceFlags: io.opentelemetry.api.trace.TraceFlags
+    traceFlags: OtelJavaTraceFlags
 ) : TraceFlags {
 
     override val isSampled: Boolean = traceFlags.isSampled

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateAdapter.kt
@@ -1,10 +1,10 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
-import io.opentelemetry.api.trace.TraceState
+import io.embrace.opentelemetry.kotlin.tracing.TraceState
 
 internal class TraceStateAdapter(
-    private val traceState: TraceState
-) : io.embrace.opentelemetry.kotlin.tracing.TraceState {
+    private val traceState: OtelJavaTraceState
+) : TraceState {
 
     override fun get(key: String): String? = traceState.get(key)
     override fun asMap(): Map<String, String> = traceState.asMap()

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -6,12 +6,11 @@ import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipContainer
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
-import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
 internal class TracerAdapter(
-    private val tracer: io.opentelemetry.api.trace.Tracer,
+    private val tracer: OtelJavaTracer,
     private val clock: ClockAdapter
 ) : Tracer {
 
@@ -38,10 +37,10 @@ internal class TracerAdapter(
         }
     }
 
-    private fun Span.findSpanContext(): Context? {
+    private fun Span.findSpanContext(): OtelJavaContext? {
         when (this) {
             is SpanAdapter -> {
-                val ctx = Context.current() ?: Context.root()
+                val ctx = OtelJavaContext.current() ?: OtelJavaContext.root()
                 return ctx.with(impl)
             }
 

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @ExperimentalApi
 public class TracerProviderAdapter(
-    private val tracerProvider: io.opentelemetry.api.trace.TracerProvider,
+    private val tracerProvider: OtelJavaTracerProvider,
     private val clock: ClockAdapter = ClockAdapter()
 ) : TracerProvider {
 


### PR DESCRIPTION
## Goal

Adds internal typealises for classes from the OTel Java SDK to increase readability in the compatibility layer.

