### PR TITLE
Set the api/language version for kotlin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,5 +40,7 @@ project.tasks.withType(JavaCompile::class.java).configureEach {
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8)
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8)
     }
 }

--- a/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
@@ -10,6 +10,7 @@ fun Project.configureKotlin(
     buildLogic: BuildLogicExtension,
     kotlin: KotlinMultiplatformExtension
 ) {
+    kotlin.jvmToolchain(8)
     afterEvaluate {
         kotlin.apply {
             val platforms = buildLogic.targetPlatforms.get()


### PR DESCRIPTION
## Goal

Sets an explicit API/Language version for Kotlin. We were doing this for `JavaCompile` but not in the Kotlin compiler options.

