### PR TITLE
[POC] Sdk creation DSL

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -11,6 +11,12 @@ public final class io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk : io/emb
 	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
+public final class io/embrace/opentelemetry/kotlin/k2j/creation/CompatSdkFactory : io/embrace/opentelemetry/kotlin/creation/SdkFactory {
+	public fun <init> ()V
+	public final fun createOpenTelemetry (Lio/opentelemetry/api/OpenTelemetry;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+}
+
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
 	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;)V
 	public synthetic fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/CompatSdkFactory.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/CompatSdkFactory.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.k2j.creation
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.creation.SdkFactory
+import io.embrace.opentelemetry.kotlin.creation.SdkParams
+import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaOpenTelemetry
+
+@ExperimentalApi
+public class CompatSdkFactory : SdkFactory {
+
+    /**
+     * Creates an instance of the Kotlin OTel API that is backed by the Java SDK implementation.
+     */
+    public fun createOpenTelemetry(otelJava: OtelJavaOpenTelemetry): OpenTelemetry = OpenTelemetrySdk(otelJava)
+
+    override fun createOpenTelemetry(action: SdkParams.() -> Unit): OpenTelemetry {
+        val params = SdkParamsImpl()
+        action(params)
+
+        // TODO: read from params to create OTel instance.
+
+        TODO("Not yet implemented")
+    }
+}

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/LoggerProviderParamsImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/LoggerProviderParamsImpl.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.k2j.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creation.LoggerProviderParams
+
+@ExperimentalApi
+internal class LoggerProviderParamsImpl(
+    override var clock: Clock? = null
+) : LoggerProviderParams

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/SdkParamsImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/SdkParamsImpl.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.k2j.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creation.LoggerProviderParams
+import io.embrace.opentelemetry.kotlin.creation.SdkParams
+import io.embrace.opentelemetry.kotlin.creation.TracerProviderParams
+
+@ExperimentalApi
+internal class SdkParamsImpl : SdkParams {
+
+    override var clock: Clock? = null
+    override val loggerProviderParams = LoggerProviderParamsImpl()
+    override val tracerProviderParams = TracerProviderParamsImpl()
+
+    override fun loggerProviderParams(action: LoggerProviderParams.() -> Unit) {
+        action(loggerProviderParams)
+    }
+
+    override fun tracerProviderParams(action: TracerProviderParams.() -> Unit) {
+        action(tracerProviderParams)
+    }
+}

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/TracerProviderParamsImpl.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/creation/TracerProviderParamsImpl.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.k2j.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creation.TracerProviderParams
+
+@ExperimentalApi
+internal class TracerProviderParamsImpl(
+    override var clock: Clock? = null
+) : TracerProviderParams

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -2,9 +2,11 @@ package io.embrace.opentelemetry.example.kotlin
 
 import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.k2j.creation.CompatSdkFactory
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 
@@ -19,6 +21,18 @@ private fun instantiateOtelApi(): OpenTelemetry {
 
 @OptIn(ExperimentalApi::class)
 fun createInstrumentationWithOtelKotlin() {
+    val overrideClock: Clock = object : Clock {
+        override fun now(): Long = System.currentTimeMillis()
+    }
+    CompatSdkFactory().createOpenTelemetry {
+        clock = overrideClock
+
+        loggerProviderParams.clock = overrideClock
+        loggerProviderParams {
+            clock = overrideClock
+        }
+        tracerProviderParams { }
+    }
     val api = instantiateOtelApi()
     val tracer = api.tracerProvider.getTracer(
         name = "kotlin-example-app",

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -51,6 +51,32 @@ public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextK
 	public abstract fun getName ()Ljava/lang/String;
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/LoggerProviderParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+}
+
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/creation/SdkCreationDsl : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/SdkFactory {
+	public abstract fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/SdkParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun getLoggerProviderParams ()Lio/embrace/opentelemetry/kotlin/creation/LoggerProviderParams;
+	public abstract fun getTracerProviderParams ()Lio/embrace/opentelemetry/kotlin/creation/TracerProviderParams;
+	public abstract fun loggerProviderParams (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+	public abstract fun tracerProviderParams (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/TracerProviderParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/LogRecord : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getBody ()Ljava/lang/String;
 	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/context/Context;

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -51,6 +51,32 @@ public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextK
 	public abstract fun getName ()Ljava/lang/String;
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/LoggerProviderParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+}
+
+public abstract interface annotation class io/embrace/opentelemetry/kotlin/creation/SdkCreationDsl : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/SdkFactory {
+	public abstract fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/SdkParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun getLoggerProviderParams ()Lio/embrace/opentelemetry/kotlin/creation/LoggerProviderParams;
+	public abstract fun getTracerProviderParams ()Lio/embrace/opentelemetry/kotlin/creation/TracerProviderParams;
+	public abstract fun loggerProviderParams (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+	public abstract fun tracerProviderParams (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creation/TracerProviderParams {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/LogRecord : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getBody ()Ljava/lang/String;
 	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/context/Context;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/LoggerProviderParams.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/LoggerProviderParams.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@SdkCreationDsl
+@ExperimentalApi
+public interface LoggerProviderParams {
+
+    @SdkCreationDsl
+    public var clock: Clock?
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkCreationDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkCreationDsl.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.creation
+
+/**
+ * Marks a class as part of the SDK creation API DSL. This helps disambiguate what symbols should be accessible
+ * as _implicit_ references within nested lambdas. It is still possible to reference the outer lambda explicitly
+ * via this@outerLambdaName.
+ *
+ * https://kotlinlang.org/docs/type-safe-builders.html#scope-control-dslmarker
+ */
+@DslMarker
+public annotation class SdkCreationDsl

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkFactory.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkFactory.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.creation
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+
+@ExperimentalApi
+@SdkCreationDsl
+public interface SdkFactory {
+    public fun createOpenTelemetry(action: SdkParams.() -> Unit): OpenTelemetry
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkParams.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/SdkParams.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@SdkCreationDsl
+@ExperimentalApi
+public interface SdkParams {
+
+    @SdkCreationDsl
+    public var clock: Clock?
+
+    @SdkCreationDsl
+    public val loggerProviderParams: LoggerProviderParams
+
+    @SdkCreationDsl
+    public val tracerProviderParams: TracerProviderParams
+
+    @SdkCreationDsl
+    public fun loggerProviderParams(action: LoggerProviderParams.() -> Unit)
+
+    @SdkCreationDsl
+    public fun tracerProviderParams(action: TracerProviderParams.() -> Unit)
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/TracerProviderParams.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creation/TracerProviderParams.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.creation
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@SdkCreationDsl
+@ExperimentalApi
+public interface TracerProviderParams {
+    public var clock: Clock?
+}


### PR DESCRIPTION
## Goal

Sketches out a Kotlin DSL for creating SDK instances. This approach aims to achieve a few things:

1. Avoid exposing constructor signatures to consumers
2. Only expose interfaces in the `opentelemetry-kotlin-api` module (with the exception of the `CompatSdkFactory` entrypoint, which is a concrete class)

The entrypoint is the `SdkFactory` interface, which `CompatSdkFactory` implements. Currently this just allows configuring a `Clock` object either globally, or on individual objects. In the OTel Java SDK a `Clock` has to be configured on each separate object passed to the API.

In future we'd expand this to allow the following sort of API invocations:

```
CompatSdkFactory().createOpenTelemetry {
        clock = MyClock()

        loggerProviderParams {
            clock = MyOverrideClock()
        }
        tracerProviderParams {
            spanLimits = SpanLimits(50)

            // add span processors etc here
            tracerOptions {
                 name = "my_tracer"
            }
        }
    }
```





