### PR TITLE
Implement storage of spans

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -69,8 +69,10 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextOtelJa
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtKt {
+	public static final fun fromContext (Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
 	public static final fun fromSpanContext (Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
 	public static final fun invalid (Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;)Lio/embrace/opentelemetry/kotlin/tracing/model/Span;
+	public static final fun storeInContext (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversionKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextAdapter.kt
@@ -9,7 +9,7 @@ import io.embrace.opentelemetry.kotlin.k2j.context.ContextKeyAdapter
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaContextAdapter(
-    private val impl: OtelJavaContext,
+    val impl: OtelJavaContext,
     private val repository: OtelJavaContextKeyRepository = OtelJavaContextKeyRepository.INSTANCE
 ) : Context {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExt.kt
@@ -3,10 +3,15 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
 import io.embrace.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.api.trace.otelJavaSpanContextKey
 
 private val invalidSpan = NonRecordingSpan(SpanContext.invalid(), SpanContext.invalid())
 
@@ -22,4 +27,23 @@ public fun Span.Companion.invalid(): Span = invalidSpan
 public fun Span.Companion.fromSpanContext(spanContext: SpanContext): Span = when {
     spanContext.isValid -> NonRecordingSpan(SpanContext.invalid(), spanContext)
     else -> invalid()
+}
+
+/**
+ * Returns a span from the supplied [Context], or the return value of [Span.Companion.invalid]
+ * if the [Context] has no span.
+ */
+public fun Span.Companion.fromContext(context: Context): Span {
+    val otelJavaCtx = (context as? OtelJavaContextAdapter)?.impl ?: OtelJavaContext.root()
+    val span: OtelJavaSpan = otelJavaCtx.get(otelJavaSpanContextKey) ?: OtelJavaSpan.getInvalid()
+    return NonRecordingSpan(SpanContext.invalid(), SpanContextAdapter(span.spanContext))
+}
+
+/**
+ * Stores a span in the supplied [Context], returning the new context.
+ */
+public fun Span.storeInContext(context: Context): Context {
+    val otelJavaCtx = (context as? OtelJavaContextAdapter)?.impl ?: OtelJavaContext.root()
+    val otelJavaSpan = this as? SpanAdapter ?: OtelJavaSpan.getInvalid()
+    return OtelJavaContextAdapter(otelJavaCtx.with(otelJavaSpan))
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/opentelemetry/api/trace/OtelJavaHooks.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/opentelemetry/api/trace/OtelJavaHooks.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.api.trace
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+
+internal val otelJavaSpanContextKey: OtelJavaContextKey<Span> = SpanContextKey.KEY

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtTest.kt
@@ -2,12 +2,21 @@ package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeClock
+import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeSpanContext
+import io.embrace.opentelemetry.kotlin.k2j.context.root
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.create
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.default
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 import kotlin.test.Test
@@ -15,6 +24,15 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
 internal class SpanExtTest {
+
+    private val generator = OtelJavaIdGenerator.random()
+
+    private val validSpanContext = SpanContext.create(
+        traceId = generator.generateTraceId(),
+        spanId = generator.generateSpanId(),
+        traceState = TraceState.default(),
+        traceFlags = TraceFlags.default()
+    )
 
     @Test
     fun `test invalid span`() {
@@ -25,16 +43,8 @@ internal class SpanExtTest {
 
     @Test
     fun `test from span context valid`() {
-        val generator = OtelJavaIdGenerator.random()
-        val spanContext = SpanContext.create(
-            traceId = generator.generateTraceId(),
-            spanId = generator.generateSpanId(),
-            traceState = TraceState.default(),
-            traceFlags = TraceFlags.default()
-        )
-
-        val span = Span.fromSpanContext(spanContext)
-        assertSpanContextsMatch(spanContext, span.spanContext)
+        val span = Span.fromSpanContext(validSpanContext)
+        assertSpanContextsMatch(validSpanContext, span.spanContext)
         assertSpanContextsMatch(SpanContext.invalid(), span.parent)
     }
 
@@ -42,5 +52,35 @@ internal class SpanExtTest {
     fun `test from span context invalid`() {
         val span = Span.fromSpanContext(SpanContext.invalid())
         assertEquals(Span.invalid(), span)
+    }
+
+    @Test
+    fun `test from context invalid`() {
+        val span = Span.fromContext(Context.root())
+        assertSpanContextsMatch(SpanContext.invalid(), span.spanContext)
+    }
+
+    @Test
+    fun `test from context valid`() {
+        val spanContext = OtelJavaSpanContext.create(
+            generator.generateTraceId(),
+            generator.generateSpanId(),
+            OtelJavaTraceFlags.getDefault(),
+            OtelJavaTraceState.getDefault()
+        )
+        val span = SpanAdapter(
+            OtelJavaSpan.wrap(spanContext),
+            FakeClock(),
+            FakeSpanContext(),
+            SpanKind.INTERNAL,
+            0
+        )
+        val root = Context.root()
+        val ctx = span.storeInContext(root)
+        val observed = Span.fromContext(root).spanContext
+        assertSpanContextsMatch(SpanContext.invalid(), observed)
+
+        val retrievedSpan = Span.fromContext(ctx)
+        assertSpanContextsMatch(SpanContextAdapter(spanContext), retrievedSpan.spanContext)
     }
 }


### PR DESCRIPTION
## Goal

Adds the ability to store spans in the Context, using the same key that opentelemetry-java uses.

## Testing

Added unit tests.
