### PR TITLE
Update kotlin version used

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
@@ -3,6 +3,7 @@ package io.embrace.otel
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.exclude
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -16,24 +17,30 @@ fun Project.configureKotlin(
             val platforms = buildLogic.targetPlatforms.get()
 
             if (platforms.contains(TargetPlatform.JVM)) {
-                jvm()
+                jvm {
+                    compilerOptions.configureCompiler()
+                }
             }
             if (platforms.contains(TargetPlatform.ANDROID)) {
                 androidTarget {
                     publishLibraryVariants("release")
                     compilerOptions {
                         jvmTarget.set(JvmTarget.JVM_1_8)
+                        configureCompiler()
                     }
                 }
             }
             // not officially supported yet, beyond confirming the target compiles.
             if (platforms.contains(TargetPlatform.IOS)) {
-                iosArm64()
+                iosArm64 {
+                    compilerOptions.configureCompiler()
+                }
             }
 
             sourceSets.apply {
                 getByName("commonMain").apply {
                     dependencies {
+                        implementation(findLibrary("kotlin-exposed"))
                         // add dependencies here
                     }
                 }
@@ -47,10 +54,14 @@ fun Project.configureKotlin(
                 }
             }
             compilerOptions {
-                allWarningsAsErrors.set(true)
-                apiVersion.set(KotlinVersion.KOTLIN_1_8)
-                languageVersion.set(KotlinVersion.KOTLIN_1_8)
+                configureCompiler()
             }
         }
     }
+}
+
+private fun KotlinCommonCompilerOptions.configureCompiler() {
+    allWarningsAsErrors.set(true)
+    apiVersion.set(KotlinVersion.KOTLIN_1_8)
+    languageVersion.set(KotlinVersion.KOTLIN_1_8)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ mavenPublish = "0.33.0"
 nexus = "2.0.0"
 junit4 = "4.13.2"
 junit5 = "5.13.1"
+kotlinExposed = "1.8.22"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -26,6 +27,7 @@ kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-j
 mavenPublish = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+kotlin-exposed = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinExposed" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }


### PR DESCRIPTION
## Goal

Updates the Kotlin version that is declared as a dependency in the POM file. By default the Kotlin Multiplatform Gradle Plugin  just uses whatever version of Kotlin we compile against, which is 2.1. We should target an older version of Kotlin instead for backwards compatibility, as otherwise consumers of this library will be forced to the latest version.

## Testing

Checked POM file before and after this change.
