### PR TITLE
Implement span processor mapping

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/ResourceAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/ResourceAdapter.kt
@@ -1,0 +1,14 @@
+package io.embrace.opentelemetry.kotlin.j2k.bridge
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
+import io.embrace.opentelemetry.kotlin.resource.Resource
+
+@OptIn(ExperimentalApi::class)
+internal class ResourceAdapter(
+    impl: OtelJavaResource
+) : Resource {
+    override val attributes: Map<String, Any> = impl.attributes.toMap()
+    override val schemaUrl: String? = impl.schemaUrl
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
@@ -6,6 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import java.util.concurrent.TimeUnit
 
@@ -25,7 +26,7 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan {
     }
 
     override fun setStatus(statusCode: OtelJavaStatusCode, description: String): OtelJavaSpan {
-        statusCode.convertToOtelKotlin(description)
+        OtelJavaStatusData.create(statusCode, description).convertToOtelKotlin()
         return this
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
@@ -1,10 +1,12 @@
 package io.embrace.opentelemetry.kotlin.j2k.tracing
 
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
-internal fun OtelJavaStatusCode.convertToOtelKotlin(description: String?): StatusCode = when (this) {
+internal fun OtelJavaStatusData.convertToOtelKotlin(): StatusCode = when (statusCode) {
     OtelJavaStatusCode.UNSET -> StatusCode.Unset
     OtelJavaStatusCode.OK -> StatusCode.Ok
     OtelJavaStatusCode.ERROR -> StatusCode.Error(description)
+    null -> StatusCode.Unset
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -14,11 +14,11 @@ internal class OtelJavaSpanProcessorAdapter(
 ) : OtelJavaSpanProcessor {
 
     override fun onStart(parentContext: Context, span: OtelJavaReadWriteSpan) {
-        impl.onStart(span.toOtelKotlin(), parentContext.toOtelKotlin())
+        impl.onStart(ReadWriteSpanAdapter(span), parentContext.toOtelKotlin())
     }
 
     override fun onEnd(span: OtelJavaReadableSpan) {
-        impl.onEnd(span.toOtelKotlin())
+        impl.onEnd(ReadableSpanAdapter(span))
     }
 
     override fun isStartRequired(): Boolean = impl.isStartRequired()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadWriteSpanAdapter.kt
@@ -1,0 +1,108 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.j2k.tracing.convertToOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.tracing.AttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
+import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
+import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.model.Link
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
+import io.opentelemetry.api.common.AttributeKey
+import java.util.concurrent.TimeUnit
+
+@Suppress("UNUSED_PARAMETER")
+@OptIn(ExperimentalApi::class)
+internal class ReadWriteSpanAdapter(
+    private val impl: OtelJavaReadWriteSpan,
+    private val readableSpan: ReadableSpanAdapter = ReadableSpanAdapter(impl)
+) : ReadWriteSpan, ReadableSpan by readableSpan {
+
+    private val data = impl.toSpanData()
+
+    override var name: String
+        get() = impl.name
+        set(value) {}
+
+    override var status: StatusCode
+        get() = data.status.convertToOtelKotlin()
+        set(value) {}
+
+    override fun end() {
+        impl.end()
+    }
+
+    override fun end(timestamp: Long) {
+        impl.end(timestamp, TimeUnit.NANOSECONDS)
+    }
+
+    override fun isRecording(): Boolean = impl.isRecording
+
+    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+        val container = AttributeContainerImpl()
+        action(container)
+        val ctx = (spanContext as SpanContextAdapter).impl
+        impl.addLink(ctx, container.otelJavaAttributes())
+    }
+
+    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+        val container = AttributeContainerImpl()
+        action(container)
+        impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)
+    }
+
+    override fun events(): List<SpanEvent> {
+        return data.events.map {
+            val container = AttributeContainerImpl(it.attributes.toBuilder())
+            SpanEventImpl(it.name, it.epochNanos, container)
+        }
+    }
+
+    override fun links(): List<Link> {
+        return data.links.map {
+            val container = AttributeContainerImpl(it.attributes.toBuilder())
+            LinkImpl(SpanContextAdapter(it.spanContext), container)
+        }
+    }
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        impl.setAttribute(key, value)
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        impl.setAttribute(key, value)
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        impl.setAttribute(key, value)
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        impl.setAttribute(key, value)
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+        impl.setAttribute(AttributeKey.booleanArrayKey(key), value)
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+        impl.setAttribute(AttributeKey.stringArrayKey(key), value)
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+        impl.setAttribute(AttributeKey.longArrayKey(key), value)
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        impl.setAttribute(AttributeKey.doubleArrayKey(key), value)
+    }
+
+    override fun attributes(): Map<String, Any> = impl.attributes.toMap()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableLinkAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableLinkAdapter.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableLink
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+
+@OptIn(ExperimentalApi::class)
+internal class ReadableLinkAdapter(
+    impl: OtelJavaLinkData
+) : ReadableLink {
+    override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
+    override val attributes: Map<String, Any> = impl.attributes.toMap()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanAdapter.kt
@@ -1,0 +1,40 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.j2k.bridge.ResourceAdapter
+import io.embrace.opentelemetry.kotlin.j2k.bridge.convertToOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.tracing.convertToOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
+import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableLink
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+@OptIn(ExperimentalApi::class)
+internal class ReadableSpanAdapter(
+    private val impl: OtelJavaReadableSpan
+) : ReadableSpan {
+
+    private val data = impl.toSpanData()
+
+    override val name: String = impl.name
+    override val status: StatusCode = data.status.convertToOtelKotlin()
+    override val parent: SpanContext = SpanContextAdapter(impl.parentSpanContext)
+    override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
+    override val spanKind: SpanKind = impl.kind.convertToOtelKotlin()
+    override val startTimestamp: Long = data.startEpochNanos
+    override val endTimestamp: Long = data.endEpochNanos
+    override val resource: Resource = ResourceAdapter(data.resource)
+    override val instrumentationScopeInfo: InstrumentationScopeInfo =
+        impl.instrumentationScopeInfo.convertToOtelKotlin()
+    override val attributes: Map<String, Any> = impl.attributes.toMap()
+    override val events: List<ReadableSpanEvent> = data.events.map(::ReadableSpanEventAdapter)
+    override val links: List<ReadableLink> = data.links.map(::ReadableLinkAdapter)
+    override fun hasEnded(): Boolean = impl.hasEnded()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanEventAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanEventAdapter.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpanEvent
+
+@OptIn(ExperimentalApi::class)
+internal class ReadableSpanEventAdapter(
+    impl: OtelJavaEventData
+) : ReadableSpanEvent {
+    override val name: String = impl.name
+    override val timestamp: Long = impl.epochNanos
+    override val attributes: Map<String, Any> = impl.attributes.toMap()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
@@ -6,15 +6,12 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaSpanDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
 import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
-import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.opentelemetry.sdk.trace.data.SpanData
 
@@ -50,14 +47,4 @@ internal fun ReadableSpan.toSpanData(): SpanData {
         }.toMutableList(),
         hasEndedImpl = hasEnded()
     )
-}
-
-@OptIn(ExperimentalApi::class)
-internal fun OtelJavaReadableSpan.toOtelKotlin(): ReadableSpan {
-    TODO("Not yet implemented")
-}
-
-@OptIn(ExperimentalApi::class)
-internal fun OtelJavaReadWriteSpan.toOtelKotlin(): ReadWriteSpan {
-    TODO("Not yet implemented")
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/AttributeContainerImpl.kt
@@ -3,12 +3,13 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributesBuilder
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 @OptIn(ExperimentalApi::class)
-internal class AttributeContainerImpl : AttributeContainer {
-
-    private val attrs = OtelJavaAttributes.builder()
+internal class AttributeContainerImpl(
+    private val attrs: OtelJavaAttributesBuilder = OtelJavaAttributes.builder()
+) : AttributeContainer {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         attrs.put(key, value)


### PR DESCRIPTION
## Goal

Implements code that wraps Kotlin/Java OTel model classes so that the span processor can function. The functionality will be covered by an integration test that will test the whole system once everything is hooked up.

