### PR TITLE
Initial context API

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -36,6 +36,16 @@ public abstract interface class io/embrace/opentelemetry/kotlin/attributes/Attri
 	public abstract fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/context/Context {
+	public abstract fun createKey (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/context/ContextKey;
+	public abstract fun getValue (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
+	public abstract fun setValue (Lio/embrace/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextKey {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -36,6 +36,16 @@ public abstract interface class io/embrace/opentelemetry/kotlin/attributes/Attri
 	public abstract fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/context/Context {
+	public abstract fun createKey (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/context/ContextKey;
+	public abstract fun getValue (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
+	public abstract fun setValue (Lio/embrace/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextKey {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
@@ -1,0 +1,41 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Immutable propagation mechanism that carries values across concerns.
+ *
+ * https://opentelemetry.io/docs/specs/otel/context/
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface Context {
+
+    /**
+     * Creates a new [ContextKey] with the given name. The name is used for debugging and does NOT uniquely identify
+     * values - use the [ContextKey] itself for that.
+     *
+     * [T] represents the type of the value that is stored in the context.
+     */
+    @ThreadSafe
+    public fun <T> createKey(name: String): ContextKey<T>
+
+    /**
+     * Associates a value on the [Context] with the given [ContextKey].
+     *
+     * [T] represents the type of the value that is stored in the context.
+     *
+     * This function returns a new immutable [Context] that contains the key-value pair.
+     */
+    @ThreadSafe
+    public fun <T> setValue(key: ContextKey<T>, value: T): Context
+
+    /**
+     * Retrieves a value from the [Context] associated with the given [ContextKey].
+     *
+     * [T] represents the type of the value that is stored in the context.
+     */
+    @ThreadSafe
+    public fun <T> getValue(key: ContextKey<T>): T?
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKey.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKey.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * A key that identifies a value in a [Context].
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ContextKey<T> {
+
+    /**
+     * The name of the key. This property does NOT uniquely identify the key in a [Context] object - pass the
+     * [ContextKey] instead. The OTel specification exposes this property for debugging purposes only.
+     */
+    @ThreadSafe
+    public val name: String
+}


### PR DESCRIPTION
## Goal

Initial attempt at the `Context` API that attempts to define the mandatory parts of the [OTel spec](https://opentelemetry.io/docs/specs/otel/context/#overview). This contains a few parts:

- Adds `ContextKey`, which acts as an opaque type so a string key isn't used to get/set context values
- Adds a type parameter onto `ContextKey` so getting/setting values can be done in a type-safe way
- Ability to get/set values on the context

