### PR TITLE
Update export tests to pass

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -78,8 +78,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter : i
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter : io/embrace/opentelemetry/kotlin/tracing/TracerProvider {
-	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;)V
-	public synthetic fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/k2j/ClockAdapter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/opentelemetry/api/trace/TracerProvider;Lio/embrace/opentelemetry/kotlin/Clock;)V
 	public fun getTracer (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2J.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2J.kt
@@ -17,12 +17,14 @@ import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
  * OpenTelemetry Java SDK code that you don't want to rewrite, but still wish to use the Kotlin API.
  */
 @ExperimentalApi
-public fun OpenTelemetryInstance.compatWithOtelJava(impl: OtelJavaOpenTelemetry): OpenTelemetry =
-    OpenTelemetrySdk(
-        tracerProvider = TracerProviderAdapter(impl.tracerProvider),
+public fun OpenTelemetryInstance.compatWithOtelJava(impl: OtelJavaOpenTelemetry): OpenTelemetry {
+    val clock = ClockAdapter(OtelJavaClock.getDefault())
+    return OpenTelemetrySdk(
+        tracerProvider = TracerProviderAdapter(impl.tracerProvider, clock),
         loggerProvider = LoggerProviderAdapter(impl.logsBridge),
-        clock = ClockAdapter(OtelJavaClock.getDefault())
+        clock = clock
     )
+}
 
 /**
  * Constructs an [OpenTelemetry] instance by using the Kotlin API DSL to configure an underlying OpenTelemetry Java SDK
@@ -34,9 +36,12 @@ public fun OpenTelemetryInstance.kotlinApi(
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
 ): OpenTelemetry {
+    val tracerCfg = TracerProviderConfigImpl(clock).apply(tracerProvider)
+    val loggerCfg = LoggerProviderConfigImpl(clock).apply(loggerProvider)
+
     return OpenTelemetrySdk(
-        tracerProvider = TracerProviderConfigImpl(clock).apply(tracerProvider).build(),
-        loggerProvider = LoggerProviderConfigImpl(clock).apply(loggerProvider).build(),
+        tracerProvider = tracerCfg.build(),
+        loggerProvider = loggerCfg.build(),
         clock = clock
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadWriteLogRecordAdapter.kt
@@ -5,6 +5,7 @@ import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.ResourceAdapter
 import io.embrace.opentelemetry.kotlin.j2k.bridge.convertToOtelKotlin
 import io.embrace.opentelemetry.kotlin.k2j.logging.convertToOtelKotlin
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
@@ -88,8 +89,8 @@ internal class ReadWriteLogRecordAdapter(
     override val context: Context?
         get() = null
 
-    override val resource: Resource?
-        get() = null
+    override val resource: Resource
+        get() = ResourceAdapter(impl.toLogRecordData().resource)
 
     override val instrumentationScopeInfo: InstrumentationScopeInfo
         get() = impl.instrumentationScopeInfo.convertToOtelKotlin()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.k2j
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.k2j.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
@@ -17,9 +16,9 @@ internal class OpenTelemetrySdk(
     override val clock: Clock,
 ) : OpenTelemetry {
 
-    constructor(impl: OtelJavaOpenTelemetry) : this(
-        TracerProviderAdapter(impl.tracerProvider),
+    constructor(impl: OtelJavaOpenTelemetry, clock: Clock) : this(
+        TracerProviderAdapter(impl.tracerProvider, clock),
         LoggerProviderAdapter(impl.logsBridge),
-        ClockAdapter(OtelJavaClock.getDefault())
+        clock
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
@@ -16,7 +16,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 
 @ExperimentalApi
 internal class TracerProviderConfigImpl(
-    clock: Clock
+    private val clock: Clock
 ) : TracerProviderConfigDsl {
 
     private val builder: SdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
@@ -38,5 +38,5 @@ internal class TracerProviderConfigImpl(
         builder.addSpanProcessor(OtelJavaSpanProcessorAdapter(processor))
     }
 
-    fun build(): TracerProvider = TracerProviderAdapter(builder.build())
+    fun build(): TracerProvider = TracerProviderAdapter(builder.build(), clock)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -1,9 +1,9 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import java.util.concurrent.ConcurrentHashMap
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap
 @ExperimentalApi
 public class TracerProviderAdapter(
     private val tracerProvider: OtelJavaTracerProvider,
-    private val clock: ClockAdapter = ClockAdapter()
+    private val clock: Clock,
 ) : TracerProvider {
 
     private val map = ConcurrentHashMap<String, TracerAdapter>()

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdkTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdkTest.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.k2j
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeClock
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -11,7 +12,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve tracer provider`() {
-        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop())
+        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop(), FakeClock())
         val provider = sdk.tracerProvider
         val a = provider.getTracer("test")
         val b = provider.getTracer("test")
@@ -26,7 +27,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve logger provider`() {
-        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop())
+        val sdk = OpenTelemetrySdk(OtelJavaOpenTelemetry.noop(), FakeClock())
         val provider = sdk.loggerProvider
         val a = provider.getLogger("test")
         val b = provider.getLogger("test")

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemoryLogRecordExporter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemoryLogRecordExporter.kt
@@ -1,21 +1,23 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
-internal class InMemoryLogRecordExporter : OtelJavaLogRecordExporter {
+@OptIn(ExperimentalApi::class)
+internal class InMemoryLogRecordExporter : LogRecordExporter {
 
-    private val impl = mutableListOf<OtelJavaLogRecordData>()
+    private val impl = mutableListOf<ReadableLogRecord>()
 
-    val exportedLogRecords: List<OtelJavaLogRecordData>
+    val exportedLogRecords: List<ReadableLogRecord>
         get() = impl
 
-    override fun export(logs: MutableCollection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
-        impl.addAll(logs)
-        return OtelJavaCompletableResultCode.ofSuccess()
+    override fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+        impl += telemetry
+        return OperationResultCode.Success
     }
 
-    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
-    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemoryLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemoryLogRecordProcessor.kt
@@ -1,14 +1,20 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 
+@OptIn(ExperimentalApi::class)
 internal class InMemoryLogRecordProcessor(
     private val exporter: InMemoryLogRecordExporter
-) : OtelJavaLogRecordProcessor {
+) : LogRecordProcessor {
 
-    override fun onEmit(context: OtelJavaContext, logRecord: OtelJavaReadWriteLogRecord) {
-        exporter.export(mutableListOf(logRecord.toLogRecordData()))
+    override fun onEmit(log: ReadWriteLogRecord, context: Context) {
+        exporter.export(listOf(log))
     }
+
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemorySpanExporter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemorySpanExporter.kt
@@ -1,21 +1,23 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 
-internal class InMemorySpanExporter : OtelJavaSpanExporter {
+@OptIn(ExperimentalApi::class)
+internal class InMemorySpanExporter : SpanExporter {
 
-    private val impl = mutableListOf<OtelJavaSpanData>()
+    private val impl = mutableListOf<ReadableSpan>()
 
-    val exportedSpans: List<OtelJavaSpanData>
+    val exportedSpans: List<ReadableSpan>
         get() = impl
 
-    override fun export(spans: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
-        impl.addAll(spans)
-        return OtelJavaCompletableResultCode.ofSuccess()
+    override fun export(telemetry: List<ReadableSpan>): OperationResultCode {
+        impl += telemetry
+        return OperationResultCode.Success
     }
 
-    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
-    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemorySpanProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/InMemorySpanProcessor.kt
@@ -1,19 +1,24 @@
 package io.embrace.opentelemetry.kotlin.k2j.framework
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 
-internal class InMemorySpanProcessor(private val exporter: InMemorySpanExporter) : OtelJavaSpanProcessor {
-    override fun onStart(parentContext: OtelJavaContext, span: OtelJavaReadWriteSpan) {
+@OptIn(ExperimentalApi::class)
+internal class InMemorySpanProcessor(private val exporter: InMemorySpanExporter) : SpanProcessor {
+
+    override fun onStart(span: ReadWriteSpan, parentContext: Context) {
     }
 
+    override fun onEnd(span: ReadableSpan) {
+        exporter.export(listOf(span))
+    }
+
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
     override fun isStartRequired(): Boolean = true
-
-    override fun onEnd(span: OtelJavaReadableSpan) {
-        exporter.export(mutableListOf(span.toSpanData()))
-    }
-
     override fun isEndRequired(): Boolean = true
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LogExportTest.kt
@@ -16,7 +16,7 @@ internal class LogExportTest {
     @BeforeTest
     fun setUp() {
         harness = OtelKotlinHarness()
-        loggerProvider = LoggerProviderAdapter(harness.sdk.logsBridge)
+        loggerProvider = harness.kotlinApi.loggerProvider
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -27,7 +27,7 @@ internal class SpanExportTest {
     @BeforeTest
     fun setUp() {
         harness = OtelKotlinHarness()
-        tracerProvider = TracerProviderAdapter(harness.sdk.tracerProvider, harness.clock)
+        tracerProvider = harness.kotlinApi.tracerProvider
         tracer = tracerProvider.getTracer("name", "version")
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
@@ -20,14 +20,14 @@
     },
     "startTimestampNs": 0,
     "attributes": {
-      "long_key": "42",
-      "long_list_key": "[42]",
-      "bool_key": "true",
-      "double_list_key": "[3.14]",
-      "string_list_key": "[a]",
-      "bool_list_key": "[true]",
-      "double_key": "3.14",
-      "string_key": "second_value"
+      "bool_key":"true",
+      "bool_list_key":"[true]",
+      "double_key":"3.14",
+      "double_list_key":"[3.14]",
+      "long_key":"42",
+      "long_list_key":"[42]",
+      "string_key":"second_value",
+      "string_list_key":"[a]"
     },
     "events": [],
     "links": [],
@@ -35,7 +35,7 @@
     "ended": true,
     "totalRecordedEvents": 0,
     "totalRecordedLinks": 0,
-    "totalAttributeCount": 9,
+    "totalAttributeCount": 8,
     "resource": {
       "schemaUrl": "null",
       "attributes": {


### PR DESCRIPTION
## Goal

Updates the span/log export tests so they pass when using an OpenTelemetry Java instance configured via the Kotlin API.
