### PR TITLE
Call setNoParent on wrapped span builder if there's no parent

### DIFF
--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -33,6 +33,8 @@ public class TracerAdapter(
         if (parent != null) {
             val ctx = findContext(parent)
             builder.setParent(ctx)
+        } else {
+            builder.setNoParent()
         }
 
         val span = builder.startSpan()


### PR DESCRIPTION
## Goal

Calling  `setNoParent` on the builder is necessary so the Java SDK doesn't use the current span but instead uses the root as the parent context, thus not setting a parent span for the newly created span
