### PR TITLE
Attribute container extension

### DIFF
--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
@@ -12,8 +12,27 @@ import io.embrace.opentelemetry.kotlin.ThreadSafe
 @ExperimentalApi
 @ThreadSafe
 public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
-    // TODO: add support for other attribute types
     attributes.forEach {
-        setStringAttribute(it.key, it.value.toString())
+        when (val input = it.value) {
+            is String -> setStringAttribute(it.key, input)
+            is Boolean -> setBooleanAttribute(it.key, input)
+            is Long -> setLongAttribute(it.key, input)
+            is Double -> setDoubleAttribute(it.key, input)
+            is Collection<*> -> handleCollection(it.key, input.toList())
+            is Array<*> -> handleCollection(it.key, input.toList())
+            else -> setStringAttribute(it.key, it.value.toString())
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+@OptIn(ExperimentalApi::class)
+private fun AttributeContainer.handleCollection(key: String, input: List<*>) {
+    when {
+        input.all { it is String } -> setStringListAttribute(key, input as List<String>)
+        input.all { it is Boolean } -> setBooleanListAttribute(key, input as List<Boolean>)
+        input.all { it is Double } -> setDoubleListAttribute(key, input as List<Double>)
+        input.all { it is Long } -> setLongListAttribute(key, input as List<Long>)
+        else -> return
     }
 }

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
@@ -1,0 +1,75 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class AttributeContainerExtTest {
+
+    @Test
+    fun `set attributes`() {
+        val attrs = FakeAttributeContainer()
+        val input = mapOf(
+            "string" to "value",
+            "long" to 5L,
+            "double" to 10L,
+            "bool" to true,
+            "stringList" to listOf("value"),
+            "longList" to mutableListOf(5L),
+            "doubleList" to setOf(10L),
+            "boolList" to arrayOf(true),
+        )
+        val expected = mapOf(
+            "string" to "value",
+            "long" to 5L,
+            "double" to 10L,
+            "bool" to true,
+            "stringList" to listOf("value"),
+            "longList" to listOf(5L),
+            "doubleList" to listOf(10L),
+            "boolList" to listOf(true),
+        )
+        attrs.setAttributes(input)
+        val observed = attrs.attributes()
+        assertEquals(expected, observed)
+    }
+
+    private class FakeAttributeContainer(
+        private val attributes: MutableMap<String, Any> = mutableMapOf()
+    ) : AttributeContainer {
+        override fun setBooleanAttribute(key: String, value: Boolean) {
+            attributes[key] = value
+        }
+
+        override fun setStringAttribute(key: String, value: String) {
+            attributes[key] = value
+        }
+
+        override fun setLongAttribute(key: String, value: Long) {
+            attributes[key] = value
+        }
+
+        override fun setDoubleAttribute(key: String, value: Double) {
+            attributes[key] = value
+        }
+
+        override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+            attributes[key] = value
+        }
+
+        override fun setStringListAttribute(key: String, value: List<String>) {
+            attributes[key] = value
+        }
+
+        override fun setLongListAttribute(key: String, value: List<Long>) {
+            attributes[key] = value
+        }
+
+        override fun setDoubleListAttribute(key: String, value: List<Double>) {
+            attributes[key] = value
+        }
+
+        override fun attributes(): Map<String, Any> = attributes
+    }
+}


### PR DESCRIPTION
## Goal

Supports multiple types in the extension for setting attributes on an `AttributeContainer`.
