### PR TITLE
Update telescope-app to use new API

### DIFF
--- a/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/SessionTelemetry.kt
+++ b/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/SessionTelemetry.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.telescope.telemetry
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.tracing.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 @OptIn(ExperimentalApi::class)

--- a/examples/telescope-app/gradle/libs.versions.toml
+++ b/examples/telescope-app/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 opentelemetry-bom = "1.46.0"
-opentelemetry-kotlin-api = "0.2.0-SNAPSHOT"
+opentelemetry-kotlin-api = "0.3.0-SNAPSHOT"
 opentelemetry-semconv = "1.28.0-alpha"
 navigationCompose = "2.8.8"
 


### PR DESCRIPTION
## Goal

App wasn't compiling, so I'm using OpenTelemetryInstance.compatWithOtelJava(javaSdk) to init the Kotlin API, and updated the span package.

