### PR TITLE
Add non-recording span

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -271,6 +271,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Re
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Span : io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships {
+	public static final field Companion Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;
 	public abstract fun end ()V
 	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
@@ -282,6 +283,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Sp
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setStatus (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)V
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/model/Span$Companion {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanContext {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
@@ -68,4 +68,6 @@ public interface Span : SpanRelationships {
      */
     @ThreadSafe
     public fun isRecording(): Boolean
+
+    public companion object
 }

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -68,6 +68,11 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJa
 	public static final fun convertToOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/opentelemetry/api/trace/SpanContext;
 }
 
+public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtKt {
+	public static final fun fromSpanContext (Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+	public static final fun invalid (Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+}
+
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversionKt {
 	public static final fun convertToOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)Lio/opentelemetry/api/trace/StatusCode;
 	public static final fun convertToOtelKotlin (Lio/opentelemetry/api/trace/StatusCode;)Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExt.kt
@@ -1,0 +1,25 @@
+@file:OptIn(ExperimentalApi::class)
+
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
+import io.embrace.opentelemetry.kotlin.tracing.NonRecordingSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+
+private val invalidSpan = NonRecordingSpan(SpanContext.invalid(), SpanContext.invalid())
+
+/**
+ * Returns an invalid span.
+ */
+public fun Span.Companion.invalid(): Span = invalidSpan
+
+/**
+ * Returns a span from the supplied [SpanContext], or the return value of [Span.Companion.invalid]
+ * if the [SpanContext] is invalid.
+ */
+public fun Span.Companion.fromSpanContext(spanContext: SpanContext): Span = when {
+    spanContext.isValid -> NonRecordingSpan(SpanContext.invalid(), spanContext)
+    else -> invalid()
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
@@ -1,0 +1,46 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
+import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.create
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.default
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class SpanExtTest {
+
+    @Test
+    fun `test invalid span`() {
+        val invalid = Span.invalid()
+        assertSpanContextsMatch(SpanContext.invalid(), invalid.spanContext)
+        assertSpanContextsMatch(SpanContext.invalid(), invalid.parent)
+    }
+
+    @Test
+    fun `test from span context valid`() {
+        val generator = OtelJavaIdGenerator.random()
+        val spanContext = SpanContext.create(
+            traceId = generator.generateTraceId(),
+            spanId = generator.generateSpanId(),
+            traceState = TraceState.default(),
+            traceFlags = TraceFlags.default()
+        )
+
+        val span = Span.fromSpanContext(spanContext)
+        assertSpanContextsMatch(spanContext, span.spanContext)
+        assertSpanContextsMatch(SpanContext.invalid(), span.parent)
+    }
+
+    @Test
+    fun `test from span context invalid`() {
+        val span = Span.fromSpanContext(SpanContext.invalid())
+        assertEquals(Span.invalid(), span)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeSpanContext
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class NonRecordingSpanTest {
+
+    @Test
+    fun `test non recording span`() {
+        val span = NonRecordingSpan(
+            FakeSpanContext(),
+            FakeSpanContext(),
+        )
+        assertTrue(span.links().isEmpty())
+        assertTrue(span.attributes().isEmpty())
+        assertTrue(span.events().isEmpty())
+        assertFalse(span.isRecording())
+    }
+}

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -39,6 +39,34 @@ public final class io/embrace/opentelemetry/kotlin/tracing/LinkImpl : io/embrace
 	public fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan : io/embrace/opentelemetry/kotlin/tracing/model/Span {
+	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)V
+	public fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
+	public fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
+	public fun attributes ()Ljava/util/Map;
+	public fun end ()V
+	public fun end (J)V
+	public fun events ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
+	public fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+	public fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+	public fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
+	public fun getStartTimestamp ()J
+	public fun getStatus ()Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
+	public fun isRecording ()Z
+	public fun links ()Ljava/util/List;
+	public fun setBooleanAttribute (Ljava/lang/String;Z)V
+	public fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public fun setDoubleAttribute (Ljava/lang/String;D)V
+	public fun setDoubleListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public fun setLongAttribute (Ljava/lang/String;J)V
+	public fun setLongListAttribute (Ljava/lang/String;Ljava/util/List;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setStatus (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)V
+	public fun setStringAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
+}
+
 public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteLogRecordImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord {
 	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/resource/Resource;Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
 	public fun attributes ()Ljava/util/Map;

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -1,0 +1,74 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.model.Link
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+/**
+ * A reference to a [Span] that cannot actively record any data. This can be useful for
+ * propagating traces where it's not necessary to mutate the span - e.g. if a caller only needs to
+ * know the trace/span IDs for a parent span.
+ */
+@OptIn(ExperimentalApi::class)
+public class NonRecordingSpan(
+    override val parent: SpanContext,
+    override val spanContext: SpanContext,
+) : Span {
+
+    override var name: String = ""
+    override var status: StatusCode = StatusCode.Unset
+    override val spanKind: SpanKind = SpanKind.INTERNAL
+    override val startTimestamp: Long = 0
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+    }
+
+    override fun end() {
+    }
+
+    override fun end(timestamp: Long) {
+    }
+
+    override fun isRecording(): Boolean = false
+
+    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
+    }
+
+    override fun addEvent(
+        name: String,
+        timestamp: Long?,
+        attributes: AttributeContainer.() -> Unit
+    ) {
+    }
+
+    override fun events(): List<SpanEvent> = emptyList()
+
+    override fun links(): List<Link> = emptyList()
+
+    override fun setStringAttribute(key: String, value: String) {
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+    }
+
+    override fun attributes(): Map<String, Any> = emptyMap()
+}


### PR DESCRIPTION
## Goal

Adds the concept of a non-recording span. This can be used to propagate traces, and more importantly, retrieve a `Span` implementation from a `SpanContext`.

## Testing

Added unit tests.