### PR TITLE
[POC] Rework API to avoid extension functions on companion objects

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -301,6 +301,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Sp
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanContext$Companion {
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanContextFactory {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/model/TraceFlags;Lio/embrace/opentelemetry/kotlin/tracing/model/TraceState;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+	public abstract fun invalid ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+}
+
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanContextOrigin : java/lang/Enum {
 	public static final field LOCAL Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContextOrigin;
 	public static final field REMOTE Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContextOrigin;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FactoryProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FactoryProvider.kt
@@ -1,0 +1,8 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextFactory
+
+@ExperimentalApi
+public interface FactoryProvider {
+    public val spanContextFactory: SpanContextFactory
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanContextFactory.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanContextFactory.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+public interface SpanContextFactory {
+
+    /**
+     * Creates an invalid SpanContext.
+     */
+    public fun invalid(): SpanContext
+
+    /**
+     * Creates a new SpanContext.
+     */
+    public fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState
+    ): SpanContext
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2J.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceK2J.kt
@@ -10,6 +10,7 @@ import io.embrace.opentelemetry.kotlin.k2j.init.LoggerProviderConfigImpl
 import io.embrace.opentelemetry.kotlin.k2j.init.TracerProviderConfigImpl
 import io.embrace.opentelemetry.kotlin.k2j.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.model.createCompatFactoryProvider
 
 /**
  * Constructs an [OpenTelemetry] instance that decorates the OpenTelemetry Java SDK. This will not use the Kotlin
@@ -17,12 +18,16 @@ import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
  * OpenTelemetry Java SDK code that you don't want to rewrite, but still wish to use the Kotlin API.
  */
 @ExperimentalApi
-public fun OpenTelemetryInstance.compatWithOtelJava(impl: OtelJavaOpenTelemetry): OpenTelemetry {
+public fun OpenTelemetryInstance.compatWithOtelJava(
+    impl: OtelJavaOpenTelemetry,
+    factoryProvider: FactoryProvider = createCompatFactoryProvider(),
+): OpenTelemetry {
     val clock = ClockAdapter(OtelJavaClock.getDefault())
     return OpenTelemetrySdk(
         tracerProvider = TracerProviderAdapter(impl.tracerProvider, clock),
         loggerProvider = LoggerProviderAdapter(impl.logsBridge),
-        clock = clock
+        clock = clock,
+        factoryProvider = factoryProvider
     )
 }
 
@@ -35,6 +40,7 @@ public fun OpenTelemetryInstance.kotlinApi(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
+    factoryProvider: FactoryProvider = createCompatFactoryProvider(),
 ): OpenTelemetry {
     val tracerCfg = TracerProviderConfigImpl(clock).apply(tracerProvider)
     val loggerCfg = LoggerProviderConfigImpl(clock).apply(loggerProvider)
@@ -42,6 +48,7 @@ public fun OpenTelemetryInstance.kotlinApi(
     return OpenTelemetrySdk(
         tracerProvider = tracerCfg.build(),
         loggerProvider = loggerCfg.build(),
-        clock = clock
+        clock = clock,
+        factoryProvider = factoryProvider,
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/OpenTelemetrySdk.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.k2j
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.FactoryProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.k2j.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerProviderAdapter
@@ -14,11 +15,13 @@ internal class OpenTelemetrySdk(
     override val tracerProvider: TracerProvider,
     override val loggerProvider: LoggerProvider,
     override val clock: Clock,
+    private val factoryProvider: FactoryProvider,
 ) : OpenTelemetry {
 
-    constructor(impl: OtelJavaOpenTelemetry, clock: Clock) : this(
+    constructor(impl: OtelJavaOpenTelemetry, clock: Clock, factoryProvider: FactoryProvider) : this(
         TracerProviderAdapter(impl.tracerProvider, clock),
         LoggerProviderAdapter(impl.logsBridge),
-        clock
+        clock,
+        factoryProvider
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/model/CompatFactoryProvider.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/model/CompatFactoryProvider.kt
@@ -1,0 +1,13 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.FactoryProvider
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextFactory
+
+@OptIn(ExperimentalApi::class)
+internal class CompatFactoryProvider : FactoryProvider {
+    override val spanContextFactory: SpanContextFactory = SpanContextFactoryImpl()
+}
+
+@ExperimentalApi
+public fun createCompatFactoryProvider(): FactoryProvider = CompatFactoryProvider()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/model/SpanContextFactoryImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/model/SpanContextFactoryImpl.kt
@@ -1,0 +1,19 @@
+package io.embrace.opentelemetry.kotlin.k2j.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextFactory
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
+
+@OptIn(ExperimentalApi::class)
+internal class SpanContextFactoryImpl : SpanContextFactory {
+    override fun invalid(): SpanContext = SpanContext.Companion.invalid()
+
+    override fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState
+    ): SpanContext = SpanContext.Companion.create(traceId, spanId, traceFlags, traceState)
+}


### PR DESCRIPTION
## Goal

This changeset contains a POC of what our API could look like if we want to avoid extension functions on companion objects. There are several downsides to the extension function approach: it's not portable across modules, it's harder to test, and isn't particularly idiomatic Kotlin.

I've attempted to show a different approach, using `SpanContext.invalid()` as an example.

The first change is that end-users must explicitly specify a `FactoryProvider` when creating a new SDK instance. This is required as the SDK has no way to know whether a noop/Kotlin/compat implementation should be used. SPI could be used for this in Java but we shouldn't rely on this when designing the API as this is a KMP library. The only publicly accessible from implementation modules is a function returning a `FactoryProvider` instance:

```
val factoryProvider = compatFactoryProvider()
val api = OpenTelemetryInstance.kotlinApi(
    factoryProvider = factoryProvider
)
```

The SDK implementation can then propagate this `FactoryProvider` as needed internally, and end-users can invoke it as required:

```
val spanContext = factoryProvider.spanContextFactory.invalid()
```

I assume we could use this approach for invalid values, defaults, and constructing new valid objects. I'm not 100% convinced that the API is as concise or as idiomatic as it could be, but think we can work around this by taking some time to think of better names etc.


