### PR TITLE
Implement java to kotlin adapters

### DIFF
--- a/opentelemetry-java-typealiases/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/opentelemetry-java-typealiases/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/aliases/Aliases.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.internal.ImmutableSpanContext
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.api.logs.LoggerBuilder
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -70,6 +71,7 @@ typealias OtelJavaClock = Clock
 typealias OtelJavaImmutableSpanContext = ImmutableSpanContext
 typealias OtelJavaOpenTelemetry = OpenTelemetry
 typealias OtelJavaLoggerProvider = LoggerProvider
+typealias OtelJavaLoggerBuilder = LoggerBuilder
 typealias OtelJavaLogger = Logger
 typealias OtelJavaSeverity = Severity
 typealias OtelJavaCompletableResultCode = CompletableResultCode

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,3 +1,7 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceJ2KKt {
+	public static final fun compatWithOtelKotlin (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+}
+
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2JKt {
 	public static final fun compatWithOtelJava (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 	public static final fun kotlinApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceJ2K.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceJ2K.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.j2k.OtelJavaOpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.j2k.logging.OtelJavaLoggerProviderAdapter
+import io.embrace.opentelemetry.kotlin.j2k.tracing.OtelJavaTracerProviderAdapter
+
+/**
+ * Constructs an [OtelJavaOpenTelemetry] instance that decorates the OpenTelemetry Kotlin SDK.
+ * This will use the Java API to access the Kotlin implementation under the hood, which can be helpful
+ * if you have instrumentation already written against the Java API.
+ */
+@ExperimentalApi
+public fun OpenTelemetryInstance.compatWithOtelKotlin(impl: OpenTelemetry): OtelJavaOpenTelemetry {
+    return OtelJavaOpenTelemetrySdk(
+        tracerProvider = OtelJavaTracerProviderAdapter(impl.tracerProvider),
+        loggerProvider = OtelJavaLoggerProviderAdapter(impl.loggerProvider)
+    )
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/OtelJavaOpenTelemetrySdk.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/OtelJavaOpenTelemetrySdk.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.j2k
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
+import io.opentelemetry.api.logs.LoggerProvider
+
+internal class OtelJavaOpenTelemetrySdk(
+    private val tracerProvider: OtelJavaTracerProvider,
+    private val loggerProvider: OtelJavaLoggerProvider,
+) : OtelJavaOpenTelemetry {
+
+    override fun getTracerProvider(): OtelJavaTracerProvider = tracerProvider
+    override fun getLogsBridge(): LoggerProvider = loggerProvider
+    override fun getPropagators(): OtelJavaContextPropagators = OtelJavaContextPropagators.noop()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLogRecordBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLogRecordBuilderAdapter.kt
@@ -1,0 +1,85 @@
+package io.embrace.opentelemetry.kotlin.j2k.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordBuilder
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.logging.convertToOtelKotlin
+import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.context.Context
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
+    OtelJavaLogRecordBuilder {
+
+    private var timestamp: Long? = null
+    private var observedTimestamp: Long? = null
+    private var context: Context? = null
+    private var severity: Severity? = null
+    private var severityText: String? = null
+    private var body: String? = null
+    private val attrs = ConcurrentHashMap<String, String>()
+
+    override fun setTimestamp(timestamp: Long, unit: TimeUnit): OtelJavaLogRecordBuilder {
+        this.timestamp = unit.toNanos(timestamp)
+        return this
+    }
+
+    override fun setTimestamp(instant: Instant): OtelJavaLogRecordBuilder {
+        return this
+    }
+
+    override fun setObservedTimestamp(timestamp: Long, unit: TimeUnit): OtelJavaLogRecordBuilder {
+        this.observedTimestamp = unit.toNanos(timestamp)
+        return this
+    }
+
+    override fun setObservedTimestamp(instant: Instant): OtelJavaLogRecordBuilder {
+        return this
+    }
+
+    override fun setContext(context: Context): OtelJavaLogRecordBuilder {
+        this.context = context
+        return this
+    }
+
+    override fun setSeverity(severity: Severity): OtelJavaLogRecordBuilder {
+        this.severity = severity
+        return this
+    }
+
+    override fun setSeverityText(severityText: String): OtelJavaLogRecordBuilder {
+        this.severityText = severityText
+        return this
+    }
+
+    override fun setBody(body: String): OtelJavaLogRecordBuilder {
+        this.body = body
+        return this
+    }
+
+    override fun <T : Any?> setAttribute(
+        key: AttributeKey<T>,
+        value: T?
+    ): OtelJavaLogRecordBuilder {
+        attrs[key.key] = value.toString()
+        return this
+    }
+
+    override fun emit() {
+        impl.log(
+            body = body,
+            timestampNs = timestamp,
+            observedTimestampNs = observedTimestamp,
+            context = context?.toOtelKotlin(),
+            severityNumber = severity?.convertToOtelKotlin(),
+            severityText = severityText,
+        ) {
+            attrs.forEach { setStringAttribute(it.key, it.value) }
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerAdapter.kt
@@ -1,0 +1,13 @@
+package io.embrace.opentelemetry.kotlin.j2k.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogger
+import io.embrace.opentelemetry.kotlin.logging.Logger
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaLoggerAdapter(private val impl: Logger) : OtelJavaLogger {
+
+    override fun logRecordBuilder(): OtelJavaLogRecordBuilder =
+        OtelJavaLogRecordBuilderAdapter(impl)
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerBuilderAdapter.kt
@@ -1,0 +1,35 @@
+package io.embrace.opentelemetry.kotlin.j2k.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogger
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerBuilder
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaLoggerBuilderAdapter(
+    private val loggerProvider: LoggerProvider,
+    private val instrumentationScopeName: String
+) : OtelJavaLoggerBuilder {
+
+    private var schemaUrl: String? = null
+    private var instrumentationScopeVersion: String? = null
+
+    override fun setSchemaUrl(schemaUrl: String): OtelJavaLoggerBuilder {
+        this.schemaUrl = schemaUrl
+        return this
+    }
+
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): OtelJavaLoggerBuilder {
+        this.instrumentationScopeVersion = instrumentationScopeVersion
+        return this
+    }
+
+    override fun build(): OtelJavaLogger {
+        val impl = loggerProvider.getLogger(
+            instrumentationScopeName,
+            instrumentationScopeVersion,
+            schemaUrl
+        )
+        return OtelJavaLoggerAdapter(impl)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLoggerProviderAdapter.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.j2k.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaLoggerProviderAdapter(
+    private val loggerProvider: LoggerProvider
+) : OtelJavaLoggerProvider {
+
+    override fun loggerBuilder(instrumentationScopeName: String): OtelJavaLoggerBuilder = OtelJavaLoggerBuilderAdapter(
+        loggerProvider,
+        instrumentationScopeName
+    )
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
@@ -7,22 +7,42 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.recordException
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan {
 
-    override fun <T : Any?> setAttribute(key: OtelJavaAttributeKey<T?>, value: T?): OtelJavaSpan? {
-        TODO("Not yet implemented")
+    override fun <T : Any?> setAttribute(key: OtelJavaAttributeKey<T?>, value: T?): OtelJavaSpan {
+        span.setStringAttribute(key.key, value.toString())
+        return this
     }
 
     override fun addEvent(name: String, attributes: OtelJavaAttributes): OtelJavaSpan {
-        TODO("Not yet implemented")
+        span.addEvent(name) {
+            attributes.toMap().forEach {
+                setStringAttribute(it.key, it.value.toString())
+            }
+        }
+        return this
     }
 
-    override fun addEvent(name: String, attributes: OtelJavaAttributes, timestamp: Long, unit: TimeUnit): OtelJavaSpan {
-        TODO("Not yet implemented")
+    override fun addEvent(
+        name: String,
+        attributes: OtelJavaAttributes,
+        timestamp: Long,
+        unit: TimeUnit
+    ): OtelJavaSpan {
+        val time = unit.toNanos(timestamp)
+        span.addEvent(name, time) {
+            attributes.toMap().forEach {
+                setStringAttribute(it.key, it.value.toString())
+            }
+        }
+        return this
     }
 
     override fun setStatus(statusCode: OtelJavaStatusCode, description: String): OtelJavaSpan {
@@ -30,8 +50,16 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan {
         return this
     }
 
-    override fun recordException(exception: Throwable, additionalAttributes: OtelJavaAttributes): OtelJavaSpan {
-        TODO("Not yet implemented")
+    override fun recordException(
+        exception: Throwable,
+        additionalAttributes: OtelJavaAttributes
+    ): OtelJavaSpan {
+        span.recordException(exception) {
+            additionalAttributes.toMap().forEach {
+                setStringAttribute(it.key, it.value.toString())
+            }
+        }
+        return this
     }
 
     override fun updateName(name: String): OtelJavaSpan {
@@ -48,7 +76,7 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan {
     }
 
     override fun getSpanContext(): OtelJavaSpanContext {
-        TODO("Not yet implemented")
+        return span.spanContext.convertToOtelJava()
     }
 
     override fun isRecording(): Boolean = span.isRecording()


### PR DESCRIPTION
## Goal

Implements code that allows the Kotlin implementation to be used via invocations of the Java API. A future PR will setup span/log exporting test cases for test coverage.
