### PR TITLE
Update trace state to remain immutable

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter.kt
@@ -4,23 +4,14 @@ import io.embrace.opentelemetry.kotlin.k2j.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
-import io.embrace.opentelemetry.kotlin.tracing.TraceStateMutator
 
 internal class SpanContextAdapter(
     val impl: OtelJavaSpanContext
 ) : SpanContext {
-
     override val traceId: String = impl.traceId
     override val spanId: String = impl.spanId
     override val traceFlags: TraceFlags = TraceFlagsAdapter(impl.traceFlags)
     override val isValid: Boolean = impl.isValid
     override val isRemote: Boolean = impl.isRemote
-
-    override fun updateTraceState(action: TraceStateMutator.() -> Unit) {
-        TODO("Not yet implemented")
-    }
-
-    override fun getTraceState(): TraceState {
-        return TraceStateAdapter(impl.traceState)
-    }
+    override val traceState: TraceState = TraceStateAdapter(impl.traceState)
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
@@ -13,7 +13,7 @@ internal fun SpanContext.convertToOtelJava(): OtelJavaSpanContext {
         traceId,
         spanId,
         traceFlags.convertToOtelJava(),
-        getTraceState().convertToOtelJava(),
+        traceState.convertToOtelJava(),
         isRemote,
         false
     )

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -39,7 +39,6 @@ internal class SpanExportTest {
         harness.assertSpans(
             expectedCount = 1,
             goldenFileName = "span_minimal.json",
-            sanitizeSpanContextIds = true,
         )
     }
 
@@ -68,7 +67,6 @@ internal class SpanExportTest {
         harness.assertSpans(
             expectedCount = 1,
             goldenFileName = "span_props.json",
-            sanitizeSpanContextIds = true,
         )
     }
 
@@ -82,7 +80,6 @@ internal class SpanExportTest {
         harness.assertSpans(
             expectedCount = 1,
             goldenFileName = "span_attrs.json",
-            sanitizeSpanContextIds = true,
         )
     }
 
@@ -107,7 +104,6 @@ internal class SpanExportTest {
         harness.assertSpans(
             expectedCount = 1,
             goldenFileName = "span_events.json",
-            sanitizeSpanContextIds = true,
         )
     }
 
@@ -152,7 +148,7 @@ internal class SpanExportTest {
     @Test
     fun `test span trace state`() {
         val span = tracer.createSpan("my_span")
-        val state = span.spanContext.getTraceState()
+        val state = span.spanContext.traceState
         assertEquals(emptyMap(), state.asMap())
     }
 
@@ -175,7 +171,6 @@ internal class SpanExportTest {
         harness.assertSpans(
             expectedCount = 2,
             goldenFileName = "span_links.json",
-            sanitizeSpanContextIds = true,
         )
     }
 

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpanContext.kt
@@ -4,15 +4,10 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @ExperimentalApi
 internal object NoopSpanContext : SpanContext {
-
     override val traceId: String = ""
     override val spanId: String = ""
     override val traceFlags: TraceFlags = NoopTraceFlags
     override val isValid: Boolean = false
     override val isRemote: Boolean = false
-
-    override fun getTraceState(): TraceState = NoopTraceState
-
-    override fun updateTraceState(action: TraceStateMutator.() -> Unit) {
-    }
+    override val traceState: TraceState = NoopTraceState
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -133,7 +133,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun getTraceState ()Lio/embrace/opentelemetry/kotlin/tracing/TraceState;
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
-	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -133,7 +133,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanCont
 	public abstract fun getTraceState ()Lio/embrace/opentelemetry/kotlin/tracing/TraceState;
 	public abstract fun isRemote ()Z
 	public abstract fun isValid ()Z
-	public abstract fun updateTraceState (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin : java/lang/Enum {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanContext.kt
@@ -46,12 +46,5 @@ public interface SpanContext {
      * Contains state about the trace.
      */
     @ThreadSafe
-    public fun getTraceState(): TraceState
-
-    /**
-     * Mutates the trace state with the given action and replaces [traceState] with a new immutable object
-     * containing the changes.
-     */
-    @ThreadSafe
-    public fun updateTraceState(action: TraceStateMutator.() -> Unit)
+    public val traceState: TraceState
 }


### PR DESCRIPTION
## Goal

Updates `traceState` on `SpanContext` so that it's an immutable property as stated in [the spec](https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate).

