### PR TITLE
Add entrypoint for accessing OpenTelemetry instances

### DIFF
--- a/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
+++ b/compat-kotlin-to-official/api/jvm/compat-kotlin-to-official.api
@@ -1,14 +1,12 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExtKt {
+	public static final fun compatWithOtelJava (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+}
+
 public final class io/embrace/opentelemetry/kotlin/k2j/ClockAdapter : io/embrace/opentelemetry/kotlin/Clock {
 	public fun <init> ()V
 	public fun <init> (Lio/opentelemetry/sdk/common/Clock;)V
 	public synthetic fun <init> (Lio/opentelemetry/sdk/common/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun now ()J
-}
-
-public final class io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk : io/embrace/opentelemetry/kotlin/OpenTelemetry {
-	public fun <init> (Lio/opentelemetry/api/OpenTelemetry;)V
-	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
-	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter : io/embrace/opentelemetry/kotlin/tracing/Span, io/opentelemetry/context/ImplicitContextKeyed {

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+
+/**
+ * Constructs an [OpenTelemetry] instance that decorates the OpenTelemetry Java SDK. This will not use the Kotlin
+ * implementation under the hood and will solely use the Java SDK implementation. This is useful if you have existing
+ * OpenTelemetry Java SDK code that you don't want to rewrite, but still wish to use the Kotlin API.
+ */
+@ExperimentalApi
+public fun OpenTelemetryInstance.compatWithOtelJava(impl: OtelJavaOpenTelemetry): OpenTelemetry = OpenTelemetrySdk(impl)

--- a/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
+++ b/compat-kotlin-to-official/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
@@ -9,7 +9,7 @@ import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @ExperimentalApi
-public class OpenTelemetrySdk(
+internal class OpenTelemetrySdk(
     private val impl: OtelJavaOpenTelemetry
 ) : OpenTelemetry {
 

--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -6,7 +6,8 @@ import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
+import io.embrace.opentelemetry.kotlin.compatWithOtelJava
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
@@ -22,7 +23,7 @@ private fun instantiateOtelApi(): OpenTelemetry {
         .setTracerProvider(SdkTracerProvider.builder().addSpanProcessor(ExampleSpanProcessor()).build())
         .setLoggerProvider(SdkLoggerProvider.builder().addLogRecordProcessor(ExampleLogRecordProcessor()).build())
         .build()
-    return OpenTelemetrySdk(otelJava)
+    return OpenTelemetryInstance.compatWithOtelJava(otelJava)
 }
 
 /**

--- a/opentelemetry-kotlin-api-noop/api/android/opentelemetry-kotlin-api-noop.api
+++ b/opentelemetry-kotlin-api-noop/api/android/opentelemetry-kotlin-api-noop.api
@@ -1,6 +1,4 @@
-public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetry : io/embrace/opentelemetry/kotlin/OpenTelemetry {
-	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/NoopOpenTelemetry;
-	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
-	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExtKt {
+	public static final fun noop (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 

--- a/opentelemetry-kotlin-api-noop/api/jvm/opentelemetry-kotlin-api-noop.api
+++ b/opentelemetry-kotlin-api-noop/api/jvm/opentelemetry-kotlin-api-noop.api
@@ -1,6 +1,4 @@
-public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetry : io/embrace/opentelemetry/kotlin/OpenTelemetry {
-	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/NoopOpenTelemetry;
-	public fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
-	public fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExtKt {
+	public static final fun noop (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.tracing.NoopTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @ExperimentalApi
-public object NoopOpenTelemetry : OpenTelemetry {
+internal object NoopOpenTelemetry : OpenTelemetry {
     override val tracerProvider: TracerProvider = NoopTracerProvider
     override val loggerProvider: LoggerProvider = NoopLoggerProvider
 }

--- a/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
+++ b/opentelemetry-kotlin-api-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Returns a no-op [OpenTelemetry] instance.
+ */
+@ExperimentalApi
+public fun OpenTelemetryInstance.noop(): OpenTelemetry = NoopOpenTelemetry

--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -10,6 +10,10 @@ public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstance {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -10,6 +10,10 @@ public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstance {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;
+}
+
 public abstract class io/embrace/opentelemetry/kotlin/StatusCode {
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstance.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstance.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Entrypoint for creating instances of [OpenTelemetry].
+ */
+@ExperimentalApi
+public object OpenTelemetryInstance

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceExt.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Constructs an [OpenTelemetry] instance that uses the opentelemetry-kotlin implementation.
+ */
+@ExperimentalApi
+public fun OpenTelemetryInstance.default(): OpenTelemetry = throw UnsupportedOperationException()

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
@@ -3,10 +3,12 @@
 package io.embrace.opentelemetry.kotlin.testing.junit4
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.compatWithOtelJava
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
@@ -49,7 +51,7 @@ public class OpenTelemetryRule : ExternalResource() {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetrySdk = OpenTelemetrySdk(sdk)
+    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.compatWithOtelJava(sdk)
 
     public val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
@@ -3,10 +3,12 @@
 package io.embrace.opentelemetry.kotlin.testing.junit5
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.k2j.OpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.compatWithOtelJava
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
@@ -49,7 +51,7 @@ public class OpenTelemetryExtension : BeforeEachCallback {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetrySdk = OpenTelemetrySdk(sdk)
+    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.compatWithOtelJava(sdk)
 
     public val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans


### PR DESCRIPTION
## Goal

Adds an entrypoint that can be used to access an entrypoint of OpenTelemetry instances. The syntax currently looks as follows:

```
OpenTelemetryInstance.noop()
OpenTelemetryInstance.default()
OpenTelemetryInstance.compatWithOtelJava(OpenTelemetryBuilder.build())
```

I'm open to different symbol names for both `OpenTelemetryInstance` and the functions themselves. In future I think we might want a DSL as part of `default()`, but we can see how this goes for now.

