### PR TITLE
Add accessors for SpanKind and startTimestamp

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -12,7 +12,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk : io/emb
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/embrace/opentelemetry/kotlin/tracing/Span {
-	public fun <init> (Lio/opentelemetry/api/trace/Span;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;)V
+	public fun <init> (Lio/opentelemetry/api/trace/Span;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;J)V
 	public fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
 	public fun attributes ()Ljava/util/Map;
@@ -23,6 +23,8 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/
 	public fun getName ()Ljava/lang/String;
 	public fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+	public fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public fun getStartTimestamp ()J
 	public fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public fun isRecording ()Z
 	public fun links ()Ljava/util/List;

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -12,6 +12,7 @@ import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -21,6 +22,8 @@ public class SpanAdapter( // temporarily public, will be internal in future
     public val impl: OtelJavaSpan,
     private val clock: Clock,
     override val parent: SpanContext?,
+    override val spanKind: SpanKind,
+    override val startTimestamp: Long,
 ) : Span {
 
     private val attrs: MutableMap<String, Any> = ConcurrentHashMap()

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -25,9 +25,10 @@ public class TracerAdapter(
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit
     ): Span {
+        val start = startTimestamp ?: clock.now()
         val builder = tracer.spanBuilder(name)
             .setSpanKind(spanKind.convertToOtelJava())
-            .setStartTimestamp(startTimestamp ?: clock.now(), TimeUnit.NANOSECONDS)
+            .setStartTimestamp(start, TimeUnit.NANOSECONDS)
 
         if (parent != null) {
             val ctx = findContext(parent)
@@ -35,7 +36,13 @@ public class TracerAdapter(
         }
 
         val span = builder.startSpan()
-        return SpanAdapter(span, clock, parent).apply {
+        return SpanAdapter(
+            impl = span,
+            clock = clock,
+            parent = parent,
+            spanKind = spanKind,
+            startTimestamp = start
+        ).apply {
             this.name = name
             action(this)
         }

--- a/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/compat-kotlin-to-official/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -64,6 +64,8 @@ internal class SpanExportTest {
         span.end(1000)
         assertFalse(span.isRecording())
 
+        assertEquals(SpanKind.CLIENT, span.spanKind)
+        assertEquals(500, span.startTimestamp)
         harness.assertSpans(
             expectedCount = 1,
             goldenFileName = "span_props.json",

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -11,6 +11,8 @@ internal object NoopSpan : Span {
     override var status: StatusCode = StatusCode.Unset
     override val parent: SpanContext? = null
     override val spanContext: SpanContext = NoopSpanContext
+    override val spanKind: SpanKind = SpanKind.INTERNAL
+    override val startTimestamp: Long = -1L
 
     override fun end() {
     }

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -117,6 +117,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public abstract fun getStartTimestamp ()J
 	public abstract fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -117,6 +117,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Span : i
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;
+	public abstract fun getStartTimestamp ()J
 	public abstract fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Span.kt
@@ -39,6 +39,18 @@ public interface Span : SpanRelationships {
     public val spanContext: SpanContext
 
     /**
+     * The kind of this span
+     */
+    @ThreadSafe
+    public val spanKind: SpanKind
+
+    /**
+     * The timestamp at which this span started, in nanoseconds.
+     */
+    @ThreadSafe
+    public val startTimestamp: Long
+
+    /**
      * Ends the span.
      */
     @ThreadSafe


### PR DESCRIPTION
## Goal

Add accessors for SpanKind and startTimestamp, which are missing from the API.

