### PR TITLE
Continue hooking up span/log processors

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -241,6 +241,8 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/S
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable {
+	public abstract fun isEndRequired ()Z
+	public abstract fun isStartRequired ()Z
 	public abstract fun onEnd (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan;)V
 	public abstract fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
@@ -24,4 +24,14 @@ public interface SpanProcessor : TelemetryCloseable {
      * Invoked after a span has ended with an immutable representation of the span.
      */
     public fun onEnd(span: ReadableSpan)
+
+    /**
+     * Determines whether this span processor is required when a span starts.
+     */
+    public fun isStartRequired(): Boolean
+
+    /**
+     * Determines whether this span processor is required when a span ends.
+     */
+    public fun isEndRequired(): Boolean
 }

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -4,14 +4,19 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2JKt {
 	public static synthetic fun kotlinApi$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/LogRecordExporterAdapter : io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
+public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapter : io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
 	public fun <init> (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 }
 
-public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/SpanExporterAdapter : io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
+public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter : io/opentelemetry/sdk/logs/LogRecordProcessor {
+	public fun <init> (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;)V
+	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapter : io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
 	public fun <init> (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/OtelJavaContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/OtelJavaContextExt.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.context.Context
+
+@OptIn(ExperimentalApi::class)
+internal fun OtelJavaContext.toOtelKotlin(): Context {
+    TODO()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
 @OptIn(ExperimentalApi::class)
-public class LogRecordExporterAdapter(
+public class OtelJavaLogRecordExporterAdapter(
     private val impl: OtelJavaLogRecordExporter
 ) : LogRecordExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.j2k.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.opentelemetry.context.Context
+
+@OptIn(ExperimentalApi::class)
+public class OtelJavaLogRecordProcessorAdapter(
+    private val impl: LogRecordProcessor
+) : OtelJavaLogRecordProcessor {
+
+    override fun onEmit(
+        context: Context,
+        logRecord: OtelJavaReadWriteLogRecord
+    ) {
+        impl.onEmit(logRecord.toOtelKotlin(), context.toOtelKotlin())
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
@@ -4,6 +4,7 @@ package io.embrace.opentelemetry.kotlin.j2k.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaLogRecordDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
@@ -11,6 +12,7 @@ import io.embrace.opentelemetry.kotlin.j2k.bridge.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
 import io.embrace.opentelemetry.kotlin.k2j.logging.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.sdk.logs.data.Body
@@ -30,4 +32,9 @@ internal fun ReadableLogRecord.toLogRecordData(): LogRecordData {
         scopeImpl = instrumentationScopeInfo?.convertToOtelJava()
             ?: OtelJavaInstrumentationScopeInfo.empty()
     )
+}
+
+@OptIn(ExperimentalApi::class)
+internal fun OtelJavaReadWriteLogRecord.toOtelKotlin(): ReadWriteLogRecord {
+    TODO()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 
 @OptIn(ExperimentalApi::class)
-public class SpanExporterAdapter(
+public class OtelJavaSpanExporterAdapter(
     private val impl: OtelJavaSpanExporter
 ) : SpanExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.opentelemetry.context.Context
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaSpanProcessorAdapter(
+    private val impl: SpanProcessor
+) : OtelJavaSpanProcessor {
+
+    override fun onStart(parentContext: Context, span: OtelJavaReadWriteSpan) {
+        impl.onStart(span.toOtelKotlin(), parentContext.toOtelKotlin())
+    }
+
+    override fun onEnd(span: OtelJavaReadableSpan) {
+        impl.onEnd(span.toOtelKotlin())
+    }
+
+    override fun isStartRequired(): Boolean = impl.isStartRequired()
+    override fun isEndRequired(): Boolean = impl.isEndRequired()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
@@ -6,12 +6,15 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaSpanDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
 import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.opentelemetry.sdk.trace.data.SpanData
 
@@ -47,4 +50,14 @@ internal fun ReadableSpan.toSpanData(): SpanData {
         }.toMutableList(),
         hasEndedImpl = hasEnded()
     )
+}
+
+@OptIn(ExperimentalApi::class)
+internal fun OtelJavaReadableSpan.toOtelKotlin(): ReadableSpan {
+    TODO("Not yet implemented")
+}
+
+@OptIn(ExperimentalApi::class)
+internal fun OtelJavaReadWriteSpan.toOtelKotlin(): ReadWriteSpan {
+    TODO("Not yet implemented")
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/LoggerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/LoggerProviderConfigImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
+import io.embrace.opentelemetry.kotlin.j2k.logging.export.OtelJavaLogRecordProcessorAdapter
 import io.embrace.opentelemetry.kotlin.k2j.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.AttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
@@ -29,7 +30,7 @@ internal class LoggerProviderConfigImpl(
     }
 
     override fun addLogRecordProcessor(processor: LogRecordProcessor) {
-        TODO("Not yet implemented")
+        builder.addLogRecordProcessor(OtelJavaLogRecordProcessorAdapter(processor))
     }
 
     fun build(): LoggerProvider = LoggerProviderAdapter(builder.build())

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.init.SpanLimitsConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
+import io.embrace.opentelemetry.kotlin.j2k.tracing.export.OtelJavaSpanProcessorAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.AttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
@@ -34,7 +35,7 @@ internal class TracerProviderConfigImpl(
     }
 
     override fun addSpanProcessor(processor: SpanProcessor) {
-        TODO("Not yet implemented")
+        builder.addSpanProcessor(OtelJavaSpanProcessorAdapter(processor))
     }
 
     fun build(): TracerProvider = TracerProviderAdapter(builder.build())

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
@@ -10,15 +10,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class LogRecordExporterAdapterTest {
+internal class OtelJavaLogRecordExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaLogRecordExporter
-    private lateinit var wrapper: LogRecordExporterAdapter
+    private lateinit var wrapper: OtelJavaLogRecordExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaLogRecordExporter()
-        wrapper = LogRecordExporterAdapter(impl)
+        wrapper = OtelJavaLogRecordExporterAdapter(impl)
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
@@ -11,15 +11,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class SpanExporterAdapterTest {
+internal class OtelJavaSpanExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaSpanExporter
-    private lateinit var wrapper: SpanExporterAdapter
+    private lateinit var wrapper: OtelJavaSpanExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaSpanExporter()
-        wrapper = SpanExporterAdapter(impl)
+        wrapper = OtelJavaSpanExporterAdapter(impl)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Continues with code that hooks up the span/log processor added via the Kotlin API to an otel-java builder. The implementation of the decorating processor will follow in a subsequent PR.
