### PR TITLE
Update span serialization to include instrumentation scope info

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanData.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/SerializableSpanData.kt
@@ -19,4 +19,5 @@ internal data class SerializableSpanData(
     val totalRecordedLinks: Int,
     val totalAttributeCount: Int,
     val resource: SerializableResource,
+    val instrumentationScopeInfo: SerializableInstrumentationScopeInfo
 )

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/conversion/SerializableSpanData.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/framework/serialization/conversion/SerializableSpanData.kt
@@ -20,4 +20,5 @@ internal fun OtelJavaSpanData.toSerializable(sanitizeSpanContextIds: Boolean) = 
     totalRecordedLinks = totalRecordedLinks,
     totalAttributeCount = totalAttributeCount,
     resource = resource.toSerializable(),
+    instrumentationScopeInfo = instrumentationScopeInfo.toSerializable()
 )

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -192,6 +192,24 @@ internal class SpanExportTest {
         )
     }
 
+    @Test
+    fun `test tracer with schema url and attributes`() {
+        val schemaUrl = "https://opentelemetry.io/schemas/1.21.0"
+        val tracerWithSchemaUrl = tracerProvider.getTracer(
+            name = "test-tracer",
+            version = "2.0.0",
+            schemaUrl = schemaUrl
+        ) {
+            setStringAttribute("tracer_attr", "tracer_value")
+            setLongAttribute("tracer_id", 123)
+        }
+
+        val span = tracerWithSchemaUrl.createSpan("schema_url_span")
+        span.end()
+
+        harness.assertSpans(expectedCount = 1, goldenFileName = "span_schema_url.json")
+    }
+
     private fun AttributeContainer.assertAttributes() {
         assertTrue(attributes().isEmpty())
 

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
@@ -44,6 +44,12 @@
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.version": "1.52.0"
       }
+    },
+    "instrumentationScopeInfo": {
+      "name": "name",
+      "version": "version",
+      "schemaUrl": "null",
+      "attributes": {}
     }
   }
 ]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
@@ -55,6 +55,12 @@
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.version": "1.52.0"
       }
+    },
+    "instrumentationScopeInfo": {
+      "name": "name",
+      "version": "version",
+      "schemaUrl": "null",
+      "attributes": {}
     }
   },
   {
@@ -93,6 +99,12 @@
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.version": "1.52.0"
       }
+    },
+    "instrumentationScopeInfo": {
+      "name": "name",
+      "version": "version",
+      "schemaUrl": "null",
+      "attributes": {}
     }
   }
 ]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
@@ -35,6 +35,12 @@
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.version": "1.52.0"
       }
+    },
+    "instrumentationScopeInfo": {
+      "name": "name",
+      "version": "version",
+      "schemaUrl": "null",
+      "attributes": {}
     }
   }
 ]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
@@ -35,6 +35,12 @@
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.version": "1.52.0"
       }
+    },
+    "instrumentationScopeInfo": {
+      "name": "name",
+      "version": "version",
+      "schemaUrl": "null",
+      "attributes": {}
     }
   }
 ]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "span_events",
+    "name": "schema_url_span",
     "kind": "INTERNAL",
     "statusData": {
       "name": "UNSET",
@@ -20,27 +20,11 @@
     },
     "startTimestampNs": 0,
     "attributes": {},
-    "events": [
-      {
-        "name": "my_event",
-        "attributes": {
-          "bool_key": "true",
-          "bool_list_key": "[true]",
-          "double_key": "3.14",
-          "double_list_key": "[3.14]",
-          "long_key": "42",
-          "long_list_key": "[42]",
-          "string_key": "second_value",
-          "string_list_key": "[a]"
-        },
-        "timestampNs": 150,
-        "totalAttributesCount": 8
-      }
-    ],
+    "events": [],
     "links": [],
     "endTimestampNs": 0,
     "ended": true,
-    "totalRecordedEvents": 1,
+    "totalRecordedEvents": 0,
     "totalRecordedLinks": 0,
     "totalAttributeCount": 0,
     "resource": {
@@ -53,9 +37,9 @@
       }
     },
     "instrumentationScopeInfo": {
-      "name": "name",
-      "version": "version",
-      "schemaUrl": "null",
+      "name": "test-tracer",
+      "version": "2.0.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.21.0",
       "attributes": {}
     }
   }


### PR DESCRIPTION
Add instrumentationScopeInfo field to SerializableSpanData and update golden files to include tracer name, version, schema URL, and attributes.