### PR TITLE
[POC] Consolidate interfaces for Span to minimize duplicate definitions

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -236,16 +236,19 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/Lin
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanData {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanData : io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getEndTimestamp ()Ljava/lang/Long;
 	public abstract fun getEvents ()Ljava/util/List;
 	public abstract fun getHasEnded ()Z
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getLinks ()Ljava/util/List;
+	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
-	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
 	public abstract fun getStartTimestamp ()J
@@ -292,15 +295,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Re
 	public abstract fun toSpanData ()Lio/embrace/opentelemetry/kotlin/tracing/data/SpanData;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Span : io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Span : io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema, io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships {
 	public static final field Companion Lio/embrace/opentelemetry/kotlin/tracing/model/Span$Companion;
 	public abstract fun end ()V
 	public abstract fun end (J)V
 	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
-	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
-	public abstract fun getSpanKind ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
-	public abstract fun getStartTimestamp ()J
 	public abstract fun getStatus ()Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;
 	public abstract fun isRecording ()Z
 	public abstract fun setName (Ljava/lang/String;)V

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
@@ -2,77 +2,53 @@ package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.resource.Resource
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 /**
- * Immutable representation of a Span used for exporting
+ * A full representation of a span that contains all the data needed for exporting.
  */
 @ExperimentalApi
-public interface SpanData {
-    /**
-     * The span name
-     */
-    public val name: String
-
-    /**
-     * The span status
-     */
-    public val status: StatusData
-
-    /**
-     * The parent span context.
-     */
-    public val parent: SpanContext
-
-    /**
-     * The span context that uniquely identifies this span.
-     */
-    public val spanContext: SpanContext
-
-    /**
-     * The kind of this span
-     */
-    public val spanKind: SpanKind
-
-    /**
-     * The timestamp at which this span started, in nanoseconds.
-     */
-    public val startTimestamp: Long
-
+public interface SpanData : SpanSchema {
     /**
      * The timestamp at which this span ended, in nanoseconds. If it has not ended null will return.
      */
+    @ThreadSafe
     public val endTimestamp: Long?
 
     /**
      * A map of attributes associated with the span.
      */
+    @ThreadSafe
     public val attributes: Map<String, Any>
 
     /**
      * A list of events associated with the span.
      */
+    @ThreadSafe
     public val events: List<EventData>
 
     /**
      * A list of links associated with the span.
      */
+    @ThreadSafe
     public val links: List<LinkData>
 
     /**
      * The resource associated with the object
      */
+    @ThreadSafe
     public val resource: Resource
 
     /**
      * The instrumentation scope information associated with the object
      */
+    @ThreadSafe
     public val instrumentationScopeInfo: InstrumentationScopeInfo
 
     /**
      * Returns true if this span has ended.
      */
+    @ThreadSafe
     public val hasEnded: Boolean
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
@@ -1,0 +1,49 @@
+package io.embrace.opentelemetry.kotlin.tracing.data
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+/**
+ * The core set of properties exposed by all interfaces that present a span, excluding related and owned objects like attributes.
+ * Mutability of the properties will the determined by the underlying implementation.
+ */
+@ExperimentalApi
+public interface SpanSchema {
+    /**
+     * The span name
+     */
+    @ThreadSafe
+    public val name: String
+
+    /**
+     * The span status
+     */
+    @ThreadSafe
+    public val status: StatusData
+
+    /**
+     * The parent span context.
+     */
+    @ThreadSafe
+    public val parent: SpanContext
+
+    /**
+     * The span context that uniquely identifies this span.
+     */
+    @ThreadSafe
+    public val spanContext: SpanContext
+
+    /**
+     * The kind of this span
+     */
+    @ThreadSafe
+    public val spanKind: SpanKind
+
+    /**
+     * The timestamp at which this span started, in nanoseconds.
+     */
+    @ThreadSafe
+    public val startTimestamp: Long
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
@@ -9,7 +9,7 @@ import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 @ExperimentalApi
 public interface ReadableSpan : SpanData {
     /**
-     * Return an immutable instance of the span at the time of invocation.
+     * Return an instance of the span at the time of invocation. The implementation provided should be immutable.
      */
     public fun toSpanData(): SpanData
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.TracingDsl
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanSchema
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 /**
@@ -14,43 +15,19 @@ import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface Span : SpanRelationships {
+public interface Span : SpanSchema, SpanRelationships {
 
     /**
      * Sets the name of the span. Must be non-empty.
      */
     @ThreadSafe
-    public var name: String
+    public override var name: String
 
     /**
      * Sets the status of the span. This defaults to [StatusCode.Unset].
      */
     @ThreadSafe
-    public var status: StatusData
-
-    /**
-     * Gets the parent span context.
-     */
-    @ThreadSafe
-    public val parent: SpanContext
-
-    /**
-     * Gets the span context that uniquely identifies this span.
-     */
-    @ThreadSafe
-    public val spanContext: SpanContext
-
-    /**
-     * The kind of this span
-     */
-    @ThreadSafe
-    public val spanKind: SpanKind
-
-    /**
-     * The timestamp at which this span started, in nanoseconds.
-     */
-    @ThreadSafe
-    public val startTimestamp: Long
+    public override var status: StatusData
 
     /**
      * Ends the span.


### PR DESCRIPTION
Reduce property definitions to a single interface to be shared by `Span` and `SpanData`