### PR TITLE
Rename parameters of type AttributeContainer, add default parameter for addLink

### DIFF
--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.Span
  */
 @ExperimentalApi
 @ThreadSafe
-public fun Span.recordException(exception: Throwable, action: AttributeContainer.() -> Unit = {}) {
+public fun Span.recordException(exception: Throwable, attributes: AttributeContainer.() -> Unit = {}) {
     addEvent("exception") {
         setStringAttribute("exception.stacktrace", exception.stackTraceToString())
         exception.message?.let {
@@ -19,6 +19,6 @@ public fun Span.recordException(exception: Throwable, action: AttributeContainer
         exception::class.qualifiedName?.let {
             setStringAttribute("exception.type", it)
         }
-        action(this)
+        attributes(this)
     }
 }

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -45,12 +45,12 @@ internal class FakeSpan : Span {
         TODO("Not yet implemented")
     }
 
-    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
         TODO("Not yet implemented")
     }
 
-    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
-        events.add(FakeSpanEvent(name, timestamp ?: 0).apply(action))
+    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
+        events.add(FakeSpanEvent(name, timestamp ?: 0).apply(attributes))
     }
 
     override fun events(): List<SpanEvent> = events.toList()

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -349,6 +349,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Sp
 
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships$DefaultImpls {
 	public static synthetic fun addEvent$default (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun addLink$default (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/TraceFlags {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
@@ -15,7 +15,7 @@ public interface LoggerProviderConfigDsl {
     /**
      * The [Resource] associated with this logger provider.
      */
-    public fun resource(action: AttributeContainer.() -> Unit)
+    public fun resource(attributes: AttributeContainer.() -> Unit)
 
     /**
      * Adds a [LogRecordProcessor] to the logger provider.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
@@ -15,7 +15,7 @@ public interface TracerProviderConfigDsl {
     /**
      * The [Resource] associated with this tracer provider.
      */
-    public fun resource(action: AttributeContainer.() -> Unit)
+    public fun resource(attributes: AttributeContainer.() -> Unit)
 
     /**
      * The span limits configuration for this tracer provider.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
@@ -16,7 +16,7 @@ public interface SpanRelationships : AttributeContainer {
      * Adds a link to the span that associates it with another [SpanContext].
      */
     @ThreadSafe
-    public fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit)
+    public fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit = {})
 
     /**
      * Adds an event to the span.
@@ -25,7 +25,7 @@ public interface SpanRelationships : AttributeContainer {
     public fun addEvent(
         name: String,
         timestamp: Long? = null,
-        action: AttributeContainer.() -> Unit = {},
+        attributes: AttributeContainer.() -> Unit = {},
     )
 
     /**

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadWriteSpanAdapter.kt
@@ -45,16 +45,16 @@ internal class ReadWriteSpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
         val container = AttributeContainerImpl()
-        action(container)
+        attributes(container)
         val ctx = (spanContext as SpanContextAdapter).impl
         impl.addLink(ctx, container.otelJavaAttributes())
     }
 
-    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
         val container = AttributeContainerImpl()
-        action(container)
+        attributes(container)
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/LoggerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/LoggerProviderConfigImpl.kt
@@ -25,8 +25,8 @@ internal class LoggerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(action: AttributeContainer.() -> Unit) {
-        val attrs = AttributeContainerImpl().apply(action).otelJavaAttributes()
+    override fun resource(attributes: AttributeContainer.() -> Unit) {
+        val attrs = AttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs))
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/init/TracerProviderConfigImpl.kt
@@ -25,8 +25,8 @@ internal class TracerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(action: AttributeContainer.() -> Unit) {
-        val attrs = AttributeContainerImpl().apply(action).otelJavaAttributes()
+    override fun resource(attributes: AttributeContainer.() -> Unit) {
+        val attrs = AttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs))
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -62,16 +62,16 @@ internal class SpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
         val container = AttributeContainerImpl()
-        action(container)
+        attributes(container)
         links.add(LinkImpl(spanContext, container))
         impl.addLink(spanContext.convertToOtelJava(), container.otelJavaAttributes())
     }
 
-    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
         val container = AttributeContainerImpl()
-        action(container)
+        attributes(container)
         val time = timestamp ?: clock.now()
         events.add(SpanEventImpl(name, time, container))
         impl.addEvent(name, container.otelJavaAttributes(), time, TimeUnit.NANOSECONDS)

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -24,10 +24,10 @@ internal object NoopSpan : Span {
     override fun end(timestamp: Long) {
     }
 
-    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
     }
 
-    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
     }
 
     override fun isRecording(): Boolean = false


### PR DESCRIPTION
## Goal
Parameters of type AttributeContainer were named both action and attributes. Attributes made more sense, so I renamed them to make it more consistent.

Also added a default parameter for addLink, so we can call it `addLink(someContext)` when we don't want to add attributes to the link.