### PR TITLE
Add conversion for context

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextAdapter.kt
@@ -1,0 +1,29 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.ContextKey
+import io.embrace.opentelemetry.kotlin.k2j.context.ContextKeyAdapter
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaContextAdapter(
+    private val impl: OtelJavaContext,
+    private val repository: OtelJavaContextKeyRepository = OtelJavaContextKeyRepository.INSTANCE
+) : Context {
+
+    override fun <T> createKey(name: String): ContextKey<T> {
+        return ContextKeyAdapter(OtelJavaContextKey.named(name))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> set(key: ContextKey<T>, value: T?): Context {
+        val ctx = impl.with(repository.get(key), value as (T & Any))
+        return OtelJavaContextAdapter(ctx, repository)
+    }
+
+    override fun <T> get(key: ContextKey<T>): T? {
+        return impl[repository.get(key)]
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextExt.kt
@@ -1,4 +1,4 @@
-package io.embrace.opentelemetry.kotlin.j2k.bridge
+package io.embrace.opentelemetry.kotlin.j2k.bridge.context
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
@@ -6,5 +6,5 @@ import io.embrace.opentelemetry.kotlin.context.Context
 
 @OptIn(ExperimentalApi::class)
 internal fun OtelJavaContext.toOtelKotlin(): Context {
-    TODO()
+    return OtelJavaContextAdapter(this)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextKeyRepository.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextKeyRepository.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.context.ContextKey
+import io.embrace.opentelemetry.kotlin.k2j.context.ContextKeyAdapter
+import java.util.concurrent.ConcurrentHashMap
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaContextKeyRepository {
+
+    // TODO: future: cleanup stale references
+    // TODO: future: support nullable values
+
+    companion object {
+        val INSTANCE = OtelJavaContextKeyRepository()
+    }
+
+    private val impl = ConcurrentHashMap<ContextKey<*>, OtelJavaContextKey<*>>()
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(key: ContextKey<T>): OtelJavaContextKey<T> {
+        return impl.getOrPut(key) {
+            (key as ContextKeyAdapter).impl
+        } as OtelJavaContextKey<T>
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.j2k.logging.export
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.context.Context
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.context.Context
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextKeyAdapter.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.context.ContextKey
 
 @ExperimentalApi
 internal class ContextKeyAdapter<T>(
-    impl: OtelJavaContextKey<T>
+    internal val impl: OtelJavaContextKey<T>
 ) : ContextKey<T> {
     override val name: String = impl.toString()
 }


### PR DESCRIPTION
## Goal

Adds conversion code between the Kotlin/Java implementations of context, which is a pre-requisite of the span/log processor implementation.

