### PR TITLE
Add ResourceConfigDsl

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -77,14 +77,17 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/LogLimitsCo
 	public abstract fun setAttributeValueLengthLimit (I)V
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl {
+public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl : io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun addLogRecordProcessor (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;)V
 	public abstract fun logLimits (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun resource (Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
 }
 
-public final class io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl$DefaultImpls {
-	public static synthetic fun resource$default (Lio/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)V
+public final class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl$DefaultImpls {
+	public static synthetic fun resource$default (Lio/embrace/opentelemetry/kotlin/init/ResourceConfigDsl;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigDsl {
@@ -100,14 +103,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/SpanLimitsC
 	public abstract fun setLinkCountLimit (I)V
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl {
+public abstract interface class io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl : io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun addSpanProcessor (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor;)V
-	public abstract fun resource (Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
 	public abstract fun spanLimits (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl$DefaultImpls {
-	public static synthetic fun resource$default (Lio/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/Logger {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
@@ -1,21 +1,14 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
-import io.embrace.opentelemetry.kotlin.resource.Resource
 
 /**
  * Defines configuration for the [io.embrace.opentelemetry.kotlin.logging.LoggerProvider].
  */
 @ExperimentalApi
 @ConfigDsl
-public interface LoggerProviderConfigDsl {
-
-    /**
-     * The [Resource] associated with this logger provider.
-     */
-    public fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String? = null)
+public interface LoggerProviderConfigDsl : ResourceConfigDsl {
 
     /**
      * Adds a [LogRecordProcessor] to the logger provider.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+@ExperimentalApi
+public interface ResourceConfigDsl {
+    public fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String? = null)
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
@@ -1,8 +1,6 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 /**
@@ -10,12 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
  */
 @ExperimentalApi
 @ConfigDsl
-public interface TracerProviderConfigDsl {
-
-    /**
-     * The [Resource] associated with this tracer provider.
-     */
-    public fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String? = null)
+public interface TracerProviderConfigDsl : ResourceConfigDsl {
 
     /**
      * The span limits configuration for this tracer provider.


### PR DESCRIPTION
## Goal

Add a common interface for both `LoggerProviderConfigDsl` and `TracerProviderConfigDsl`: `ResourceConfigDsl`. This lets us centralize the behavior and maintain it in just one place.

