### PR TITLE
[DO NOT MERGE] Allow descriptions on non-error Span Statuses

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -304,8 +304,12 @@ public abstract class io/embrace/opentelemetry/kotlin/tracing/data/StatusData {
 	public final fun getStatusCode ()Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
 }
 
+public final class io/embrace/opentelemetry/kotlin/tracing/data/StatusData$Custom : io/embrace/opentelemetry/kotlin/tracing/data/StatusData {
+	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;Ljava/lang/String;)V
+}
+
 public final class io/embrace/opentelemetry/kotlin/tracing/data/StatusData$Error : io/embrace/opentelemetry/kotlin/tracing/data/StatusData {
-	public fun <init> (Ljava/lang/String;)V
+	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData$Error;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/data/StatusData$Ok : io/embrace/opentelemetry/kotlin/tracing/data/StatusData {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
@@ -10,23 +10,29 @@ import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 @ExperimentalApi
 public sealed class StatusData(
     public val statusCode: StatusCode,
-    public val description: String?
+    public val description: String
 ) {
     /**
      * Default status.
      */
     @ThreadSafe
-    public object Unset : StatusData(StatusCode.Unset, null)
+    public object Unset : StatusData(StatusCode.Unset, "")
 
     /**
      * The operation completed successfully.
      */
     @ThreadSafe
-    public object Ok : StatusData(StatusCode.Ok, null)
+    public object Ok : StatusData(StatusCode.Ok, "")
 
     /**
-     * The operation completed with an error. An optional description of the error may be provided.
+     * The operation completed with an error.
      */
     @ThreadSafe
-    public class Error(description: String?) : StatusData(StatusCode.Error, description)
+    public object Error : StatusData(StatusCode.Error, "")
+
+    /**
+     * Create a custom status with a status code and description.
+     */
+    @ThreadSafe
+    public class Custom(statusCode: StatusCode, description: String) : StatusData(statusCode, description)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
@@ -16,5 +16,9 @@ public fun OtelJavaStatusCode.toOtelKotlin(): StatusCode = when (this) {
 public fun OtelJavaStatusCode.toOtelKotlinStatusData(description: String?): StatusData = when (this) {
     OtelJavaStatusCode.UNSET -> StatusData.Unset
     OtelJavaStatusCode.OK -> StatusData.Ok
-    OtelJavaStatusCode.ERROR -> StatusData.Error(description)
+    OtelJavaStatusCode.ERROR -> if (description.isNullOrEmpty()) {
+        StatusData.Error
+    } else {
+        StatusData.Custom(StatusCode.Error, description)
+    }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusDataConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusDataConversion.kt
@@ -3,12 +3,17 @@ package io.embrace.opentelemetry.kotlin.j2k.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 @OptIn(ExperimentalApi::class)
 internal fun OtelJavaStatusData.toOtelKotlin(): StatusData = when (statusCode) {
     OtelJavaStatusCode.UNSET -> StatusData.Unset
     OtelJavaStatusCode.OK -> StatusData.Ok
-    OtelJavaStatusCode.ERROR -> StatusData.Error(description)
+    OtelJavaStatusCode.ERROR -> if (description.isNullOrEmpty()) {
+        StatusData.Error
+    } else {
+        StatusData.Custom(StatusCode.Error, description)
+    }
     null -> StatusData.Unset
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -54,8 +54,14 @@ internal class SpanAdapter(
         get() = implStatus
         set(value) {
             implStatus = value
-            value.toOtelJava().let {
-                impl.setStatus(it.statusCode, it.description)
+            with(value) {
+                if (description.isEmpty()) {
+                    impl.setStatus(statusCode.toOtelJava())
+                } else {
+                    toOtelJava().let {
+                        impl.setStatus(it.statusCode, it.description)
+                    }
+                }
             }
         }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusDataConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusDataConversion.kt
@@ -1,13 +1,18 @@
 package io.embrace.opentelemetry.kotlin.k2j.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 @OptIn(ExperimentalApi::class)
-public fun StatusData.toOtelJava(): OtelJavaStatusData = when (this) {
-    StatusData.Unset -> OtelJavaStatusData.unset()
-    StatusData.Ok -> OtelJavaStatusData.ok()
-    is StatusData.Error -> OtelJavaStatusData.create(OtelJavaStatusCode.ERROR, description)
-}
+public fun StatusData.toOtelJava(): OtelJavaStatusData =
+    if (description.isEmpty()) {
+        when (statusCode) {
+            StatusCode.Unset -> OtelJavaStatusData.unset()
+            StatusCode.Ok -> OtelJavaStatusData.ok()
+            StatusCode.Error -> OtelJavaStatusData.error()
+        }
+    } else {
+        OtelJavaStatusData.create(statusCode.toOtelJava(), description)
+    }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
@@ -41,7 +41,7 @@ internal class OtelJavaSpanExporterAdapterTest {
 
         val observed = impl.exports.single()
         assertEquals(original.name, observed.name)
-        assertEquals(original.status.statusCode.toOtelJava(), observed.status.statusCode)
+        assertEquals(original.status.toOtelJava(), observed.status)
         assertEquals(original.parent.spanId, observed.parentSpanContext.spanId)
         assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
         assertEquals(original.spanKind.toOtelJava(), observed.kind)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -12,6 +12,7 @@ import io.embrace.opentelemetry.kotlin.k2j.framework.OtelKotlinHarness
 import io.embrace.opentelemetry.kotlin.k2j.framework.TestHarnessConfig
 import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.SerializableSpanContext
 import io.embrace.opentelemetry.kotlin.k2j.framework.serialization.conversion.toSerializable
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -70,8 +71,9 @@ internal class SpanExportTest {
         assertEquals(name, span.name)
 
         assertEquals(StatusData.Unset, span.status)
-        span.status = StatusData.Ok
-        assertEquals(StatusData.Ok, span.status)
+        span.status = StatusData.Custom(StatusCode.Ok, "aight")
+        assertEquals(StatusCode.Ok, span.status.statusCode)
+        assertEquals("aight", span.status.description)
 
         assertTrue(span.isRecording())
         span.end(1000)


### PR DESCRIPTION
Allow custom span statues to be set with any `StatusCode` and description. The description-less sealed classes are still available.