### PR TITLE
Alter API for getting tracing ids

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -54,6 +54,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/creator/ContextC
 
 public abstract interface class io/embrace/opentelemetry/kotlin/creator/ObjectCreator {
 	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/creator/ContextCreator;
+	public abstract fun getIdCreator ()Lio/embrace/opentelemetry/kotlin/creator/TracingIdCreator;
 	public abstract fun getSpan ()Lio/embrace/opentelemetry/kotlin/creator/SpanCreator;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/creator/SpanContextCreator;
 	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/creator/TraceFlagsCreator;
@@ -77,6 +78,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/creator/TraceFla
 
 public abstract interface class io/embrace/opentelemetry/kotlin/creator/TraceStateCreator {
 	public abstract fun getDefault ()Lio/embrace/opentelemetry/kotlin/tracing/model/TraceState;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/creator/TracingIdCreator {
+	public abstract fun generateSpanId ()Ljava/lang/String;
+	public abstract fun generateTraceId ()Ljava/lang/String;
+	public abstract fun getInvalidSpanId ()Ljava/lang/String;
+	public abstract fun getInvalidTraceId ()Ljava/lang/String;
 }
 
 public abstract class io/embrace/opentelemetry/kotlin/export/OperationResultCode {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreator.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreator.kt
@@ -32,4 +32,9 @@ public interface ObjectCreator {
      * Factory that constructs Span objects.
      */
     public val span: SpanCreator
+
+    /**
+     * Factory that constructs tracing IDs.
+     */
+    public val idCreator: TracingIdCreator
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreator.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreator.kt
@@ -1,6 +1,9 @@
-package io.embrace.opentelemetry.kotlin.k2j.id
+package io.embrace.opentelemetry.kotlin.creator
 
-public interface TracingIdGenerator {
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+public interface TracingIdCreator {
 
     /**
      * Generates a new ID for a span.

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -37,23 +37,6 @@ public final class io/embrace/opentelemetry/kotlin/k2j/context/ContextExtKt {
 	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/opentelemetry/context/Context;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/k2j/id/TracingIdGenerator {
-	public abstract fun generateSpanId ()Ljava/lang/String;
-	public abstract fun generateTraceId ()Ljava/lang/String;
-	public abstract fun getInvalidSpanId ()Ljava/lang/String;
-	public abstract fun getInvalidTraceId ()Ljava/lang/String;
-}
-
-public final class io/embrace/opentelemetry/kotlin/k2j/id/TracingIdGeneratorImpl : io/embrace/opentelemetry/kotlin/k2j/id/TracingIdGenerator {
-	public fun <init> ()V
-	public fun <init> (Lio/opentelemetry/sdk/trace/IdGenerator;)V
-	public synthetic fun <init> (Lio/opentelemetry/sdk/trace/IdGenerator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun generateSpanId ()Ljava/lang/String;
-	public fun generateTraceId ()Ljava/lang/String;
-	public fun getInvalidSpanId ()Ljava/lang/String;
-	public fun getInvalidTraceId ()Ljava/lang/String;
-}
-
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/ContextKeyConversionKt {
 	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Lio/opentelemetry/context/ContextKey;
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
@@ -9,4 +9,5 @@ internal class CompatObjectCreator : ObjectCreator {
     override val traceState: TraceStateCreator by lazy { TraceStateCreatorImpl() }
     override val context: ContextCreator by lazy { ContextCreatorImpl() }
     override val span: SpanCreator by lazy { SpanCreatorImpl(spanContext) }
+    override val idCreator: TracingIdCreator by lazy { TracingIdCreatorImpl() }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImpl.kt
@@ -1,12 +1,14 @@
-package io.embrace.opentelemetry.kotlin.k2j.id
+package io.embrace.opentelemetry.kotlin.creator
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
 
-public class TracingIdGeneratorImpl(
+@OptIn(ExperimentalApi::class)
+internal class TracingIdCreatorImpl(
     private val generator: OtelJavaIdGenerator = OtelJavaIdGenerator.random()
-) : TracingIdGenerator {
+) : TracingIdCreator {
     override fun generateSpanId(): String = generator.generateSpanId()
     override fun generateTraceId(): String = generator.generateTraceId()
     override val invalidTraceId: String = OtelJavaTraceId.getInvalid()

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.k2j.id.TracingIdGeneratorImpl
 import org.junit.Test
 import kotlin.test.assertSame
 
@@ -17,7 +16,7 @@ internal class SpanContextCreatorImplTest {
 
     @Test
     fun `test valid`() {
-        val generator = TracingIdGeneratorImpl()
+        val generator = TracingIdCreatorImpl()
         val traceId = generator.generateTraceId()
         val spanId = generator.generateSpanId()
         val traceFlags = creator.traceFlags.default

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.k2j.id.TracingIdGeneratorImpl
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
@@ -26,7 +25,7 @@ internal class SpanCreatorImplTest {
 
     @Test
     fun `test from span context`() {
-        val generator = TracingIdGeneratorImpl()
+        val generator = TracingIdCreatorImpl()
         val spanContext = creator.spanContext.create(
             traceId = generator.generateTraceId(),
             spanId = generator.generateSpanId(),

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImplTest.kt
@@ -1,0 +1,29 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TracingIdCreatorImplTest {
+
+    private val creator = createCompatObjectCreator().idCreator
+
+    @Test
+    fun `test invalid`() {
+        assertEquals("00000000000000000000000000000000", creator.invalidTraceId)
+        assertEquals("0000000000000000", creator.invalidSpanId)
+    }
+
+    @Test
+    fun `test trace ID generation`() {
+        val traceId = creator.generateTraceId()
+        assertEquals(32, traceId.length)
+    }
+
+    @Test
+    fun `test span ID generation`() {
+        val spanId = creator.generateSpanId()
+        assertEquals(16, spanId.length)
+    }
+}

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/NoopObjectCreator.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/NoopObjectCreator.kt
@@ -9,4 +9,5 @@ internal object NoopObjectCreator : ObjectCreator {
     override val traceState: TraceStateCreator = NoopTraceStateCreator
     override val context: ContextCreator = NoopContextCreator
     override val span: SpanCreator = NoopSpanCreator
+    override val idCreator: TracingIdCreator = NoopTracingIdCreator
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/NoopTracingIdCreator.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/NoopTracingIdCreator.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+internal object NoopTracingIdCreator : TracingIdCreator {
+    override fun generateSpanId(): String = ""
+    override fun generateTraceId(): String = ""
+    override val invalidTraceId: String = ""
+    override val invalidSpanId: String = ""
+}


### PR DESCRIPTION
## Goal

Alters the API for getting tracing IDs to ensure that the API is defined in the API module, not just the compat module.