### PR TITLE
Enhance implementation of Context

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapter.kt
@@ -7,15 +7,16 @@ import io.embrace.opentelemetry.kotlin.k2j.OtelJavaContextKey
 
 @ExperimentalApi
 internal class ContextAdapter(
-    private val impl: Context
+    private val impl: Context,
+    private val repository: ContextKeyRepository,
 ) : OtelJavaContext {
 
     override fun <V : Any?> get(key: OtelJavaContextKey<V>): V? {
-        return impl[ContextKeyAdapter(key)]
+        return impl[repository.get(key)]
     }
 
     override fun <V : Any?> with(key: OtelJavaContextKey<V>, value: V): OtelJavaContext {
-        val ctx = impl.set(ContextKeyAdapter(key), value)
-        return ContextAdapter(ctx)
+        val ctx = impl.set(repository.get(key), value)
+        return ContextAdapter(ctx, repository)
     }
 }

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyRepository.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyRepository.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.k2j.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.ContextKey
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaContextKey
+import java.util.concurrent.ConcurrentHashMap
+
+@Suppress("UNCHECKED_CAST")
+@OptIn(ExperimentalApi::class)
+internal class ContextKeyRepository {
+
+    // TODO: future: cleanup stale references
+    // TODO: future: support nullable values
+
+    companion object {
+        val INSTANCE = ContextKeyRepository()
+    }
+
+    private val impl = ConcurrentHashMap<OtelJavaContextKey<*>, ContextKey<*>>()
+
+    fun <T> get(key: OtelJavaContextKey<T>): ContextKey<T> {
+        return impl.getOrPut(key) {
+            ContextKeyAdapter(key)
+        } as ContextKey<T>
+    }
+}

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LoggerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LoggerAdapter.kt
@@ -5,13 +5,17 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.k2j.OtelJavaLogger
 import io.embrace.opentelemetry.kotlin.k2j.context.ContextAdapter
+import io.embrace.opentelemetry.kotlin.k2j.context.ContextKeyRepository
 import io.embrace.opentelemetry.kotlin.k2j.tracing.AttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import java.util.concurrent.TimeUnit
 
 @ExperimentalApi
-internal class LoggerAdapter(private val impl: OtelJavaLogger) : Logger {
+internal class LoggerAdapter(
+    private val impl: OtelJavaLogger,
+    private val contextKeyRepository: ContextKeyRepository = ContextKeyRepository.INSTANCE,
+) : Logger {
 
     override fun log(
         body: String?,
@@ -34,7 +38,7 @@ internal class LoggerAdapter(private val impl: OtelJavaLogger) : Logger {
             builder.setObservedTimestamp(observedTimestampNs, TimeUnit.NANOSECONDS)
         }
         if (context != null) {
-            builder.setContext(ContextAdapter(context))
+            builder.setContext(ContextAdapter(context, contextKeyRepository))
         }
         if (severityNumber != null) {
             builder.setSeverity(severityNumber.convertToOtelJava())

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdkTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdkTest.kt
@@ -1,0 +1,40 @@
+package io.embrace.opentelemetry.kotlin.k2j
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class OpenTelemetrySdkTest {
+
+    @Test
+    fun `retrieve tracer provider`() {
+        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop())
+        val provider = sdk.tracerProvider
+        val a = provider.getTracer("test")
+        val b = provider.getTracer("test")
+        val c = provider.getTracer("test", "1.0.0") {
+            setStringAttribute("key", "value")
+        }
+        val d = provider.getTracer("another")
+        assertSame(a, b)
+        assertNotSame(b, c)
+        assertNotSame(c, d)
+    }
+
+    @Test
+    fun `retrieve logger provider`() {
+        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop())
+        val provider = sdk.loggerProvider
+        val a = provider.getLogger("test")
+        val b = provider.getLogger("test")
+        val c = provider.getLogger("test", "1.0.0") {
+            setStringAttribute("key", "value")
+        }
+        val d = provider.getLogger("another")
+        assertSame(a, b)
+        assertNotSame(b, c)
+        assertNotSame(c, d)
+    }
+}

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapterTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapterTest.kt
@@ -1,0 +1,32 @@
+package io.embrace.opentelemetry.kotlin.k2j.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.ContextImpl
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaContextKey
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalApi::class)
+internal class ContextAdapterTest {
+
+    @Test
+    fun `test context`() {
+        val repository = ContextKeyRepository()
+        val ctx = ContextAdapter(ContextImpl(), repository)
+        val key1 = OtelJavaContextKey.named<String>("foo")
+        val key2 = OtelJavaContextKey.named<String>("foo")
+        val key3 = OtelJavaContextKey.named<String>("bar")
+
+        assertNull(ctx.get(key1))
+        assertNull(ctx.get(key2))
+        assertNull(ctx.get(key3))
+
+        val newCtx = ctx.with(key1, "value1")
+        assertNotSame(ctx, newCtx)
+        assertEquals("value1", newCtx.get(key1))
+        assertNull(newCtx.get(key2))
+        assertNull(newCtx.get(key3))
+    }
+}

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyAdapterTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyAdapterTest.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin.k2j.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.k2j.OtelJavaContextKey
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@OptIn(ExperimentalApi::class)
+internal class ContextKeyAdapterTest {
+
+    @Test
+    fun `test context key`() {
+        val key = "foo"
+        val a = ContextKeyAdapter<String>(OtelJavaContextKey.named(key))
+        val sharedKey = OtelJavaContextKey.named<String>(key)
+        val b = ContextKeyAdapter<String>(sharedKey)
+        val c = ContextKeyAdapter<String>(sharedKey)
+
+        assertEquals(key, a.name)
+        assertNotEquals(a, b)
+        assertNotEquals(b, c)
+    }
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
@@ -29,7 +29,7 @@ public interface Context {
      * This function returns a new immutable [Context] that contains the key-value pair.
      */
     @ThreadSafe
-    public operator fun <T> set(key: ContextKey<T>, value: T): Context
+    public operator fun <T> set(key: ContextKey<T>, value: T?): Context
 
     /**
      * Retrieves a value from the [Context] associated with the given [ContextKey].

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+public class ContextImpl(
+    private val impl: Map<ContextKey<*>, Any> = mapOf()
+) : Context {
+
+    override fun <T> createKey(name: String): ContextKey<T> = ContextKeyImpl(name)
+
+    override fun <T> set(
+        key: ContextKey<T>,
+        value: T?
+    ): Context {
+        val newCtx = when (value) {
+            null -> impl.minus(key)
+            else -> impl.plus(Pair(key, value as Any))
+        }
+        return ContextImpl(newCtx)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> get(key: ContextKey<T>): T? = impl[key] as T?
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKeyImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKeyImpl.kt
@@ -3,4 +3,4 @@ package io.embrace.opentelemetry.kotlin.context
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class ContextKeyImpl<T>(override val name: String) : ContextKey<T>
+public class ContextKeyImpl<T>(override val name: String) : ContextKey<T>


### PR DESCRIPTION
## Goal

Makes a few changes to the implementation of `Context` to avoid instantiating different keys when the underlying OTel Java implementation would use the same key. I've taken similar steps to avoid creating additional instances of the logger/tracer wrappers.

## Testing

Added unit tests.
