### PR TITLE
Create no-op implementations

### DIFF
--- a/opentelemetry-kotlin-api-noop/api/android/opentelemetry-kotlin-api-noop.api
+++ b/opentelemetry-kotlin-api-noop/api/android/opentelemetry-kotlin-api-noop.api
@@ -1,0 +1,6 @@
+public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetry : io/embrace/opentelemetry/kotlin/OpenTelemetry {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/NoopOpenTelemetry;
+	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
+	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+}
+

--- a/opentelemetry-kotlin-api-noop/api/jvm/opentelemetry-kotlin-api-noop.api
+++ b/opentelemetry-kotlin-api-noop/api/jvm/opentelemetry-kotlin-api-noop.api
@@ -1,0 +1,6 @@
+public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetry : io/embrace/opentelemetry/kotlin/OpenTelemetry {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/NoopOpenTelemetry;
+	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
+	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+}
+

--- a/opentelemetry-kotlin-api-noop/build.gradle.kts
+++ b/opentelemetry-kotlin-api-noop/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("com.android.library")
+    id("io.embrace.otel.build-logic")
+    id("com.vanniktech.maven.publish")
+}
+
+buildLogic {
+    containsPublicApi.set(true)
+}
+
+android {
+    namespace = "io.embrace.opentelemetry.kotlin.api.noop"
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":opentelemetry-kotlin-api"))
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopClock.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopClock.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin
+
+internal object NoopClock : Clock {
+    override fun now(): Long = 0L
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
+import io.embrace.opentelemetry.kotlin.logging.NoopLoggerProvider
+import io.embrace.opentelemetry.kotlin.tracing.NoopTracerProvider
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+
+@ExperimentalApi
+public object NoopOpenTelemetry : OpenTelemetry {
+    override val tracerProvider: TracerProvider = NoopTracerProvider
+    override val loggerProvider: LoggerProvider = NoopLoggerProvider
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.context.Context
+
+@ExperimentalApi
+internal object NoopLogger : Logger {
+    override fun log(
+        body: String?,
+        timestampNs: Long?,
+        observedTimestampNs: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: AttributeContainer.() -> Unit
+    ) {
+    }
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+@ExperimentalApi
+internal object NoopLoggerProvider : LoggerProvider {
+    override fun getLogger(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: AttributeContainer.() -> Unit
+    ): Logger = NoopLogger
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -1,0 +1,53 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+@ExperimentalApi
+internal object NoopSpan : Span {
+
+    override var name: String = ""
+    override var status: StatusCode = StatusCode.Unset
+    override val parent: SpanContext? = null
+    override val spanContext: SpanContext = NoopSpanContext
+
+    override fun end(timestamp: Long?) {
+    }
+
+    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    }
+
+    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+    }
+
+    override fun isRecording(): Boolean = false
+    override fun events(): List<SpanEvent> = emptyList()
+    override fun links(): List<Link> = emptyList()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+    }
+
+    override fun attributes(): Map<String, Any> = emptyMap()
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopSpanContext : SpanContext {
+
+    override val traceId: String = ""
+    override val spanId: String = ""
+    override val traceFlags: TraceFlags = NoopTraceFlags
+    override val isValid: Boolean = false
+    override val isRemote: Boolean = false
+
+    override fun getTraceState(): TraceState = NoopTraceState
+
+    override fun updateTraceState(action: TraceStateMutator.() -> Unit) {
+    }
+
+    override fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState,
+        origin: SpanContextOrigin
+    ): SpanContext = NoopSpanContext
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopTraceFlags : TraceFlags {
+    override val isSampled: Boolean = false
+    override val isRandom: Boolean = false
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTraceState.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTraceState.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopTraceState : TraceState {
+    override fun get(key: String): String? = null
+    override fun asMap(): Map<String, String> = emptyMap()
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopTracer : Tracer {
+    override fun createSpan(
+        name: String,
+        parent: Span?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: SpanRelationshipContainer.() -> Unit
+    ): Span = NoopSpan
+}

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+@ExperimentalApi
+internal object NoopTracerProvider : TracerProvider {
+    override fun getTracer(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: AttributeContainer.() -> Unit
+    ): Tracer = NoopTracer
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ rootProject.name = "opentelemetry-kotlin"
 include(
     ":opentelemetry-kotlin-api",
     ":opentelemetry-kotlin-api-ext",
+    ":opentelemetry-kotlin-api-noop",
     ":opentelemetry-kotlin-implementation",
     ":compat-shared",
     ":compat-official-to-kotlin",


### PR DESCRIPTION
## Goal

Creates no-op implementations of the OpenTelemetry API. This can be used in the case where folks don't want to perform any action with the API.

