### PR TITLE
Add processor api

### DIFF
--- a/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/android/opentelemetry-kotlin-api.api
@@ -5,13 +5,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
-public final class io/embrace/opentelemetry/kotlin/ExportResult : java/lang/Enum {
-	public static final field FAILURE Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static final field SUCCESS Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static fun values ()[Lio/embrace/opentelemetry/kotlin/ExportResult;
-}
-
 public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
@@ -61,6 +54,22 @@ public abstract interface class io/embrace/opentelemetry/kotlin/context/Context 
 
 public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextKey {
 	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract class io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+}
+
+public final class io/embrace/opentelemetry/kotlin/export/OperationResultCode$Failure : io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/export/OperationResultCode$Failure;
+}
+
+public final class io/embrace/opentelemetry/kotlin/export/OperationResultCode$Success : io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/export/OperationResultCode$Success;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/LogRecord : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -122,10 +131,12 @@ public final class io/embrace/opentelemetry/kotlin/logging/SeverityNumber : java
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordData {
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
-	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun onEmit (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordData;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -234,9 +245,12 @@ public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$Defaul
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanData {
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
-	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun onEnd (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanData;)V
+	public abstract fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 

--- a/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/jvm/opentelemetry-kotlin-api.api
@@ -5,13 +5,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/Clock {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
-public final class io/embrace/opentelemetry/kotlin/ExportResult : java/lang/Enum {
-	public static final field FAILURE Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static final field SUCCESS Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public static fun values ()[Lio/embrace/opentelemetry/kotlin/ExportResult;
-}
-
 public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
@@ -61,6 +54,22 @@ public abstract interface class io/embrace/opentelemetry/kotlin/context/Context 
 
 public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextKey {
 	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract class io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+}
+
+public final class io/embrace/opentelemetry/kotlin/export/OperationResultCode$Failure : io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/export/OperationResultCode$Failure;
+}
+
+public final class io/embrace/opentelemetry/kotlin/export/OperationResultCode$Success : io/embrace/opentelemetry/kotlin/export/OperationResultCode {
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/export/OperationResultCode$Success;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/LogRecord : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -122,10 +131,12 @@ public final class io/embrace/opentelemetry/kotlin/logging/SeverityNumber : java
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordData {
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
-	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun onEmit (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordData;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
@@ -234,9 +245,12 @@ public final class io/embrace/opentelemetry/kotlin/tracing/TracingFactory$Defaul
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanData {
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
-	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun forceFlush ()Lio/embrace/opentelemetry/kotlin/ExportResult;
-	public abstract fun shutdown ()Lio/embrace/opentelemetry/kotlin/ExportResult;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun onEnd (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanData;)V
+	public abstract fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/Span;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExportResult.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ExportResult.kt
@@ -1,9 +1,0 @@
-package io.embrace.opentelemetry.kotlin
-
-/**
- * Whether the export operation was successful or not.
- */
-public enum class ExportResult {
-    SUCCESS,
-    FAILURE,
-}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/OperationResultCode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/OperationResultCode.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.export
+
+/**
+ * Whether an operation was successful or not.
+ */
+public sealed class OperationResultCode {
+
+    /**
+     * Indicates that the operation was successful.
+     */
+    public object Success : OperationResultCode()
+
+    /**
+     * Indicates that the operation failed.
+     */
+    public object Failure : OperationResultCode()
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/TelemetryCloseable.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/TelemetryCloseable.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.export
+
+/**
+ * Implementations of this interface handle telemetry. The interface allows callers to request a flush of any
+ * buffered telemetry, and to perform any necessary cleanup tasks when the SDK is shutting down.
+ */
+public interface TelemetryCloseable {
+
+    /**
+     * Requests the implementation to flush any buffered telemetry.
+     */
+    public fun forceFlush(): OperationResultCode
+
+    /**
+     * Shuts down the implementation and completes cleanup tasks necessary.
+     */
+    public fun shutdown(): OperationResultCode
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
@@ -1,27 +1,18 @@
 package io.embrace.opentelemetry.kotlin.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.ExportResult
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
 
 /**
  * An interface for exporting logs to an arbitrary destination.
  */
 @ExperimentalApi
-public interface LogRecordExporter {
+public interface LogRecordExporter : TelemetryCloseable {
 
     /**
      * Exports a batch of logs. This operation is considered successful if the implementation
-     * returns [ExportResult.SUCCESS]. If the export operation fails the batch must be dropped.
+     * returns [OperationResultCode.Success]. If the export operation fails the batch must be dropped.
      */
-    public fun export(telemetry: List<LogRecordData>): ExportResult
-
-    /**
-     * Requests the exporter to flush any buffered telemetry since the last call to [export].
-     */
-    public fun forceFlush(): ExportResult
-
-    /**
-     * Shuts down the exporter and completes cleanup tasks necessary.
-     */
-    public fun shutdown(): ExportResult
+    public fun export(telemetry: List<LogRecordData>): OperationResultCode
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor.kt
@@ -1,0 +1,20 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
+
+/**
+ * Processes logs before they are exported as batches.
+ */
+@ExperimentalApi
+public interface LogRecordProcessor : TelemetryCloseable {
+
+    /**
+     * Invoked when a log record is emitted.
+     *
+     * @param log The log record that has been emitted.
+     * @param context The context associated with the log record.
+     */
+    public fun onEmit(log: LogRecordData, context: Context)
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter.kt
@@ -1,27 +1,18 @@
 package io.embrace.opentelemetry.kotlin.tracing.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.ExportResult
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
 
 /**
  * An interface for exporting spans to an arbitrary destination.
  */
 @ExperimentalApi
-public interface SpanExporter {
+public interface SpanExporter : TelemetryCloseable {
 
     /**
      * Exports a batch of spans. This operation is considered successful if the implementation
-     * returns [ExportResult.SUCCESS]. If the export operation fails the batch must be dropped.
+     * returns [OperationResultCode.Success]. If the export operation fails the batch must be dropped.
      */
-    public fun export(telemetry: List<SpanData>): ExportResult
-
-    /**
-     * Requests the exporter to flush any buffered telemetry since the last call to [export].
-     */
-    public fun forceFlush(): ExportResult
-
-    /**
-     * Shuts down the exporter and completes cleanup tasks necessary.
-     */
-    public fun shutdown(): ExportResult
+    public fun export(telemetry: List<SpanData>): OperationResultCode
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
+import io.embrace.opentelemetry.kotlin.tracing.Span
+
+/**
+ * Processes spans before they are exported as batches.
+ */
+@ExperimentalApi
+public interface SpanProcessor : TelemetryCloseable {
+
+    /**
+     * Invoked when a span is created.
+     *
+     * @param span A reference to the span that has been created. This reference can be held & used to update the span.
+     * @param parentContext The context of the parent span or the current context if there is none.
+     */
+    public fun onStart(span: Span, parentContext: Context)
+
+    /**
+     * Invoked after a span has ended with an immutable representation of the span.
+     */
+    public fun onEnd(span: SpanData)
+}


### PR DESCRIPTION
## Goal

Adds the initial interface that will be used for the `LogRecordProcessor` and `SpanProcessor` APIs.
