### PR TITLE
Begin creating exporters api

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -5,6 +5,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
+public final class io/embrace/opentelemetry/kotlin/ExportResult : java/lang/Enum {
+	public static final field FAILURE Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static final field SUCCESS Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/ExportResult;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
@@ -112,6 +119,15 @@ public final class io/embrace/opentelemetry/kotlin/logging/SeverityNumber : java
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/logging/SeverityNumber;
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordData {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
@@ -213,5 +229,14 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracingF
 
 public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$DefaultImpls {
 	public static synthetic fun createSpanContext$default (Lio/embrace/opentelemetry/kotlin/tracing/TracingFactory;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanData {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -5,6 +5,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
+public final class io/embrace/opentelemetry/kotlin/ExportResult : java/lang/Enum {
+	public static final field FAILURE Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static final field SUCCESS Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/ExportResult;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
@@ -112,6 +119,15 @@ public final class io/embrace/opentelemetry/kotlin/logging/SeverityNumber : java
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/logging/SeverityNumber;
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordData {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
 }
@@ -213,5 +229,14 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracingF
 
 public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$DefaultImpls {
 	public static synthetic fun createSpanContext$default (Lio/embrace/opentelemetry/kotlin/tracing/TracingFactory;Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/TraceState;Lio/embrace/opentelemetry/kotlin/tracing/SpanContextOrigin;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/SpanContext;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanData {
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExportResult.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExportResult.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Whether the export operation was successful or not.
+ */
+public enum class ExportResult {
+    SUCCESS,
+    FAILURE,
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordData.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * An immutable representation of a log record that is ready for export.
+ */
+@ExperimentalApi
+public interface LogRecordData // TODO: add required properties.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ExportResult
+
+/**
+ * An interface for exporting logs to an arbitrary destination.
+ */
+@ExperimentalApi
+public interface LogRecordExporter {
+
+    /**
+     * Exports a batch of logs. This operation is considered successful if the implementation
+     * returns [ExportResult.SUCCESS]. If the export operation fails the batch must be dropped.
+     */
+    public fun export(telemetry: List<LogRecordData>): ExportResult
+
+    /**
+     * Requests the exporter to flush any buffered telemetry since the last call to [export].
+     */
+    public fun forceFlush(): ExportResult
+
+    /**
+     * Shuts down the exporter and completes cleanup tasks necessary.
+     */
+    public fun shutdown(): ExportResult
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanData.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * An immutable representation of a span that is ready for export.
+ */
+@ExperimentalApi
+public interface SpanData // TODO: add required properties.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ExportResult
+
+/**
+ * An interface for exporting spans to an arbitrary destination.
+ */
+@ExperimentalApi
+public interface SpanExporter {
+
+    /**
+     * Exports a batch of spans. This operation is considered successful if the implementation
+     * returns [ExportResult.SUCCESS]. If the export operation fails the batch must be dropped.
+     */
+    public fun export(telemetry: List<SpanData>): ExportResult
+
+    /**
+     * Requests the exporter to flush any buffered telemetry since the last call to [export].
+     */
+    public fun forceFlush(): ExportResult
+
+    /**
+     * Shuts down the exporter and completes cleanup tasks necessary.
+     */
+    public fun shutdown(): ExportResult
+}


### PR DESCRIPTION
## Goal

Starts fleshing out the exporter API for spans and logs. `LogRecordData` and `SpanData` are left as placeholder types for now.

