### PR TITLE
Remove operator overloading from context

### DIFF
--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
@@ -29,7 +29,7 @@ public interface Context {
      * This function returns a new immutable [Context] that contains the key-value pair.
      */
     @ThreadSafe
-    public operator fun <T> set(key: ContextKey<T>, value: T?): Context
+    public fun <T> set(key: ContextKey<T>, value: T?): Context
 
     /**
      * Retrieves a value from the [Context] associated with the given [ContextKey].
@@ -37,7 +37,7 @@ public interface Context {
      * [T] represents the type of the value that is stored in the context.
      */
     @ThreadSafe
-    public operator fun <T> get(key: ContextKey<T>): T?
+    public fun <T> get(key: ContextKey<T>): T?
 
     public companion object
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapter.kt
@@ -12,7 +12,7 @@ internal class ContextAdapter(
 ) : OtelJavaContext {
 
     override fun <V : Any?> get(key: OtelJavaContextKey<V>): V? {
-        return impl[repository.get(key)]
+        return impl.get(repository.get(key))
     }
 
     override fun <V : Any> with(key: OtelJavaContextKey<V>, value: V): OtelJavaContext {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextRetrievalTest.kt
@@ -43,8 +43,8 @@ internal class ContextRetrievalTest {
         val kotlinKey = kotlinDecorator.createKey<String>("kotlin")
         val kotlinValue = "kotlin_value"
         val kotlinCtx = kotlinDecorator.set(kotlinKey, kotlinValue)
-        assertEquals(kotlinValue, kotlinCtx[kotlinKey])
-        assertNull(kotlinDecorator[kotlinKey])
+        assertEquals(kotlinValue, kotlinCtx.get(kotlinKey))
+        assertNull(kotlinDecorator.get(kotlinKey))
 
         // assert that values are stored via 2 layers
         val javaKey = OtelJavaContextKey.named<Any>("java-key")


### PR DESCRIPTION
## Goal

Removes operator overloading from the `Context` functions. The operator overloading allows context to be accessed with this syntax:

```
val ctx = ContextImpl()
val key = ctx.createKey<String>("test_key")
ctx[key] = ""
ctx[key]
```

However, I believe this syntax is unhelpful given context is immutable and always returns a new object. The correct usage of the API should look like this and the operator overloading nudges users of the API in the wrong direction via IDE auto-complete:

```
val key = ctx.createKey<String>("test_key")
val newCtx = ctx.set(key, "")
newCtx.get(key)
```