### PR TITLE
Alter api for ending span

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -46,12 +46,12 @@ internal class SpanAdapter(
 
     override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
 
-    override fun end(timestamp: Long?) {
-        if (timestamp != null) {
-            impl.end(timestamp, TimeUnit.NANOSECONDS)
-        } else {
-            impl.end()
-        }
+    override fun end() {
+        impl.end()
+    }
+
+    override fun end(timestamp: Long) {
+        impl.end(timestamp, TimeUnit.NANOSECONDS)
     }
 
     override fun isRecording(): Boolean = impl.isRecording

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -12,7 +12,10 @@ internal object NoopSpan : Span {
     override val parent: SpanContext? = null
     override val spanContext: SpanContext = NoopSpanContext
 
-    override fun end(timestamp: Long?) {
+    override fun end() {
+    }
+
+    override fun end(timestamp: Long) {
     }
 
     override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -112,7 +112,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : i
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer {
-	public abstract fun end (Ljava/lang/Long;)V
+	public abstract fun end ()V
+	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
@@ -120,10 +121,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setStatus (Lio/embrace/opentelemetry/kotlin/StatusCode;)V
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
-	public static synthetic fun end$default (Lio/embrace/opentelemetry/kotlin/tracing/Span;Ljava/lang/Long;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -112,7 +112,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : i
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer {
-	public abstract fun end (Ljava/lang/Long;)V
+	public abstract fun end ()V
+	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
@@ -120,10 +121,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setStatus (Lio/embrace/opentelemetry/kotlin/StatusCode;)V
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/Span$DefaultImpls {
-	public static synthetic fun end$default (Lio/embrace/opentelemetry/kotlin/tracing/Span;Ljava/lang/Long;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanContext {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -39,10 +39,16 @@ public interface Span : SpanRelationshipContainer {
     public val spanContext: SpanContext
 
     /**
-     * Ends the span. An optional timestamp in nanoseconds can be supplied.
+     * Ends the span.
      */
     @ThreadSafe
-    public fun end(timestamp: Long? = null)
+    public fun end()
+
+    /**
+     * Ends the span, setting an explicit end-time in nanoseconds.
+     */
+    @ThreadSafe
+    public fun end(timestamp: Long)
 
     /**
      * Returns true if the span is currently recording.


### PR DESCRIPTION
## Goal

Alters the API for ending a span by creating function overloads, instead of a parameter with default values.

