### PR TITLE
Use Context instead of SpanContext

### DIFF
--- a/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-shared/src/main/java/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -8,6 +8,8 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.compatWithOtelJava
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.k2j.context.root
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
@@ -84,7 +86,7 @@ private fun createComplexSpan(
 ): Span = tracer.createSpan(
     name = "complex_span",
     spanKind = SpanKind.CLIENT,
-    parent = simpleSpan.spanContext,
+    parentContext = Context.root(),
     startTimestamp = 15000000000L,
 ) {
     // alter the span during its initialization

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -207,11 +207,11 @@ public final class io/embrace/opentelemetry/kotlin/tracing/StatusCode$Unset : io
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/Tracer {
-	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/Tracer$DefaultImpls {
-	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+	public static synthetic fun createSpan$default (Lio/embrace/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/TracerProvider {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
@@ -22,7 +22,7 @@ public interface Tracer {
     @ThreadSafe
     public fun createSpan(
         name: String,
-        parent: SpanContext? = null,
+        parentContext: Context? = null,
         spanKind: SpanKind = SpanKind.INTERNAL,
         startTimestamp: Long? = null,
         action: SpanRelationships.() -> Unit = {}

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -8,6 +8,10 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2JKt {
 	public static synthetic fun kotlinApi$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
+public final class io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextExtKt {
+	public static final fun toOtelKotlin (Lio/opentelemetry/context/Context;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
 public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterAdapter : io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter {
 	public fun <init> (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun export (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
@@ -34,6 +38,7 @@ public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSp
 public final class io/embrace/opentelemetry/kotlin/k2j/context/ContextExtKt {
 	public static final fun current (Lio/embrace/opentelemetry/kotlin/context/Context$Companion;)Lio/embrace/opentelemetry/kotlin/context/Context;
 	public static final fun root (Lio/embrace/opentelemetry/kotlin/context/Context$Companion;)Lio/embrace/opentelemetry/kotlin/context/Context;
+	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/opentelemetry/context/Context;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/k2j/id/TracingIdGenerator {
@@ -82,7 +87,7 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConvers
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter : io/embrace/opentelemetry/kotlin/tracing/Tracer {
 	public fun <init> (Lio/opentelemetry/api/trace/Tracer;Lio/embrace/opentelemetry/kotlin/Clock;)V
-	public fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+	public fun createSpan (Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/model/SpanContextExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextExt.kt
@@ -5,6 +5,6 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
 
 @OptIn(ExperimentalApi::class)
-internal fun OtelJavaContext.toOtelKotlin(): Context {
+public fun OtelJavaContext.toOtelKotlin(): Context {
     return OtelJavaContextAdapter(this)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -11,7 +11,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
-import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.context.Context
@@ -95,7 +95,7 @@ internal class OtelJavaSpanBuilderAdapter(
             name = spanName,
             spanKind = kind.convertToOtelKotlin(),
             startTimestamp = start,
-            parent = findParentSpanContext()
+            parentContext = OtelJavaContextAdapter(parent ?: OtelJavaContext.current())
         ) {
             setAttributes(attrs.build().asMap().mapKeys { it.key.key })
             links.forEach {
@@ -103,12 +103,6 @@ internal class OtelJavaSpanBuilderAdapter(
             }
         }
         return OtelJavaSpanAdapter(span)
-    }
-
-    private fun findParentSpanContext(): SpanContextAdapter {
-        val ctx = parent ?: Context.current()
-        val parentSpan = OtelJavaSpan.fromContext(ctx)
-        return SpanContextAdapter(parentSpan.spanContext)
     }
 
     private class LinkBuilder(

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
@@ -5,6 +5,7 @@ package io.embrace.opentelemetry.kotlin.k2j.context
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
 
 /**
@@ -16,3 +17,8 @@ public fun Context.Companion.root(): Context = OtelJavaContext.root().toOtelKotl
  * Returns the current context.
  */
 public fun Context.Companion.current(): Context = OtelJavaContext.current().toOtelKotlin()
+
+@OptIn(ExperimentalApi::class)
+public fun Context.toOtelJava(): OtelJavaContext {
+    return (this as? OtelJavaContextAdapter)?.impl ?: ContextAdapter(this)
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -3,13 +3,12 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
-import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.k2j.context.ContextAdapter
+import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 import java.util.concurrent.TimeUnit
@@ -22,7 +21,7 @@ public class TracerAdapter(
 
     override fun createSpan(
         name: String,
-        parent: SpanContext?,
+        parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit
@@ -32,9 +31,8 @@ public class TracerAdapter(
             .setSpanKind(spanKind.convertToOtelJava())
             .setStartTimestamp(start, TimeUnit.NANOSECONDS)
 
-        if (parent != null) {
-            val ctx = findContext(parent)
-            builder.setParent(ctx)
+        if (parentContext != null) {
+            builder.setParent(parentContext.toOtelJava())
         } else {
             builder.setNoParent()
         }
@@ -43,19 +41,12 @@ public class TracerAdapter(
         return SpanAdapter(
             impl = span,
             clock = clock,
-            parent = parent ?: SpanContext.invalid(),
+            parentCtx = parentContext?.let(::ContextAdapter) ?: OtelJavaContext.current() ?: OtelJavaContext.root(),
             spanKind = spanKind,
             startTimestamp = start
         ).apply {
             this.name = name
             action(this)
         }
-    }
-
-    private fun findContext(spanContext: SpanContext): OtelJavaContext {
-        val ctx = OtelJavaContext.current() ?: OtelJavaContext.root()
-        val impl = (spanContext as? SpanContextAdapter)?.impl ?: OtelJavaSpanContext.getInvalid()
-        val span = OtelJavaSpan.wrap(impl)
-        return ctx.with(span)
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
@@ -14,8 +14,6 @@ import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.j2k.tracing.OtelJavaSpanAdapter
 import io.embrace.opentelemetry.kotlin.k2j.context.ContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanAdapter
-import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Before
 import org.junit.Test
@@ -64,7 +62,7 @@ internal class ContextRetrievalTest {
     @Test
     fun `store and retrieve implicit span from context`() {
         val impl = FakeSpanImpl()
-        val kotlinSpan = SpanAdapter(impl, FakeClock(), SpanContext.invalid(), SpanKind.INTERNAL, 0)
+        val kotlinSpan = SpanAdapter(impl, FakeClock(), null, SpanKind.INTERNAL, 0)
         val javaSpan = OtelJavaSpanAdapter(kotlinSpan)
 
         val ctx = javaDecorator.with(javaSpan)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
@@ -9,7 +10,6 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeClock
-import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeSpanContext
 import io.embrace.opentelemetry.kotlin.k2j.context.root
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.create
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.default
@@ -71,7 +71,7 @@ internal class SpanExtTest {
         val span = SpanAdapter(
             OtelJavaSpan.wrap(spanContext),
             FakeClock(),
-            FakeSpanContext(),
+            OtelJavaContext.root(),
             SpanKind.INTERNAL,
             0
         )

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -1,8 +1,8 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 internal object NoopTracer : Tracer {
     override fun createSpan(
         name: String,
-        parent: SpanContext?,
+        parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit


### PR DESCRIPTION
## Goal

Use `Context` instead of `SpanContext` when creating spans as this is what is mandated by the OTel spec.

It's worth noting I couldn't immediately figure out how to support `TraceState` with this approach, so I deleted a test case that is now failing. I imagine we can support this later as it's not important for our use-case.

## Testing

Updated existing unit tests.

