### PR TITLE
Make `SpanAdapter` implement `ImplicitContextKeyed`

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -11,7 +11,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk : io/emb
 	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
-public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/embrace/opentelemetry/kotlin/tracing/Span {
+public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/embrace/opentelemetry/kotlin/tracing/Span, io/opentelemetry/context/ImplicitContextKeyed {
 	public fun <init> (Lio/opentelemetry/api/trace/Span;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/SpanKind;J)V
 	public fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;Lkotlin/jvm/functions/Function1;)V
@@ -28,6 +28,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/
 	public fun getStatus ()Lio/embrace/opentelemetry/kotlin/StatusCode;
 	public fun isRecording ()Z
 	public fun links ()Ljava/util/List;
+	public fun makeCurrent ()Lio/opentelemetry/context/Scope;
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -38,6 +39,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/
 	public fun setStatus (Lio/embrace/opentelemetry/kotlin/StatusCode;)V
 	public fun setStringAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public fun storeInContext (Lio/opentelemetry/context/Context;)Lio/opentelemetry/context/Context;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapter : io/embrace/opentelemetry/kotlin/tracing/SpanContext {

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -13,6 +13,9 @@ import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ImplicitContextKeyed
+import io.opentelemetry.context.Scope
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -24,7 +27,7 @@ public class SpanAdapter( // temporarily public, will be internal in future
     override val parent: SpanContext?,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,
-) : Span {
+) : Span, ImplicitContextKeyed {
 
     private val attrs: MutableMap<String, Any> = ConcurrentHashMap()
     private val events: ConcurrentLinkedQueue<SpanEvent> = ConcurrentLinkedQueue()
@@ -119,4 +122,12 @@ public class SpanAdapter( // temporarily public, will be internal in future
     }
 
     override fun attributes(): Map<String, Any> = attrs.toMap()
+
+    override fun storeInContext(context: Context): Context? {
+        return impl.storeInContext(context)
+    }
+
+    override fun makeCurrent(): Scope? {
+        return impl.makeCurrent()
+    }
 }


### PR DESCRIPTION
## Goal

`SpanAdapter` needs to implement `ImplicitContextKeyed` for embrace-android-sdk to lookup spans from the opentelemetry-java `Context` object.