### PR TITLE
Adaptor for Java Span should use current context by default

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -35,7 +35,7 @@ internal class OtelJavaSpanBuilderAdapter(
     }
 
     override fun setNoParent(): OtelJavaSpanBuilder {
-        parent = null
+        parent = Context.root()
         return this
     }
 
@@ -106,7 +106,7 @@ internal class OtelJavaSpanBuilderAdapter(
     }
 
     private fun findParentSpanContext(): SpanContextAdapter {
-        val ctx = parent ?: Context.root()
+        val ctx = parent ?: Context.current()
         val parentSpan = OtelJavaSpan.fromContext(ctx)
         return SpanContextAdapter(parentSpan.spanContext)
     }


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. -->

**WHAT**:<br>
**WHY**:<br>

