### PR TITLE
Implement recordException()

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -14,5 +14,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
 	public static final fun recordException (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun recordException$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 
 /**
  * Record an exception on the span as an event.
@@ -11,6 +11,14 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 @Suppress("UNUSED_PARAMETER")
 @ExperimentalApi
 @ThreadSafe
-public fun Span.recordException(exception: Throwable, action: SpanEvent.() -> Unit) {
-    TODO()
+public fun Span.recordException(exception: Throwable, action: AttributeContainer.() -> Unit = {}) {
+    addEvent("exception") {
+        setStringAttribute("exception.stacktrace", exception.stackTraceToString())
+        exception.message?.let {
+            setStringAttribute("exception.message", it)
+        }
+        exception::class.qualifiedName?.let {
+            setStringAttribute("exception.type", it)
+        }
+    }
 }

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -1,0 +1,93 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.model.Link
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+@Suppress("UNUSED_PARAMETER")
+@OptIn(ExperimentalApi::class)
+internal class FakeSpan : Span {
+
+    private val events = mutableListOf<SpanEvent>()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override var name: String
+        get() = TODO("Not yet implemented")
+        set(value) {}
+    override var status: StatusCode
+        get() = TODO("Not yet implemented")
+        set(value) {}
+    override val parent: SpanContext?
+        get() = TODO("Not yet implemented")
+    override val spanContext: SpanContext
+        get() = TODO("Not yet implemented")
+    override val spanKind: SpanKind
+        get() = TODO("Not yet implemented")
+    override val startTimestamp: Long
+        get() = TODO("Not yet implemented")
+
+    override fun end() {
+        TODO("Not yet implemented")
+    }
+
+    override fun end(timestamp: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRecording(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+        events.add(FakeSpanEvent(name, timestamp ?: 0).apply(action))
+    }
+
+    override fun events(): List<SpanEvent> = events.toList()
+
+    override fun links(): List<Link> {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun attributes(): Map<String, Any> {
+        TODO("Not yet implemented")
+    }
+}

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpanEvent.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpanEvent.kt
@@ -1,0 +1,47 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
+
+@OptIn(ExperimentalApi::class)
+internal class FakeSpanEvent(
+    override val name: String,
+    override val timestamp: Long
+) : SpanEvent {
+
+    private val attrs = mutableMapOf<String, Any>()
+
+    override fun setStringAttribute(key: String, value: String) {
+        attrs[key] = value
+    }
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        attrs[key] = value
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        attrs[key] = value
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        attrs[key] = value
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+        attrs[key] = value
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+        attrs[key] = value
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+        attrs[key] = value
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        attrs[key] = value
+    }
+
+    override fun attributes(): Map<String, Any> = attrs.toMap()
+}

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -1,0 +1,38 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalApi::class)
+internal class SpanExtTest {
+
+    @Test
+    fun `record exception`() {
+        val span = FakeSpan()
+        assertEquals(0, span.events().size)
+
+        span.recordException(IllegalArgumentException())
+        span.recordException(IllegalStateException("Whoops!")) {
+            setStringAttribute("extra", "value")
+        }
+        val events = span.events()
+        assertEquals(2, events.size)
+
+        val simple = events.first()
+        assertEquals("exception", simple.name)
+        val simpleAttrs = simple.attributes()
+        assertEquals(2, simpleAttrs.size)
+        assertEquals("java.lang.IllegalArgumentException", simpleAttrs["exception.type"])
+        assertNotNull(simpleAttrs["exception.stacktrace"])
+
+        val complex = events.last()
+        assertEquals("exception", complex.name)
+        val complexAttrs = complex.attributes()
+        assertEquals(3, complexAttrs.size)
+        assertEquals("java.lang.IllegalStateException", complexAttrs["exception.type"])
+        assertEquals("Whoops!", complexAttrs["exception.message"])
+        assertNotNull(complexAttrs["exception.stacktrace"])
+    }
+}


### PR DESCRIPTION
## Goal

Implements[ recordException() ](https://opentelemetry.io/docs/specs/otel/trace/exceptions/)as an extension on `Span`.

## Testing

Added unit test coverage.

