### PR TITLE
Create mapping functions for span/log exporters

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -129,18 +129,14 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getSeverityNumber ()Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;
 	public abstract fun getSeverityText ()Ljava/lang/String;
-	public abstract fun getSpanId ()Ljava/lang/String;
+	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public abstract fun getTimestamp ()Ljava/lang/Long;
-	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/model/TraceFlags;
-	public abstract fun getTraceId ()Ljava/lang/String;
 	public abstract fun setBody (Ljava/lang/String;)V
 	public abstract fun setObservedTimestamp (Ljava/lang/Long;)V
 	public abstract fun setSeverityNumber (Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;)V
 	public abstract fun setSeverityText (Ljava/lang/String;)V
-	public abstract fun setSpanId (Ljava/lang/String;)V
+	public abstract fun setSpanContext (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)V
 	public abstract fun setTimestamp (Ljava/lang/Long;)V
-	public abstract fun setTraceFlags (Lio/embrace/opentelemetry/kotlin/tracing/model/TraceFlags;)V
-	public abstract fun setTraceId (Ljava/lang/String;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
@@ -152,10 +148,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;
 	public abstract fun getSeverityNumber ()Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;
 	public abstract fun getSeverityText ()Ljava/lang/String;
-	public abstract fun getSpanId ()Ljava/lang/String;
+	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public abstract fun getTimestamp ()Ljava/lang/Long;
-	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/tracing/model/TraceFlags;
-	public abstract fun getTraceId ()Ljava/lang/String;
 }
 
 public final class io/embrace/opentelemetry/kotlin/logging/model/SeverityNumber : java/lang/Enum {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
  * A read-write representation of a log record.
@@ -43,17 +43,7 @@ public interface ReadWriteLogRecord : ReadableLogRecord {
     public override val attributes: MutableMap<String, Any>
 
     /**
-     * The trace ID associated with the log record, if any.
+     * The span context associated with the log record
      */
-    public override var traceId: String?
-
-    /**
-     * The span ID associated with the log record, if any.
-     */
-    public override var spanId: String?
-
-    /**
-     * The trace flags associated with the log record, if any.
-     */
-    public override var traceFlags: TraceFlags?
+    public override var spanContext: SpanContext
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.Resource
-import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
  * A read-only representation of a log record.
@@ -51,19 +51,9 @@ public interface ReadableLogRecord {
     public val attributes: Map<String, Any>
 
     /**
-     * The trace ID associated with the log record, if any.
+     * The span context associated with the log record
      */
-    public val traceId: String?
-
-    /**
-     * The span ID associated with the log record, if any.
-     */
-    public val spanId: String?
-
-    /**
-     * The trace flags associated with the log record, if any.
-     */
-    public val traceFlags: TraceFlags?
+    public val spanContext: SpanContext
 
     /**
      * The resource associated with the log record, if any.

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/InstrumentationScopeInfoExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/InstrumentationScopeInfoExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge
+
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+
+internal fun InstrumentationScopeInfo.convertToOtelJava(): OtelJavaInstrumentationScopeInfo {
+    val builder = OtelJavaInstrumentationScopeInfo.builder(name)
+    version?.let(builder::setVersion)
+    schemaUrl?.let(builder::setSchemaUrl)
+    builder.setAttributes(attrsFromMap(attributes))
+    return builder.build()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/OtelJavaAttributesExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/OtelJavaAttributesExt.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.resource.Resource
+
+internal fun attrsFromMap(map: Map<String, Any>): OtelJavaAttributes {
+    val builder = OtelJavaAttributes.builder()
+    map.forEach {
+        builder.put(it.key, it.value.toString())
+    }
+    return builder.build()
+}
+
+@OptIn(ExperimentalApi::class)
+internal fun resourceFromMap(resource: Resource): OtelJavaResource {
+    val map = resource.attributes
+    val schemaUrl = resource.schemaUrl
+    return OtelJavaResource.create(
+        attrsFromMap(map),
+        schemaUrl
+    )
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
@@ -1,11 +1,33 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.opentelemetry.kotlin.j2k.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaLogRecordDataImpl
+import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
+import io.embrace.opentelemetry.kotlin.j2k.bridge.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
+import io.embrace.opentelemetry.kotlin.k2j.logging.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.sdk.logs.data.Body
 import io.opentelemetry.sdk.logs.data.LogRecordData
 
-@Suppress("UnusedReceiverParameter")
 @OptIn(ExperimentalApi::class)
 internal fun ReadableLogRecord.toLogRecordData(): LogRecordData {
-    throw UnsupportedOperationException()
+    return OtelJavaLogRecordDataImpl(
+        timestampNanos = timestamp ?: -1,
+        observedTimestampNanos = observedTimestamp ?: -1,
+        spanContextImpl = spanContext.convertToOtelJava(),
+        severityTextImpl = severityText,
+        severityImpl = severityNumber?.convertToOtelJava() ?: Severity.UNDEFINED_SEVERITY_NUMBER,
+        bodyImpl = body?.let(Body::string) ?: Body.empty(),
+        attributesImpl = attrsFromMap(attributes),
+        resourceImpl = resource?.let(::resourceFromMap) ?: OtelJavaResource.empty(),
+        scopeImpl = instrumentationScopeInfo?.convertToOtelJava()
+            ?: OtelJavaInstrumentationScopeInfo.empty()
+    )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
@@ -1,11 +1,50 @@
+@file:Suppress("TYPEALIAS_EXPANSION_DEPRECATION")
+
 package io.embrace.opentelemetry.kotlin.j2k.tracing.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaSpanDataImpl
+import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
+import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
+import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.opentelemetry.sdk.trace.data.SpanData
 
-@Suppress("UnusedReceiverParameter")
 @OptIn(ExperimentalApi::class)
 internal fun ReadableSpan.toSpanData(): SpanData {
-    throw UnsupportedOperationException()
+    return OtelJavaSpanDataImpl(
+        nameImpl = name,
+        statusImpl = OtelJavaStatusData.create(status.convertToOtelJava(), null),
+        parentSpanContextImpl = parent?.convertToOtelJava() ?: OtelJavaSpanContext.getInvalid(),
+        spanContextImpl = spanContext.convertToOtelJava(),
+        kindImpl = spanKind.convertToOtelJava(),
+        startEpochNanosImpl = startTimestamp,
+        endEpochNanosImpl = -1, // FIXME: need to populate
+        resourceImpl = resource.let(::resourceFromMap),
+        scopeImpl = OtelJavaInstrumentationLibraryInfo.create(
+            instrumentationScopeInfo.name,
+            instrumentationScopeInfo.version,
+            instrumentationScopeInfo.schemaUrl
+        ),
+        attributesImpl = attrsFromMap(attributes),
+        eventsImpl = events.map {
+            OtelJavaEventData.create(
+                it.timestamp,
+                it.name,
+                attrsFromMap(it.attributes)
+            )
+        }.toMutableList(),
+        linksImpl = links.map {
+            OtelJavaLinkData.create(
+                it.spanContext.convertToOtelJava(),
+                attrsFromMap(it.attributes)
+            )
+        }.toMutableList(),
+        hasEndedImpl = hasEnded()
+    )
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableLogRecord.kt
@@ -8,7 +8,6 @@ import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.resource.Resource
-import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 
 internal class FakeReadableLogRecord(
     override val timestamp: Long? = 1000,
@@ -18,9 +17,7 @@ internal class FakeReadableLogRecord(
     override val severityText: String? = "warning",
     override val body: String? = "Hello, World!",
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
-    override val traceId: String? = "my-trace-id",
-    override val spanId: String? = "my-span-id",
-    override val traceFlags: TraceFlags? = FakeTraceFlags(),
+    override val spanContext: FakeSpanContext = FakeSpanContext(),
     override val resource: Resource? = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo? = FakeInstrumentationScopeInfo()
 ) : ReadableLogRecord

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeSpanContext.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeSpanContext.kt
@@ -6,10 +6,12 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
+import io.opentelemetry.sdk.trace.IdGenerator
 
 internal class FakeSpanContext(
-    override val traceId: String = "traceId",
-    override val spanId: String = "spanId",
+    private val idGenerator: IdGenerator = IdGenerator.random(),
+    override val traceId: String = idGenerator.generateTraceId(),
+    override val spanId: String = idGenerator.generateSpanId(),
     override val traceFlags: TraceFlags = FakeTraceFlags(),
     override val isValid: Boolean = true,
     override val isRemote: Boolean = false,

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/LogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/LogRecordExporterAdapterTest.kt
@@ -1,11 +1,15 @@
 package io.embrace.opentelemetry.kotlin.j2k.logging.export
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeReadableLogRecord
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalApi::class)
 internal class LogRecordExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaLogRecordExporter
@@ -31,6 +35,24 @@ internal class LogRecordExporterAdapterTest {
 
     @Test
     fun `test export`() {
-        TODO("Not yet implemented")
+        val original = FakeReadableLogRecord()
+        assertEquals(OperationResultCode.Success, wrapper.export(listOf(original)))
+
+        val observed = impl.exports.single()
+        assertEquals(original.timestamp, observed.timestampEpochNanos)
+        assertEquals(original.observedTimestamp, observed.observedTimestampEpochNanos)
+        assertEquals(original.severityText, observed.severityText)
+        assertEquals(original.severityNumber?.severityNumber, observed.severity.severityNumber)
+        assertEquals(original.body, observed.bodyValue?.asString())
+        assertEquals(original.attributes, observed.attributes.toMap())
+        assertEquals(original.resource?.attributes, observed.resource.attributes.toMap())
+        assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
+
+        val originalScope = original.instrumentationScopeInfo
+        val observedScope = observed.instrumentationScopeInfo
+        assertEquals(originalScope?.name, observedScope.name)
+        assertEquals(originalScope?.version, observedScope.version)
+        assertEquals(originalScope?.schemaUrl, observedScope.schemaUrl)
+        assertEquals(originalScope?.attributes, observedScope.attributes.toMap())
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/SpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/SpanExporterAdapterTest.kt
@@ -1,11 +1,16 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing.export
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeReadableSpan
+import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalApi::class)
 internal class SpanExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaSpanExporter
@@ -31,6 +36,34 @@ internal class SpanExporterAdapterTest {
 
     @Test
     fun `test export`() {
-        TODO("Not yet implemented")
+        val original = FakeReadableSpan()
+        assertEquals(OperationResultCode.Success, wrapper.export(listOf(original)))
+
+        val observed = impl.exports.single()
+        assertEquals(original.name, observed.name)
+        assertEquals(original.status.convertToOtelJava(), observed.status.statusCode)
+        assertEquals(original.parent?.spanId, observed.parentSpanContext.spanId)
+        assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
+        assertEquals(original.spanKind.convertToOtelJava(), observed.kind)
+        assertEquals(original.startTimestamp, observed.startEpochNanos)
+        assertEquals(original.attributes, observed.attributes.toMap())
+        assertEquals(original.resource.attributes, observed.resource.attributes.toMap())
+
+        val originalScope = original.instrumentationScopeInfo
+        val observedScope = observed.instrumentationScopeInfo
+        assertEquals(originalScope.name, observedScope.name)
+        assertEquals(originalScope.version, observedScope.version)
+        assertEquals(originalScope.schemaUrl, observedScope.schemaUrl)
+        assertEquals(emptyMap(), observedScope.attributes.toMap()) // otel-java don't support this
+
+        val originalEvent = original.events.single()
+        val observedEvent = observed.events.single()
+        assertEquals(originalEvent.name, observedEvent.name)
+        assertEquals(originalEvent.attributes, observedEvent.attributes.toMap())
+
+        val originalLink = original.links.single()
+        val observedLink = observed.links.single()
+        assertEquals(originalLink.spanContext.spanId, observedLink.spanContext.spanId)
+        assertEquals(originalLink.attributes, observedLink.attributes.toMap())
     }
 }


### PR DESCRIPTION
## Goal

Builds on #140 by creating mapping functions that allow the span/log exporters to work with backwards compatibility.

## Testing

Added unit test coverage.