### PR TITLE
Add context passing tests for spans

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LogExportTest.kt
@@ -102,10 +102,10 @@ internal class LogExportTest {
         )
 
         // Create a context key and add a test value
-        val rootContext = Context.Companion.current()
-        val contextKey = rootContext.createKey<String>("best_team")
+        val currentContext = Context.Companion.current()
+        val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
-        val testContext = rootContext.set(contextKey, testContextValue)
+        val testContext = currentContext.set(contextKey, testContextValue)
 
         // Log a message with the created context
         val logger = contextCapturingHarness.kotlinApi.loggerProvider.getLogger("test_logger")

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -5,6 +5,8 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.k2j.context.current
 import io.embrace.opentelemetry.kotlin.k2j.context.root
 import io.embrace.opentelemetry.kotlin.k2j.framework.OtelKotlinHarness
 import io.embrace.opentelemetry.kotlin.k2j.framework.TestHarnessConfig
@@ -14,6 +16,9 @@ import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import kotlin.test.BeforeTest
@@ -22,6 +27,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
@@ -387,5 +393,49 @@ internal class SpanExportTest {
             goldenFileName = "span_resource.json",
             sanitizeSpanContextIds = true,
         )
+    }
+
+    @Test
+    fun `test context is passed to processor`() {
+        // Create a SpanProcessor that captures any passed Context.
+        val contextCapturingProcessor = ContextCapturingProcessor()
+
+        // Use it on OpenTelemetryInstance creation.
+        val contextCapturingHarness = OtelKotlinHarness(
+            TestHarnessConfig(
+                spanProcessors = listOf(contextCapturingProcessor)
+            )
+        )
+
+        // Create a context key and add a test value
+        val currentContext = Context.Companion.current()
+        val contextKey = currentContext.createKey<String>("best_team")
+        val testContextValue = "independiente"
+        val testContext = currentContext.set(contextKey, testContextValue)
+
+        // Create a span with the created context
+        val tracer = contextCapturingHarness.kotlinApi.tracerProvider.getTracer("test_tracer")
+        tracer.createSpan("Test span with context", parentContext = testContext).end()
+
+        // Verify context was captured and contains expected value
+        val actualValue = contextCapturingProcessor.capturedContext?.get(contextKey)
+        assertSame(testContextValue, actualValue)
+    }
+
+    /**
+     * Custom processor that captures the context passed to onStart
+     */
+    private class ContextCapturingProcessor : SpanProcessor {
+        var capturedContext: Context? = null
+
+        override fun onStart(span: ReadWriteSpan, parentContext: Context) {
+            capturedContext = parentContext
+        }
+
+        override fun onEnd(span: ReadableSpan) = Unit
+        override fun isStartRequired(): Boolean = true
+        override fun isEndRequired(): Boolean = false
+        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 }


### PR DESCRIPTION
## Summary
- Add context passing test for Java spans in OtelJavaSpanExportTest
- Add context passing test for Kotlin spans in SpanExportTest
- Both tests verify that context is properly passed to span processors