### PR TITLE
Remove signing + publishing plugin from test module

### DIFF
--- a/opentelemetry-kotlin-testing/build.gradle.kts
+++ b/opentelemetry-kotlin-testing/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
     id("io.embrace.otel.build-logic")
-    id("signing")
-    id("com.vanniktech.maven.publish")
 }
 
 buildLogic {


### PR DESCRIPTION
## Goal

Removes the signing + publishing plugin from the test module as this was leading to it being published as an artifact.

