### PR TITLE
Make ContextImpl internal

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextAdapterTest.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.k2j.context
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
-import io.embrace.opentelemetry.kotlin.context.ContextImpl
+import io.embrace.opentelemetry.kotlin.context.Context
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -14,7 +14,7 @@ internal class ContextAdapterTest {
     @Test
     fun `test context`() {
         val repository = ContextKeyRepository()
-        val ctx = ContextAdapter(ContextImpl(), repository)
+        val ctx = ContextAdapter(Context.root(), repository)
         val key1 = OtelJavaContextKey.named<String>("foo")
         val key2 = OtelJavaContextKey.named<String>("foo")
         val key3 = OtelJavaContextKey.named<String>("bar")

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -11,15 +11,6 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImplKt {
 	public static synthetic fun default$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/context/ContextImpl : io/embrace/opentelemetry/kotlin/context/Context {
-	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun createKey (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/context/ContextKey;
-	public fun get (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
-	public fun set (Lio/embrace/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/embrace/opentelemetry/kotlin/context/Context;
-}
-
 public final class io/embrace/opentelemetry/kotlin/context/ContextKeyImpl : io/embrace/opentelemetry/kotlin/context/ContextKey {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getName ()Ljava/lang/String;

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.context
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-public class ContextImpl(
+internal class ContextImpl(
     private val impl: Map<ContextKey<*>, Any> = mapOf()
 ) : Context {
 


### PR DESCRIPTION
## Goal

Don't allow `ContextImpl` to be created explicitly, but make users go through an existing `Context` object's factory methods 