### PR TITLE
Rename span relationships

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.k2j.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
-import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipContainer
+import io.embrace.opentelemetry.kotlin.tracing.SpanRelationships
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import java.util.concurrent.TimeUnit
 
@@ -23,7 +23,7 @@ internal class TracerAdapter(
         parent: SpanContext?,
         spanKind: SpanKind,
         startTimestamp: Long?,
-        action: SpanRelationshipContainer.() -> Unit
+        action: SpanRelationships.() -> Unit
     ): Span {
         val builder = tracer.spanBuilder(name)
             .setSpanKind(spanKind.convertToOtelJava())

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -9,6 +9,6 @@ internal object NoopTracer : Tracer {
         parent: SpanContext?,
         spanKind: SpanKind,
         startTimestamp: Long?,
-        action: SpanRelationshipContainer.() -> Unit
+        action: SpanRelationships.() -> Unit
     ): Span = NoopSpan
 }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -111,7 +111,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : i
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationships {
 	public abstract fun end ()V
 	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
@@ -154,15 +154,15 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationships : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun events ()Ljava/util/List;
 	public abstract fun links ()Ljava/util/List;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer$DefaultImpls {
-	public static synthetic fun addEvent$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationships$DefaultImpls {
+	public static synthetic fun addEvent$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanRelationships;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceFlags {

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -111,7 +111,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : i
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : io/embrace/opentelemetry/kotlin/tracing/SpanRelationships {
 	public abstract fun end ()V
 	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
@@ -154,15 +154,15 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanKind : java/lang/
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/SpanRelationships : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun events ()Ljava/util/List;
 	public abstract fun links ()Ljava/util/List;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer$DefaultImpls {
-	public static synthetic fun addEvent$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanRelationshipContainer;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanRelationships$DefaultImpls {
+	public static synthetic fun addEvent$default (Lio/embrace/opentelemetry/kotlin/tracing/SpanRelationships;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TraceFlags {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -12,7 +12,7 @@ import io.embrace.opentelemetry.kotlin.ThreadSafe
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface Span : SpanRelationshipContainer {
+public interface Span : SpanRelationships {
 
     /**
      * Sets the name of the span. Must be non-empty.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationships.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationships.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  * https://opentelemetry.io/docs/specs/otel/trace/api/
  */
 @ExperimentalApi
-public interface SpanRelationshipContainer : AttributeContainer {
+public interface SpanRelationships : AttributeContainer {
 
     /**
      * Adds a link to the span that associates it with another [SpanContext].

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -21,6 +21,6 @@ public interface Tracer {
         parent: SpanContext? = null,
         spanKind: SpanKind = SpanKind.INTERNAL,
         startTimestamp: Long? = null,
-        action: SpanRelationshipContainer.() -> Unit = {}
+        action: SpanRelationships.() -> Unit = {}
     ): Span
 }


### PR DESCRIPTION
## Goal

Renames `SpanRelationshipContainer` to `SpanRelationships`.

