### PR TITLE
Add entrypoint interface

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -5,6 +5,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
+	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
+	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -5,6 +5,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
+	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
+	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+
+/**
+ * The main entry point for the OpenTelemetry API.
+ */
+@ExperimentalApi
+public interface OpenTelemetry {
+
+    /**
+     * The [TracerProvider] for creating [Tracer] instances.
+     */
+    public val tracerProvider: TracerProvider
+
+    /**
+     * The [LoggerProvider] for creating [Logger] instances.
+     */
+    public val loggerProvider: LoggerProvider
+}


### PR DESCRIPTION
## Goal

Adds an initial entrypoint that will be used for accessing OpenTelemetry APIs.

