### PR TITLE
Add an endTimestamp property on Span API

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -259,6 +259,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Re
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan {
 	public abstract fun getAttributes ()Ljava/util/Map;
+	public abstract fun getEndTimestamp ()Ljava/lang/Long;
 	public abstract fun getEvents ()Ljava/util/List;
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getLinks ()Ljava/util/List;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
@@ -42,6 +42,11 @@ public interface ReadableSpan {
     public val startTimestamp: Long
 
     /**
+     * The timestamp at which this span ended, in nanoseconds. If it has not ended null will return.
+     */
+    public val endTimestamp: Long?
+
+    /**
      * The resource associated with the object
      */
     public val resource: Resource

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
@@ -19,8 +19,8 @@ import io.opentelemetry.sdk.logs.data.LogRecordData
 @OptIn(ExperimentalApi::class)
 internal fun ReadableLogRecord.toLogRecordData(): LogRecordData {
     return OtelJavaLogRecordDataImpl(
-        timestampNanos = timestamp ?: -1,
-        observedTimestampNanos = observedTimestamp ?: -1,
+        timestampNanos = timestamp ?: 0,
+        observedTimestampNanos = observedTimestamp ?: 0,
         spanContextImpl = spanContext.convertToOtelJava(),
         severityTextImpl = severityText,
         severityImpl = severityNumber?.convertToOtelJava() ?: Severity.UNDEFINED_SEVERITY_NUMBER,

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
@@ -24,7 +24,7 @@ internal fun ReadableSpan.toSpanData(): SpanData {
         spanContextImpl = spanContext.convertToOtelJava(),
         kindImpl = spanKind.convertToOtelJava(),
         startEpochNanosImpl = startTimestamp,
-        endEpochNanosImpl = -1, // FIXME: need to populate
+        endEpochNanosImpl = endTimestamp ?: 0,
         resourceImpl = resource.let(::resourceFromMap),
         scopeImpl = OtelJavaInstrumentationLibraryInfo.create(
             instrumentationScopeInfo.name,

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableSpan.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableSpan.kt
@@ -18,6 +18,7 @@ internal class FakeReadableSpan(
     override val spanContext: SpanContext = FakeSpanContext(),
     override val spanKind: SpanKind = SpanKind.INTERNAL,
     override val startTimestamp: Long = 1000,
+    override val endTimestamp: Long = 2000,
     override val resource: Resource = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo(),
     override val attributes: Map<String, Any> = mapOf("key" to "value"),


### PR DESCRIPTION
## Goal

Adds an `endTimestamp` property to the Span API.

