### PR TITLE
Rename conversion functions

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -18,40 +18,40 @@ public final class io/embrace/opentelemetry/kotlin/creator/ContextCreatorExtKt {
 }
 
 public final class io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/context/Context;)Lio/embrace/opentelemetry/kotlin/context/Context;
+	public static final fun toOtelKotlinContext (Lio/opentelemetry/context/Context;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }
 
 public final class io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static final fun toOtelKotlinLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/api/trace/SpanKind;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
+	public static final fun toOtelKotlinSpanKind (Lio/opentelemetry/api/trace/SpanKind;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
 }
 
 public final class io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/api/trace/StatusCode;)Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
+	public static final fun toOtelKotlinStatusCode (Lio/opentelemetry/api/trace/StatusCode;)Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
 	public static final fun toOtelKotlinStatusData (Lio/opentelemetry/api/trace/StatusCode;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;
 }
 
 public final class io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static final fun toOtelKotlinSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/context/ContextExtKt {
-	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/opentelemetry/context/Context;
+	public static final fun toOtelJavaContext (Lio/embrace/opentelemetry/kotlin/context/Context;)Lio/opentelemetry/context/Context;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/ContextKeyConversionKt {
-	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Lio/opentelemetry/context/ContextKey;
+	public static final fun toOtelJavaContextKey (Lio/embrace/opentelemetry/kotlin/context/ContextKey;)Lio/opentelemetry/context/ContextKey;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/OtelJavaSpanContextConversionKt {
-	public static final fun toOtelKotlin (Lio/opentelemetry/api/trace/SpanContext;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+	public static final fun toOtelKotlinSpanContext (Lio/opentelemetry/api/trace/SpanContext;)Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextConversionKt {
-	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/opentelemetry/api/trace/SpanContext;
+	public static final fun toOtelJavaSpanContext (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)Lio/opentelemetry/api/trace/SpanContext;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtKt {
@@ -59,10 +59,10 @@ public final class io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExtKt {
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversionKt {
-	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)Lio/opentelemetry/api/trace/StatusCode;
+	public static final fun toOtelJavaStatusCode (Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;)Lio/opentelemetry/api/trace/StatusCode;
 }
 
 public final class io/embrace/opentelemetry/kotlin/k2j/tracing/StatusDataConversionKt {
-	public static final fun toOtelJava (Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;)Lio/opentelemetry/sdk/trace/data/StatusData;
+	public static final fun toOtelJavaStatusData (Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;)Lio/opentelemetry/sdk/trace/data/StatusData;
 }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorExt.kt
@@ -3,10 +3,10 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlinContext
 
 /**
  * Retrieves the current Context.
  */
 @OptIn(ExperimentalApi::class)
-public fun ContextCreator.current(): Context = OtelJavaContext.current().toOtelKotlin()
+public fun ContextCreator.current(): Context = OtelJavaContext.current().toOtelKotlinContext()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImpl.kt
@@ -3,10 +3,10 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlinContext
 
 @OptIn(ExperimentalApi::class)
 internal class ContextCreatorImpl : ContextCreator {
 
-    override fun root(): Context = OtelJavaContext.root().toOtelKotlin()
+    override fun root(): Context = OtelJavaContext.root().toOtelKotlinContext()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImpl.kt
@@ -5,7 +5,8 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TraceFlagsAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TraceStateAdapter
-import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.SpanContextImpl
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
@@ -36,8 +37,8 @@ internal class SpanContextCreatorImpl : SpanContextCreator {
         OtelJavaSpanContext.create(
             traceId,
             spanId,
-            traceFlags.toOtelJava(),
-            traceState.toOtelJava()
+            traceFlags.toOtelJavaTraceFlags(),
+            traceState.toOtelJavaTraceState()
         )
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/InstrumentationScopeInfoExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/InstrumentationScopeInfoExt.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 
 @OptIn(ExperimentalApi::class)
-internal fun InstrumentationScopeInfo.toOtelJava(): OtelJavaInstrumentationScopeInfo {
+internal fun InstrumentationScopeInfo.toOtelJavaInstrumentationScopeInfo(): OtelJavaInstrumentationScopeInfo {
     val builder = OtelJavaInstrumentationScopeInfo.builder(name)
     version?.let(builder::setVersion)
     schemaUrl?.let(builder::setSchemaUrl)
@@ -16,7 +16,7 @@ internal fun InstrumentationScopeInfo.toOtelJava(): OtelJavaInstrumentationScope
 }
 
 @OptIn(ExperimentalApi::class)
-internal fun OtelJavaInstrumentationScopeInfo.toOtelKotlin(): InstrumentationScopeInfo =
+internal fun OtelJavaInstrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo(): InstrumentationScopeInfo =
     InstrumentationScopeInfoImpl(
         name = name,
         version = version,

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/bridge/context/OtelJavaContextConversion.kt
@@ -5,6 +5,6 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaContext.toOtelKotlin(): Context {
+public fun OtelJavaContext.toOtelKotlinContext(): Context {
     return OtelJavaContextAdapter(this)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLogRecordBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/OtelJavaLogRecordBuilderAdapter.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.j2k.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordBuilder
-import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlinContext
+import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelKotlinSeverityNumber
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Severity
@@ -75,8 +75,8 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
             body = body,
             timestamp = timestamp,
             observedTimestamp = observedTimestamp,
-            context = context?.toOtelKotlin(),
-            severityNumber = severity?.toOtelKotlin(),
+            context = context?.toOtelKotlinContext(),
+            severityNumber = severity?.toOtelKotlinSeverityNumber(),
             severityText = severityText,
         ) {
             attrs.forEach { setStringAttribute(it.key, it.value) }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordExporterConversion.kt
@@ -5,5 +5,5 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaLogRecordExporter.toOtelKotlin(): LogRecordExporter =
+public fun OtelJavaLogRecordExporter.toOtelKotlinLogRecordExporter(): LogRecordExporter =
     OtelJavaLogRecordExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/OtelJavaLogRecordProcessorAdapter.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.j2k.logging.export
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
-import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlinContext
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.context.Context
 
@@ -16,6 +16,6 @@ internal class OtelJavaLogRecordProcessorAdapter(
         context: Context,
         logRecord: OtelJavaReadWriteLogRecord
     ) {
-        impl.onEmit(ReadWriteLogRecordAdapter(logRecord), context.toOtelKotlin())
+        impl.onEmit(ReadWriteLogRecordAdapter(logRecord), context.toOtelKotlinContext())
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadWriteLogRecordAdapter.kt
@@ -6,8 +6,8 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.j2k.bridge.ResourceAdapter
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlinInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelKotlinSeverityNumber
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
@@ -32,7 +32,7 @@ internal class ReadWriteLogRecordAdapter(
         }
 
     override var severityNumber: SeverityNumber?
-        get() = impl.severity.toOtelKotlin()
+        get() = impl.severity.toOtelKotlinSeverityNumber()
         set(value) {}
 
     override var severityText: String?
@@ -93,5 +93,5 @@ internal class ReadWriteLogRecordAdapter(
         get() = ResourceAdapter(impl.toLogRecordData().resource)
 
     override val instrumentationScopeInfo: InstrumentationScopeInfo
-        get() = impl.instrumentationScopeInfo.toOtelKotlin()
+        get() = impl.instrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/logging/export/ReadableLogRecordExt.kt
@@ -8,9 +8,9 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaLogRecordDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
 import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelJava
-import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelJava
-import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJava
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.k2j.logging.toOtelJavaSeverityNumber
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.sdk.logs.data.Body
@@ -21,13 +21,13 @@ internal fun ReadableLogRecord.toLogRecordData(): LogRecordData {
     return OtelJavaLogRecordDataImpl(
         timestampNanos = timestamp ?: 0,
         observedTimestampNanos = observedTimestamp ?: 0,
-        spanContextImpl = spanContext.toOtelJava(),
+        spanContextImpl = spanContext.toOtelJavaSpanContext(),
         severityTextImpl = severityText,
-        severityImpl = severityNumber?.toOtelJava() ?: Severity.UNDEFINED_SEVERITY_NUMBER,
+        severityImpl = severityNumber?.toOtelJavaSeverityNumber() ?: Severity.UNDEFINED_SEVERITY_NUMBER,
         bodyImpl = body?.let(Body::string) ?: Body.empty(),
         attributesImpl = attrsFromMap(attributes),
         resourceImpl = resource?.let(::resourceFromMap) ?: OtelJavaResource.empty(),
-        scopeImpl = instrumentationScopeInfo?.toOtelJava()
+        scopeImpl = instrumentationScopeInfo?.toOtelJavaInstrumentationScopeInfo()
             ?: OtelJavaInstrumentationScopeInfo.empty()
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
-import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.recordException
 import io.opentelemetry.api.common.Attributes
@@ -93,7 +93,7 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, Impli
     }
 
     override fun getSpanContext(): OtelJavaSpanContext {
-        return span.spanContext.toOtelJava()
+        return span.spanContext.toOtelJavaSpanContext()
     }
 
     override fun isRecording(): Boolean = span.isRecording()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -93,7 +93,7 @@ internal class OtelJavaSpanBuilderAdapter(
     override fun startSpan(): OtelJavaSpan {
         val span = tracer.createSpan(
             name = spanName,
-            spanKind = kind.toOtelKotlin(),
+            spanKind = kind.toOtelKotlinSpanKind(),
             startTimestamp = start,
             parentContext = OtelJavaContextAdapter(parent ?: OtelJavaContext.current())
         ) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaSpanKindConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaSpanKind.toOtelKotlin(): SpanKind = when (this) {
+public fun OtelJavaSpanKind.toOtelKotlinSpanKind(): SpanKind = when (this) {
     OtelJavaSpanKind.INTERNAL -> SpanKind.INTERNAL
     OtelJavaSpanKind.CLIENT -> SpanKind.CLIENT
     OtelJavaSpanKind.SERVER -> SpanKind.SERVER

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusCodeConversion.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaStatusCode.toOtelKotlin(): StatusCode = when (this) {
+public fun OtelJavaStatusCode.toOtelKotlinStatusCode(): StatusCode = when (this) {
     OtelJavaStatusCode.UNSET -> StatusCode.Unset
     OtelJavaStatusCode.OK -> StatusCode.Ok
     OtelJavaStatusCode.ERROR -> StatusCode.Error

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusDataConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/OtelJavaStatusDataConversion.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 @OptIn(ExperimentalApi::class)
-internal fun OtelJavaStatusData.toOtelKotlin(): StatusData = when (statusCode) {
+internal fun OtelJavaStatusData.toOtelKotlinStatusData(): StatusData = when (statusCode) {
     OtelJavaStatusCode.UNSET -> StatusData.Unset
     OtelJavaStatusCode.OK -> StatusData.Ok
     OtelJavaStatusCode.ERROR -> StatusData.Error(description)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterConversion.kt
@@ -5,4 +5,4 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaSpanExporter.toOtelKotlin(): SpanExporter = OtelJavaSpanExporterAdapter(this)
+public fun OtelJavaSpanExporter.toOtelKotlinSpanExporter(): SpanExporter = OtelJavaSpanExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
-import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlinContext
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.context.Context
 
@@ -14,7 +14,7 @@ internal class OtelJavaSpanProcessorAdapter(
 ) : OtelJavaSpanProcessor {
 
     override fun onStart(parentContext: Context, span: OtelJavaReadWriteSpan) {
-        impl.onStart(ReadWriteSpanAdapter(span), parentContext.toOtelKotlin())
+        impl.onStart(ReadWriteSpanAdapter(span), parentContext.toOtelKotlinContext())
     }
 
     override fun onEnd(span: OtelJavaReadableSpan) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/ReadableSpanAdapter.kt
@@ -4,8 +4,9 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.j2k.bridge.ResourceAdapter
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlinInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlinSpanKind
+import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlinStatusData
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.data.EventDataAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.data.LinkDataAdapter
@@ -26,16 +27,16 @@ internal class ReadableSpanAdapter(
 ) : ReadableSpan {
     override val name: String = impl.name
     override val status: StatusData
-        get() = getSnapshot().status.toOtelKotlin()
+        get() = getSnapshot().status.toOtelKotlinStatusData()
     override val parent: SpanContext = SpanContextAdapter(impl.parentSpanContext)
     override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
-    override val spanKind: SpanKind = impl.kind.toOtelKotlin()
+    override val spanKind: SpanKind = impl.kind.toOtelKotlinSpanKind()
     override val startTimestamp: Long
         get() = getSnapshot().startEpochNanos
     override val endTimestamp: Long
         get() = getSnapshot().endEpochNanos
     override val resource: Resource = ResourceAdapter(getSnapshot().resource)
-    override val instrumentationScopeInfo: InstrumentationScopeInfo = impl.instrumentationScopeInfo.toOtelKotlin()
+    override val instrumentationScopeInfo: InstrumentationScopeInfo = impl.instrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo()
     override val attributes: Map<String, Any> = impl.attributes.toMap()
     override val events: List<EventData>
         get() = getSnapshot().events.map(::EventDataAdapter)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/SpanDataExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/SpanDataExt.kt
@@ -9,17 +9,19 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.j2k.bridge.OtelJavaSpanDataImpl
 import io.embrace.opentelemetry.kotlin.j2k.bridge.attrsFromMap
 import io.embrace.opentelemetry.kotlin.j2k.bridge.resourceFromMap
-import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 
 @OptIn(ExperimentalApi::class)
 internal fun SpanData.toOtelJavaSpanData(): OtelJavaSpanData {
     return OtelJavaSpanDataImpl(
         nameImpl = name,
-        statusImpl = OtelJavaStatusData.create(status.statusCode.toOtelJava(), status.description),
-        parentSpanContextImpl = parent.toOtelJava(),
-        spanContextImpl = spanContext.toOtelJava(),
-        kindImpl = spanKind.toOtelJava(),
+        statusImpl = OtelJavaStatusData.create(status.statusCode.toOtelJavaStatusCode(), status.description),
+        parentSpanContextImpl = parent.toOtelJavaSpanContext(),
+        spanContextImpl = spanContext.toOtelJavaSpanContext(),
+        kindImpl = spanKind.toOtelJavaSpanKind(),
         startEpochNanosImpl = startTimestamp,
         endEpochNanosImpl = endTimestamp ?: 0,
         resourceImpl = resource.let(::resourceFromMap),
@@ -38,7 +40,7 @@ internal fun SpanData.toOtelJavaSpanData(): OtelJavaSpanData {
         }.toMutableList(),
         linksImpl = links.map {
             OtelJavaLinkData.create(
-                it.spanContext.toOtelJava(),
+                it.spanContext.toOtelJavaSpanContext(),
                 attrsFromMap(it.attributes)
             )
         }.toMutableList(),

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/context/ContextExt.kt
@@ -8,6 +8,6 @@ import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.j2k.bridge.context.OtelJavaContextAdapter
 
 @OptIn(ExperimentalApi::class)
-public fun Context.toOtelJava(): OtelJavaContext {
+public fun Context.toOtelJavaContext(): OtelJavaContext {
     return (this as? OtelJavaContextAdapter)?.impl ?: ContextAdapter(this)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LoggerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/LoggerAdapter.kt
@@ -41,7 +41,7 @@ internal class LoggerAdapter(
             builder.setContext(ContextAdapter(context, contextKeyRepository))
         }
         if (severityNumber != null) {
-            builder.setSeverity(severityNumber.toOtelJava())
+            builder.setSeverity(severityNumber.toOtelJavaSeverityNumber())
         }
         if (severityText != null) {
             builder.setSeverityText(severityText)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/SeverityNumberConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/logging/SeverityNumberConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
 @OptIn(ExperimentalApi::class)
-internal fun SeverityNumber.toOtelJava(): OtelJavaSeverity = when (this) {
+internal fun SeverityNumber.toOtelJavaSeverityNumber(): OtelJavaSeverity = when (this) {
     SeverityNumber.UNKNOWN -> OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER
     SeverityNumber.TRACE -> OtelJavaSeverity.TRACE
     SeverityNumber.TRACE2 -> OtelJavaSeverity.TRACE2
@@ -34,7 +34,7 @@ internal fun SeverityNumber.toOtelJava(): OtelJavaSeverity = when (this) {
 }
 
 @OptIn(ExperimentalApi::class)
-internal fun OtelJavaSeverity.toOtelKotlin(): SeverityNumber = when (this) {
+internal fun OtelJavaSeverity.toOtelKotlinSeverityNumber(): SeverityNumber = when (this) {
     OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER -> SeverityNumber.UNKNOWN
     OtelJavaSeverity.TRACE -> SeverityNumber.TRACE
     OtelJavaSeverity.TRACE2 -> SeverityNumber.TRACE2

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/ContextKeyConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/ContextKeyConversion.kt
@@ -6,4 +6,4 @@ import io.embrace.opentelemetry.kotlin.context.ContextKey
 import io.embrace.opentelemetry.kotlin.k2j.context.ContextKeyAdapter
 
 @OptIn(ExperimentalApi::class)
-public fun <T> ContextKey<T>.toOtelJava(): OtelJavaContextKey<T> = (this as ContextKeyAdapter).impl
+public fun <T> ContextKey<T>.toOtelJavaContextKey(): OtelJavaContextKey<T> = (this as ContextKeyAdapter).impl

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/OtelJavaSpanContextConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/OtelJavaSpanContextConversion.kt
@@ -5,4 +5,4 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-public fun OtelJavaSpanContext.toOtelKotlin(): SpanContext = SpanContextAdapter(this)
+public fun OtelJavaSpanContext.toOtelKotlinSpanContext(): SpanContext = SpanContextAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanAdapter.kt
@@ -54,7 +54,7 @@ internal class SpanAdapter(
         get() = implStatus
         set(value) {
             implStatus = value
-            value.toOtelJava().let {
+            value.toOtelJavaStatusData().let {
                 impl.setStatus(it.statusCode, it.description)
             }
         }
@@ -75,7 +75,7 @@ internal class SpanAdapter(
         val container = AttributeContainerImpl()
         attributes(container)
         links.add(LinkImpl(spanContext, container))
-        impl.addLink(spanContext.toOtelJava(), container.otelJavaAttributes())
+        impl.addLink(spanContext.toOtelJavaSpanContext(), container.otelJavaAttributes())
     }
 
     override fun addEvent(

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanContextConversion.kt
@@ -6,12 +6,12 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-public fun SpanContext.toOtelJava(): OtelJavaSpanContext {
+public fun SpanContext.toOtelJavaSpanContext(): OtelJavaSpanContext {
     return OtelJavaImmutableSpanContext.create(
         traceId,
         spanId,
-        traceFlags.toOtelJava(),
-        traceState.toOtelJava(),
+        traceFlags.toOtelJavaTraceFlags(),
+        traceState.toOtelJavaTraceState(),
         isRemote,
         false
     )

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanKindConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 @OptIn(ExperimentalApi::class)
-internal fun SpanKind.toOtelJava(): OtelJavaSpanKind = when (this) {
+internal fun SpanKind.toOtelJavaSpanKind(): OtelJavaSpanKind = when (this) {
     SpanKind.INTERNAL -> OtelJavaSpanKind.INTERNAL
     SpanKind.CLIENT -> OtelJavaSpanKind.CLIENT
     SpanKind.SERVER -> OtelJavaSpanKind.SERVER

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusCodeConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
 @OptIn(ExperimentalApi::class)
-public fun StatusCode.toOtelJava(): OtelJavaStatusCode = when (this) {
+public fun StatusCode.toOtelJavaStatusCode(): OtelJavaStatusCode = when (this) {
     StatusCode.Unset -> OtelJavaStatusCode.UNSET
     StatusCode.Ok -> OtelJavaStatusCode.OK
     StatusCode.Error -> OtelJavaStatusCode.ERROR

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusDataConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/StatusDataConversion.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
 @OptIn(ExperimentalApi::class)
-public fun StatusData.toOtelJava(): OtelJavaStatusData = when (this) {
+public fun StatusData.toOtelJavaStatusData(): OtelJavaStatusData = when (this) {
     StatusData.Unset -> OtelJavaStatusData.unset()
     StatusData.Ok -> OtelJavaStatusData.ok()
     is StatusData.Error -> OtelJavaStatusData.create(OtelJavaStatusCode.ERROR, description)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceFlagsConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 
 @OptIn(ExperimentalApi::class)
-internal fun TraceFlags.toOtelJava(): OtelJavaTraceFlags {
+internal fun TraceFlags.toOtelJavaTraceFlags(): OtelJavaTraceFlags {
     val sb = StringBuilder()
     sb.append(if (isRandom) "1" else "0")
     sb.append(if (isSampled) "1" else "0")

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateConversion.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TraceStateConversion.kt
@@ -5,7 +5,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 
 @OptIn(ExperimentalApi::class)
-internal fun TraceState.toOtelJava(): OtelJavaTraceState {
+internal fun TraceState.toOtelJavaTraceState(): OtelJavaTraceState {
     return OtelJavaTraceState.builder().apply {
         asMap().entries.forEach {
             put(it.key, it.value)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/TracerAdapter.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.k2j.context.ContextAdapter
-import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
@@ -28,11 +28,11 @@ internal class TracerAdapter(
     ): Span {
         val start = startTimestamp ?: clock.now()
         val builder = tracer.spanBuilder(name)
-            .setSpanKind(spanKind.toOtelJava())
+            .setSpanKind(spanKind.toOtelJavaSpanKind())
             .setStartTimestamp(start, TimeUnit.NANOSECONDS)
 
         if (parentContext != null) {
-            builder.setParent(parentContext.toOtelJava())
+            builder.setParent(parentContext.toOtelJavaContext())
         } else {
             builder.setNoParent()
         }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/data/SpanDataAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/data/SpanDataAdapter.kt
@@ -4,8 +4,9 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.j2k.bridge.ResourceAdapter
-import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.j2k.bridge.toOtelKotlinInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlinSpanKind
+import io.embrace.opentelemetry.kotlin.j2k.tracing.toOtelKotlinStatusData
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
 import io.embrace.opentelemetry.kotlin.resource.Resource
@@ -21,16 +22,16 @@ internal class SpanDataAdapter(
     val impl: OtelJavaSpanData,
 ) : SpanData {
     override val name: String = impl.name
-    override val status: StatusData = impl.status.toOtelKotlin()
+    override val status: StatusData = impl.status.toOtelKotlinStatusData()
     override val parent: SpanContext = SpanContextAdapter(impl.parentSpanContext)
     override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
-    override val spanKind: SpanKind = impl.kind.toOtelKotlin()
+    override val spanKind: SpanKind = impl.kind.toOtelKotlinSpanKind()
     override val startTimestamp: Long = impl.startEpochNanos
     override val endTimestamp: Long? = impl.endEpochNanos
     override val attributes: Map<String, Any> = impl.attributes.toMap()
     override val events: List<EventData> = impl.events.map { EventDataAdapter(it) }
     override val links: List<LinkData> = impl.links.map { LinkDataAdapter(it) }
     override val resource: Resource = ResourceAdapter(impl.resource)
-    override val instrumentationScopeInfo: InstrumentationScopeInfo = impl.instrumentationScopeInfo.toOtelKotlin()
+    override val instrumentationScopeInfo: InstrumentationScopeInfo = impl.instrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo()
     override val hasEnded: Boolean = impl.hasEnded()
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJavaContext
 import org.junit.Test
 import kotlin.test.assertSame
 
@@ -13,11 +13,11 @@ internal class ContextCreatorImplTest {
 
     @Test
     fun `test root`() {
-        assertSame(OtelJavaContext.root(), creator.context.root().toOtelJava())
+        assertSame(OtelJavaContext.root(), creator.context.root().toOtelJavaContext())
     }
 
     @Test
     fun `test current`() {
-        assertSame(OtelJavaContext.current(), creator.context.current().toOtelJava())
+        assertSame(OtelJavaContext.current(), creator.context.current().toOtelJavaContext())
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/j2k/tracing/export/OtelJavaSpanExporterAdapterTest.kt
@@ -5,7 +5,8 @@ import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanExporter
 import io.embrace.opentelemetry.kotlin.fakes.otel.kotlin.FakeSpanData
 import io.embrace.opentelemetry.kotlin.k2j.tracing.toMap
-import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelJavaStatusCode
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -41,10 +42,10 @@ internal class OtelJavaSpanExporterAdapterTest {
 
         val observed = impl.exports.single()
         assertEquals(original.name, observed.name)
-        assertEquals(original.status.statusCode.toOtelJava(), observed.status.statusCode)
+        assertEquals(original.status.statusCode.toOtelJavaStatusCode(), observed.status.statusCode)
         assertEquals(original.parent.spanId, observed.parentSpanContext.spanId)
         assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
-        assertEquals(original.spanKind.toOtelJava(), observed.kind)
+        assertEquals(original.spanKind.toOtelJavaSpanKind(), observed.kind)
         assertEquals(original.startTimestamp, observed.startEpochNanos)
         assertEquals(original.attributes, observed.attributes.toMap())
         assertEquals(original.resource.attributes, observed.resource.attributes.toMap())

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/k2j/tracing/SpanExportTest.kt
@@ -164,7 +164,7 @@ internal class SpanExportTest {
     fun `test span trace flags`() {
         val span = tracer.createSpan("my_span")
         val flags = span.spanContext.traceFlags
-        assertEquals("01", flags.toOtelJava().asHex())
+        assertEquals("01", flags.toOtelJavaTraceFlags().asHex())
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
     }


### PR DESCRIPTION
## Goal

Renames conversion functions so that they include the returned type in the name, rather than just otelJava/otelKotlin - this was getting confusing with all the different functions with the same name.

