### PR TITLE
Make symbol public

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -16,6 +16,10 @@ public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLo
 	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversionKt {
+	public static final fun convertToOtelKotlin (Lio/opentelemetry/api/trace/SpanKind;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
+}
+
 public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapter : io/embrace/opentelemetry/kotlin/tracing/export/SpanExporter {
 	public fun <init> (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
@@ -70,6 +74,14 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextAdapte
 	public fun getTraceState ()Lio/embrace/opentelemetry/kotlin/tracing/model/TraceState;
 	public fun isRemote ()Z
 	public fun isValid ()Z
+}
+
+public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverterKt {
+	public static final fun convertToOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/opentelemetry/api/trace/SpanContext;
+}
+
+public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversionKt {
+	public static final fun convertToOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)Lio/opentelemetry/api/trace/StatusCode;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter : io/embrace/opentelemetry/kotlin/tracing/Tracer {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversion.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.j2k.tracing
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
-internal fun OtelJavaSpanKind.convertToOtelKotlin(): SpanKind = when (this) {
+public fun OtelJavaSpanKind.convertToOtelKotlin(): SpanKind = when (this) {
     OtelJavaSpanKind.INTERNAL -> SpanKind.INTERNAL
     OtelJavaSpanKind.CLIENT -> SpanKind.CLIENT
     OtelJavaSpanKind.SERVER -> SpanKind.SERVER

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJavaConverter.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 
 @OptIn(ExperimentalApi::class)
-internal fun SpanContext.convertToOtelJava(): OtelJavaSpanContext {
+public fun SpanContext.convertToOtelJava(): OtelJavaSpanContext {
     return OtelJavaImmutableSpanContext.create(
         traceId,
         spanId,

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
-internal fun StatusCode.convertToOtelJava(): OtelJavaStatusCode = when (this) {
+public fun StatusCode.convertToOtelJava(): OtelJavaStatusCode = when (this) {
     StatusCode.Unset -> OtelJavaStatusCode.UNSET
     StatusCode.Ok -> OtelJavaStatusCode.OK
     is StatusCode.Error -> OtelJavaStatusCode.ERROR


### PR DESCRIPTION
## Goal

Makes a symbol public in the compat module. This will allow for the deletion of ~3 duplicate classes in embrace-android-sdk.

