### PR TITLE
Publish opentelemetry-kotlin-testing module

### DIFF
--- a/opentelemetry-kotlin-testing/build.gradle.kts
+++ b/opentelemetry-kotlin-testing/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("io.embrace.otel.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
 }
 
 kotlin {

--- a/opentelemetry-kotlin-testing/gradle.properties
+++ b/opentelemetry-kotlin-testing/gradle.properties
@@ -1,1 +1,2 @@
 io.embrace.containsPublicApi=false
+io.embrace.javaSdkCompatModule=true


### PR DESCRIPTION
## Goal

Ensures the opentelemetry-kotlin-testing module is published to allow backwards compatibility with tests using the Java API.