### PR TITLE
Add function for creating span context

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.SpanContextOrigin
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.TraceStateMutator
@@ -21,5 +22,15 @@ internal class SpanContextAdapter(
 
     override fun getTraceState(): TraceState {
         return TraceStateAdapter(spanContext.traceState)
+    }
+
+    override fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState,
+        origin: SpanContextOrigin
+    ): SpanContext {
+        TODO("Not yet implemented")
     }
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -56,6 +56,7 @@ public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanId ()Ljava/lang/String;
 	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
@@ -63,6 +64,17 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
 	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContext$DefaultImpls {
+	public static synthetic fun create$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {
+	public static final field LOCAL Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static final field REMOTE Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -56,6 +56,7 @@ public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanId ()Ljava/lang/String;
 	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
@@ -63,6 +64,17 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
 	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContext$DefaultImpls {
+	public static synthetic fun create$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {
+	public static final field LOCAL Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static final field REMOTE Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -54,4 +54,16 @@ public interface SpanContext {
      */
     @ThreadSafe
     public fun updateTraceState(action: TraceStateMutator.() -> Unit)
+
+    /**
+     * Creates a new [SpanContext] from the given parameters.
+     */
+    @ThreadSafe
+    public fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState,
+        origin: SpanContextOrigin = SpanContextOrigin.LOCAL,
+    ): SpanContext
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Indicates whether a [SpanContext] was created locally or received from a remote source.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#isremote
+ */
+@ThreadSafe
+public enum class SpanContextOrigin {
+    LOCAL,
+    REMOTE
+}


### PR DESCRIPTION
## Goal

Reviews the [SpanContext](https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext) API and adds the ability to create new objects, which is the one requirement missing from our current interface.
