### PR TITLE
Alter tracing api to use span context

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -7,20 +7,20 @@ import io.embrace.opentelemetry.kotlin.tracing.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.TraceStateMutator
 
 internal class SpanContextAdapter(
-    private val spanContext: OtelJavaSpanContext
+    val impl: OtelJavaSpanContext
 ) : SpanContext {
 
-    override val traceId: String = spanContext.traceId
-    override val spanId: String = spanContext.spanId
-    override val traceFlags: TraceFlags = TraceFlagsAdapter(spanContext.traceFlags)
-    override val isValid: Boolean = spanContext.isValid
-    override val isRemote: Boolean = spanContext.isRemote
+    override val traceId: String = impl.traceId
+    override val spanId: String = impl.spanId
+    override val traceFlags: TraceFlags = TraceFlagsAdapter(impl.traceFlags)
+    override val isValid: Boolean = impl.isValid
+    override val isRemote: Boolean = impl.isRemote
 
     override fun updateTraceState(action: TraceStateMutator.() -> Unit) {
         TODO("Not yet implemented")
     }
 
     override fun getTraceState(): TraceState {
-        return TraceStateAdapter(spanContext.traceState)
+        return TraceStateAdapter(impl.traceState)
     }
 }

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -114,8 +114,8 @@ internal class SpanExportTest {
     @Test
     fun `test span context parent`() {
         val a = tracer.createSpan("a")
-        val b = tracer.createSpan("b", parent = a)
-        val c = tracer.createSpan("c", parent = b)
+        val b = tracer.createSpan("b", parent = a.spanContext)
+        val c = tracer.createSpan("c", parent = b.spanContext)
 
         assertNull(a.parent)
         assertNotNull(a.spanContext)

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 internal object NoopTracer : Tracer {
     override fun createSpan(
         name: String,
-        parent: Span?,
+        parent: SpanContext?,
         spanKind: SpanKind,
         startTimestamp: Long?,
         action: SpanRelationshipContainer.() -> Unit

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -185,11 +185,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceSta
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {
-	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/Tracer$DefaultImpls {
-	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracerProvider {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -185,11 +185,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceSta
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {
-	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/Tracer$DefaultImpls {
-	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
+	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/Span;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracerProvider {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -18,7 +18,7 @@ public interface Tracer {
     @ThreadSafe
     public fun createSpan(
         name: String,
-        parent: Span? = null,
+        parent: SpanContext? = null,
         spanKind: SpanKind = SpanKind.INTERNAL,
         startTimestamp: Long? = null,
         action: SpanRelationshipContainer.() -> Unit = {}


### PR DESCRIPTION
## Goal

Alters the Tracing API to pass `SpanContext` rather than `Span`, as it's technically possible for spans from other processes/machines to get propagated.

