### PR TITLE
Add entrypoint for open telemetry sdk

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -5,6 +5,12 @@ public final class io/embrace/opentelemetry/kotlin/k2j/ClockAdapter : io/embrace
 	public fun now ()J
 }
 
+public final class io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk : io/embrace/opentelemetry/kotlin/OpenTelemetry {
+	public fun <init> (Lio/opentelemetry/api/OpenTelemetry;)V
+	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
+	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+}
+
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
 	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;)V
 	public synthetic fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/Aliases.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/Aliases.kt
@@ -1,5 +1,6 @@
-package io.embrace.opentelemetry.kotlin.k2j.tracing
+package io.embrace.opentelemetry.kotlin.k2j
 
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.internal.ImmutableSpanContext
@@ -27,3 +28,4 @@ internal typealias OtelJavaTracer = Tracer
 internal typealias OtelJavaTracerProvider = TracerProvider
 internal typealias OtelJavaClock = Clock
 internal typealias OtelJavaImmutableSpanContext = ImmutableSpanContext
+internal typealias OtelJavaOpenTelemetry = OpenTelemetry

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/ClockAdapter.kt
@@ -1,7 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j
 
 import io.embrace.opentelemetry.kotlin.Clock
-import io.embrace.opentelemetry.kotlin.k2j.tracing.OtelJavaClock
 
 public class ClockAdapter(
     private val clock: OtelJavaClock = OtelJavaClock.getDefault()

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+
+@ExperimentalApi
+public class OpenTelemetrySdk(
+    private val impl: OtelJavaOpenTelemetry
+) : OpenTelemetry {
+
+    override val tracerProvider: TracerProvider by lazy { TracerProviderAdapter(impl.tracerProvider) }
+    override val loggerProvider: LoggerProvider
+        get() = TODO("Not yet implemented")
+}

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
@@ -2,6 +2,8 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaAttributes
 
 @OptIn(ExperimentalApi::class)
 internal class AttributeContainerImpl : AttributeContainer {

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributesExt.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributesExt.kt
@@ -1,5 +1,7 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaAttributes
+
 internal fun OtelJavaAttributes.toMap(): Map<String, Any> {
     return this.asMap().mapKeys { it.key.key }
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -4,6 +4,8 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.tracing.Link
 import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
 import io.embrace.opentelemetry.kotlin.tracing.Span

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanContextOrigin
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
@@ -1,5 +1,9 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaImmutableSpanContext
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 
 internal fun SpanKind.convertToOtelJava(): OtelJavaSpanKind = when (this) {

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaStatusCode
 
 internal fun StatusCode.convertToOtelJava(): OtelJavaStatusCode = when (this) {
     StatusCode.Unset -> OtelJavaStatusCode.UNSET

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 
 internal class TraceFlagsAdapter(

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateAdapter.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
 
 internal class TraceStateAdapter(

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -2,6 +2,8 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipContainer

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 


### PR DESCRIPTION
## Goal

Adds the main entrypoint for the SDK. Effectively this decorates an instance of the official Java OTel API and allows folks to call the Kotlin API instead.

