### PR TITLE
Propagate schemaUrl to tracer provider

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerProviderAdapter.kt
@@ -23,11 +23,13 @@ public class TracerProviderAdapter(
         attributes: AttributeContainer.() -> Unit
     ): Tracer {
         val key = name.plus(version).plus(schemaUrl)
+
         return map.getOrPut(key) {
-            val tracer = when (version) {
-                null -> tracerProvider.get(name)
-                else -> tracerProvider.get(name, version)
-            }
+            val tracerBuilder = tracerProvider.tracerBuilder(name)
+
+            schemaUrl?.let(tracerBuilder::setSchemaUrl)
+            version?.let(tracerBuilder::setInstrumentationVersion)
+            val tracer = tracerBuilder.build()
             TracerAdapter(tracer, clock)
         }
     }


### PR DESCRIPTION
## Goal

Propagates schemaUrl to the `TracerProvider` implementation.

