### PR TITLE
Add simplified helper to get tracer and logger from OTel instance

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -1,3 +1,8 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryExtKt {
+	public static final fun getLogger (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/logging/Logger;
+	public static final fun getTracer (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
+}
+
 public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtKt {
 	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
 }

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryExt.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+
+@ExperimentalApi
+@ThreadSafe
+public fun OpenTelemetry.getTracer(instrumentationScopeName: String): Tracer {
+    return tracerProvider.getTracer(name = instrumentationScopeName)
+}
+
+@ExperimentalApi
+@ThreadSafe
+public fun OpenTelemetry.getLogger(instrumentationScopeName: String): Logger {
+    return loggerProvider.getLogger(name = instrumentationScopeName)
+}

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
@@ -9,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.compatWithOtelJava
+import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
@@ -57,7 +58,7 @@ public class OpenTelemetryRule : ExternalResource() {
         get() = spanExporter.exportedSpans
 
     public fun getTracer(name: String): Tracer {
-        return openTelemetry.tracerProvider.getTracer(name)
+        return openTelemetry.getTracer(name)
     }
 
     override fun before() {

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
@@ -9,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.compatWithOtelJava
+import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
@@ -57,7 +58,7 @@ public class OpenTelemetryExtension : BeforeEachCallback {
         get() = spanExporter.exportedSpans
 
     public fun getTracer(name: String): Tracer {
-        return openTelemetry.tracerProvider.getTracer(name)
+        return openTelemetry.getTracer(name)
     }
 
     override fun beforeEach(context: ExtensionContext?) {


### PR DESCRIPTION
## Goal

The OTel Java API have a helper to get a tracer with just the instrumentation scope name. Add something similar in an extension to the Kotlin OTel instance.
