### PR TITLE
Create object factory

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -2,7 +2,6 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
-import io.embrace.opentelemetry.kotlin.tracing.SpanContextOrigin
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.TraceStateMutator
@@ -23,15 +22,5 @@ internal class SpanContextAdapter(
 
     override fun getTraceState(): TraceState {
         return TraceStateAdapter(spanContext.traceState)
-    }
-
-    override fun create(
-        traceId: String,
-        spanId: String,
-        traceFlags: TraceFlags,
-        traceState: TraceState,
-        origin: SpanContextOrigin
-    ): SpanContext {
-        TODO("Not yet implemented")
     }
 }

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
@@ -15,12 +15,4 @@ internal object NoopSpanContext : SpanContext {
 
     override fun updateTraceState(action: TraceStateMutator.() -> Unit) {
     }
-
-    override fun create(
-        traceId: String,
-        spanId: String,
-        traceFlags: TraceFlags,
-        traceState: TraceState,
-        origin: SpanContextOrigin
-    ): SpanContext = NoopSpanContext
 }

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracingFactory.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracingFactory.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopTracingFactory : TracingFactory {
+
+    override fun createSpanContext(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState,
+        origin: SpanContextOrigin
+    ): SpanContext = NoopSpanContext
+}

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -127,7 +127,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanId ()Ljava/lang/String;
 	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
@@ -135,10 +134,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
 	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/SpanContext$DefaultImpls {
-	public static synthetic fun create$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {
@@ -206,5 +201,13 @@ public final class io/embrace/opentelemetry/kotlin/tracing/TracerProvider$Defaul
 }
 
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/tracing/TracingDsl : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracingFactory {
+	public abstract fun createSpanContext (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$DefaultImpls {
+	public static synthetic fun createSpanContext$default (Lio/embrace/opentelemetry/kotlin/tracing/TracingFactory;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -127,7 +127,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanId ()Ljava/lang/String;
 	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;
 	public abstract fun getTraceId ()Ljava/lang/String;
@@ -135,10 +134,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
 	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/SpanContext$DefaultImpls {
-	public static synthetic fun create$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {
@@ -206,5 +201,13 @@ public final class io/embrace/opentelemetry/kotlin/tracing/TracerProvider$Defaul
 }
 
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/tracing/TracingDsl : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracingFactory {
+	public abstract fun createSpanContext (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$DefaultImpls {
+	public static synthetic fun createSpanContext$default (Lio/embrace/opentelemetry/kotlin/tracing/TracingFactory;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -54,16 +54,4 @@ public interface SpanContext {
      */
     @ThreadSafe
     public fun updateTraceState(action: TraceStateMutator.() -> Unit)
-
-    /**
-     * Creates a new [SpanContext] from the given parameters.
-     */
-    @ThreadSafe
-    public fun create(
-        traceId: String,
-        spanId: String,
-        traceFlags: TraceFlags,
-        traceState: TraceState,
-        origin: SpanContextOrigin = SpanContextOrigin.LOCAL,
-    ): SpanContext
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracingFactory.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracingFactory.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+public interface TracingFactory {
+
+    /**
+     * Creates a new [SpanContext] from the given parameters.
+     */
+    @ThreadSafe
+    public fun createSpanContext(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState,
+        origin: SpanContextOrigin = SpanContextOrigin.LOCAL,
+    ): SpanContext
+}


### PR DESCRIPTION
## Goal

Creates a factory that can be used to create objects on the Tracing API. The OTel spec mandates that users have a way of constructing/copying certain objects where possible. We therefore need to support this, but want to avoid polluting the API with constructor signatures/internal implementation details.

I _think_ the best way of achieving this is to expose a factory (or individual factories for the logging/tracing API if things get too unwieldy) and have that construct objects given some parameters. That avoids exposing concrete types and constructors, and avoids needing to use a companion object in interfaces.

This would ultimately be exposed as something like this (TBD):

```
val spanContext = OpenTelemetryFactory.createSpanContext(...)
```

