### PR TITLE
Add OtelJavaTracerBuilderAdapter

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaTracerBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaTracerBuilderAdapter.kt
@@ -1,0 +1,34 @@
+package io.embrace.opentelemetry.kotlin.j2k.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
+import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaTracerBuilderAdapter(
+    private val tracerProvider: TracerProvider,
+    private val instrumentationScopeName: String
+) : OtelJavaTracerBuilder {
+    private var instrumentationScopeVersion: String? = null
+    private var schemaUrl: String? = null
+
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): OtelJavaTracerBuilder {
+        this.instrumentationScopeVersion = instrumentationScopeVersion
+        return this
+    }
+
+    override fun setSchemaUrl(schemaUrl: String): OtelJavaTracerBuilder {
+        this.schemaUrl = schemaUrl
+        return this
+    }
+
+    override fun build(): OtelJavaTracer {
+        val tracer = tracerProvider.getTracer(
+            name = instrumentationScopeName,
+            version = instrumentationScopeVersion,
+            schemaUrl = schemaUrl
+        )
+        return OtelJavaTracerAdapter(tracer)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaTracerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaTracerProviderAdapter.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.j2k.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
@@ -18,5 +19,9 @@ internal class OtelJavaTracerProviderAdapter(
     override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): OtelJavaTracer {
         val tracer = tracerProvider.getTracer(instrumentationScopeName, instrumentationScopeVersion)
         return OtelJavaTracerAdapter(tracer)
+    }
+
+    override fun tracerBuilder(instrumentationScopeName: String): OtelJavaTracerBuilder {
+        return OtelJavaTracerBuilderAdapter(tracerProvider, instrumentationScopeName)
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanExportTest.kt
@@ -154,6 +154,31 @@ internal class OtelJavaSpanExportTest {
         )
     }
 
+    @Test
+    fun `test java tracer builder`() {
+        val javaTracer = tracerProvider.tracerBuilder("test-tracer")
+            .build()
+
+        val span = javaTracer.spanBuilder("tracer_builder_span").startSpan()
+        span.end()
+
+        harness.assertSpans(expectedCount = 1, goldenFileName = "span_tracer_builder.json")
+    }
+
+    @Test
+    fun `test java tracer with schema url and attributes`() {
+        val schemaUrl = "https://opentelemetry.io/schemas/1.21.0"
+        val javaTracerWithSchemaUrl = tracerProvider.tracerBuilder("test-tracer")
+            .setInstrumentationVersion("2.0.0")
+            .setSchemaUrl(schemaUrl)
+            .build()
+
+        val span = javaTracerWithSchemaUrl.spanBuilder("schema_url_span").startSpan()
+        span.end()
+
+        harness.assertSpans(expectedCount = 1, goldenFileName = "span_schema_url.json")
+    }
+
     private val attrs = OtelJavaAttributes.builder()
         .put("string_key", "value")
         .put("string_key", "second_value")

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "tracer_builder_span",
+    "kind": "INTERNAL",
+    "statusData": {
+      "name": "UNSET",
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "startTimestamp": 0,
+    "attributes": {},
+    "events": [],
+    "links": [],
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 0,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 0,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.52.0"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test-tracer",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    }
+  }
+]


### PR DESCRIPTION
## Summary
• Implement `OtelJavaTracerBuilderAdapter`.
• Add `tracerBuilder()` method to `OtelJavaTracerProviderAdapter` for Java API compatibility  
• Enable passing custom `schemaUrl` and `instrumentationScopeVersion` parameters
• Add tests


The use case is as follows: 

If we have an OTel Kotlin instance, but we want to wrap it in an `OtelJavaOpenTelemetry` instance, we can use `OpenTelemetryInstance.compatWithOtelKotlin`. 

Once we are left with that instance, we should be able to set up a custom tracerBuilder like this: 
```
 val schemaUrl = "https://opentelemetry.io/schemas/1.21.0"
 val javaTracerWithSchemaUrl = tracerProvider.tracerBuilder("test-tracer")
     .setInstrumentationVersion("2.0.0")
     .setSchemaUrl(schemaUrl)
     .build()
```

This would always leave us with a default tracer builder that results in `noop()`.

With these changes, we now wrap the kotlin tracerProvider instance, implementing the tracerBuilder() method that returns a OtelJavaTracerBuilderAdapter. This adapter allows configuration of instrumentation scope version and schema URL before building the final tracer instance.