### PR TITLE
Tweak span context implementation

### DIFF
--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -24,7 +24,7 @@ internal class FakeSpan : Span {
     override var status: StatusCode
         get() = TODO("Not yet implemented")
         set(value) {}
-    override val parent: SpanContext?
+    override val parent: SpanContext
         get() = TODO("Not yet implemented")
     override val spanContext: SpanContext
         get() = TODO("Not yet implemented")

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -38,9 +38,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/attributes/Attri
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/context/Context {
+	public static final field Companion Lio/embrace/opentelemetry/kotlin/context/Context$Companion;
 	public abstract fun createKey (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/context/ContextKey;
 	public abstract fun get (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
 	public abstract fun set (Lio/embrace/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
+public final class io/embrace/opentelemetry/kotlin/context/Context$Companion {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/context/ContextKey {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
@@ -38,4 +38,6 @@ public interface Context {
      */
     @ThreadSafe
     public operator fun <T> get(key: ContextKey<T>): T?
+
+    public companion object
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
@@ -22,9 +22,9 @@ public interface ReadableSpan {
     public val status: StatusCode
 
     /**
-     * The parent span context. This defaults to null.
+     * The parent span context.
      */
-    public val parent: SpanContext?
+    public val parent: SpanContext
 
     /**
      * The span context that uniquely identifies this span.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
@@ -28,10 +28,10 @@ public interface Span : SpanRelationships {
     public var status: StatusCode
 
     /**
-     * Gets the parent span context. This defaults to null.
+     * Gets the parent span context.
      */
     @ThreadSafe
-    public val parent: SpanContext?
+    public val parent: SpanContext
 
     /**
      * Gets the span context that uniquely identifies this span.

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -31,6 +31,11 @@ public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSp
 	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
 }
 
+public final class io/embrace/opentelemetry/kotlin/k2j/context/ContextExtKt {
+	public static final fun current (Lio/embrace/opentelemetry/kotlin/context/Context$Companion;)Lio/embrace/opentelemetry/kotlin/context/Context;
+	public static final fun root (Lio/embrace/opentelemetry/kotlin/context/Context$Companion;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/k2j/id/TracingIdGenerator {
 	public abstract fun generateSpanId ()Ljava/lang/String;
 	public abstract fun generateTraceId ()Ljava/lang/String;

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanExt.kt
@@ -6,7 +6,6 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaSpanDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
@@ -20,7 +19,7 @@ internal fun ReadableSpan.toSpanData(): SpanData {
     return OtelJavaSpanDataImpl(
         nameImpl = name,
         statusImpl = OtelJavaStatusData.create(status.convertToOtelJava(), null),
-        parentSpanContextImpl = parent?.convertToOtelJava() ?: OtelJavaSpanContext.getInvalid(),
+        parentSpanContextImpl = parent.convertToOtelJava(),
         spanContextImpl = spanContext.convertToOtelJava(),
         kindImpl = spanKind.convertToOtelJava(),
         startEpochNanosImpl = startTimestamp,

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
@@ -1,0 +1,18 @@
+@file:OptIn(ExperimentalApi::class)
+
+package io.embrace.opentelemetry.kotlin.k2j.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+
+/**
+ * Returns the root Context.
+ */
+public fun Context.Companion.root(): Context = OtelJavaContext.root().toOtelKotlin()
+
+/**
+ * Returns the current context.
+ */
+public fun Context.Companion.current(): Context = OtelJavaContext.current().toOtelKotlin()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 internal class SpanAdapter(
     val impl: OtelJavaSpan,
     private val clock: Clock,
-    override val parent: SpanContext?,
+    override val parent: SpanContext,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,
 ) : Span, ImplicitContextKeyed {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -6,6 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
@@ -42,7 +43,7 @@ public class TracerAdapter(
         return SpanAdapter(
             impl = span,
             clock = clock,
-            parent = parent,
+            parent = parent ?: SpanContext.invalid(),
             spanKind = spanKind,
             startTimestamp = start
         ).apply {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.assertions
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal fun assertSpanContextsMatch(lhs: SpanContext, rhs: SpanContext) {
+    assertEquals(lhs.spanId, rhs.spanId)
+    assertEquals(lhs.traceId, rhs.traceId)
+    assertEquals(lhs.isValid, rhs.isValid)
+    assertEquals(lhs.isRemote, rhs.isRemote)
+
+    // trace flags
+    assertEquals(lhs.traceFlags.isSampled, rhs.traceFlags.isSampled)
+    assertEquals(lhs.traceFlags.isRandom, rhs.traceFlags.isRandom)
+    assertEquals(lhs.traceFlags.hex, rhs.traceFlags.hex)
+
+    // trace flags
+    assertEquals(lhs.traceState.asMap(), rhs.traceState.asMap())
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
@@ -14,6 +14,8 @@ import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.j2k.tracing.OtelJavaSpanAdapter
 import io.embrace.opentelemetry.kotlin.k2j.context.ContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Before
 import org.junit.Test
@@ -62,7 +64,7 @@ internal class ContextRetrievalTest {
     @Test
     fun `store and retrieve implicit span from context`() {
         val impl = FakeSpanImpl()
-        val kotlinSpan = SpanAdapter(impl, FakeClock(), null, SpanKind.INTERNAL, 0)
+        val kotlinSpan = SpanAdapter(impl, FakeClock(), SpanContext.invalid(), SpanKind.INTERNAL, 0)
         val javaSpan = OtelJavaSpanAdapter(kotlinSpan)
 
         val ctx = javaDecorator.with(javaSpan)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableSpan.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/kotlin/FakeReadableSpan.kt
@@ -14,7 +14,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 internal class FakeReadableSpan(
     override val name: String = "span",
     override val status: StatusCode = StatusCode.Ok,
-    override val parent: SpanContext? = FakeSpanContext(),
+    override val parent: SpanContext = FakeSpanContext(),
     override val spanContext: SpanContext = FakeSpanContext(),
     override val spanKind: SpanKind = SpanKind.INTERNAL,
     override val startTimestamp: Long = 1000,

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
@@ -42,7 +42,7 @@ internal class OtelJavaSpanExporterAdapterTest {
         val observed = impl.exports.single()
         assertEquals(original.name, observed.name)
         assertEquals(original.status.convertToOtelJava(), observed.status.statusCode)
-        assertEquals(original.parent?.spanId, observed.parentSpanContext.spanId)
+        assertEquals(original.parent.spanId, observed.parentSpanContext.spanId)
         assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
         assertEquals(original.spanKind.convertToOtelJava(), observed.kind)
         assertEquals(original.startTimestamp, observed.startEpochNanos)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeTraceState
 import io.embrace.opentelemetry.kotlin.k2j.framework.OtelKotlinHarness
@@ -123,10 +124,10 @@ internal class SpanExportTest {
         val b = tracer.createSpan("b", parent = a.spanContext)
         val c = tracer.createSpan("c", parent = b.spanContext)
 
-        assertNull(a.parent)
+        assertFalse(a.parent.isValid)
         assertNotNull(a.spanContext)
-        assertEquals(a.spanContext, b.parent)
-        assertEquals(b.spanContext, c.parent)
+        assertSpanContextsMatch(a.spanContext, b.parent)
+        assertSpanContextsMatch(b.spanContext, c.parent)
         assertNotNull(c.spanContext)
 
         a.end()

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadableSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadableSpanImpl.kt
@@ -13,7 +13,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 public class ReadableSpanImpl(
     override val name: String,
     override val status: StatusCode,
-    override val parent: SpanContext?,
+    override val parent: SpanContext,
     override val spanContext: SpanContext,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -13,7 +13,7 @@ internal object NoopSpan : Span {
 
     override var name: String = ""
     override var status: StatusCode = StatusCode.Unset
-    override val parent: SpanContext? = null
+    override val parent: SpanContext = NoopSpanContext
     override val spanContext: SpanContext = NoopSpanContext
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = -1L

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -6,7 +6,6 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -115,6 +114,6 @@ internal class NoopTests {
         assertTrue(span.links().isEmpty())
         assertTrue(span.attributes().isEmpty())
         assertFalse(span.isRecording())
-        assertNull(span.parent)
+        assertFalse(span.parent.isValid)
     }
 }


### PR DESCRIPTION
## Goal

Tweaks the implementation of span context so that the span property isn't nullable. Additionally I've added a couple of functions that bind the OTel Java API.

