### PR TITLE
Create implementation module

### DIFF
--- a/compat-kotlin-to-official/build.gradle.kts
+++ b/compat-kotlin-to-official/build.gradle.kts
@@ -27,6 +27,8 @@ project.afterEvaluate {
                 dependencies {
                     api(project(":opentelemetry-kotlin-api"))
                     api(project(":opentelemetry-kotlin-api-ext"))
+                    implementation(project(":opentelemetry-kotlin-implementation"))
+
                     api(project.dependencies.platform(libs.opentelemetry.bom))
                     api(libs.opentelemetry.api)
                     implementation(libs.opentelemetry.sdk)

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -5,9 +5,11 @@ import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Link
+import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit

--- a/opentelemetry-kotlin-implementation/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation/build.gradle.kts
@@ -1,11 +1,8 @@
-import com.vanniktech.maven.publish.SonatypeHost
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
 }
 
 group = "io.embrace.opentelemetry.kotlin"
@@ -25,6 +22,7 @@ project.afterEvaluate {
             val commonMain by getting {
                 dependencies {
                     implementation(project(":opentelemetry-kotlin-api"))
+                }
             }
         }
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
@@ -1,12 +1,10 @@
-package io.embrace.opentelemetry.kotlin.k2j.tracing
+package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.tracing.Link
-import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 
 @OptIn(ExperimentalApi::class)
-internal class LinkImpl(
+class LinkImpl(
     override val spanContext: SpanContext,
     private val attributes: AttributeContainer
 ) : Link, AttributeContainer by attributes

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
@@ -1,11 +1,10 @@
-package io.embrace.opentelemetry.kotlin.k2j.tracing
+package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
 
 @OptIn(ExperimentalApi::class)
-internal class SpanEventImpl(
+class SpanEventImpl(
     override val name: String,
     override val timestamp: Long,
     private val attributes: AttributeContainer

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ rootProject.name = "opentelemetry-kotlin"
 include(
     ":opentelemetry-kotlin-api",
     ":opentelemetry-kotlin-api-ext",
+    ":opentelemetry-kotlin-implementation",
     ":compat-shared",
     ":compat-official-to-kotlin",
     ":compat-kotlin-to-official",


### PR DESCRIPTION
## Goal

Creates a module that can be used for the actual implementation & moves a few classes built via composition to it (implementations of `SpanEvent` and `Link`)

