### PR TITLE
Setup code coverage

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Gradle Build
-        run: ./gradlew assembleRelease check --stacktrace
+        run: ./gradlew assembleRelease check koverXmlReport --stacktrace
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: embrace-io/opentelemetry-kotlin
+          fail_ci_if_error: false
+          files: build/reports/kover/reportRelease.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,31 @@ plugins {
     id("com.android.kotlin.multiplatform.library") apply false
     id("org.jetbrains.kotlin.multiplatform") apply false
     id("com.vanniktech.maven.publish") apply false
+    id("org.jetbrains.kotlinx.kover") version "0.9.1"
 }
 
 group = "io.embrace"
 version = project.version
+
+kover {
+    merge {
+        subprojects { project ->
+            val testCoverageProjects = listOf(
+                "opentelemetry-kotlin-api",
+                "opentelemetry-kotlin-api-ext",
+                "opentelemetry-kotlin-compat",
+                "opentelemetry-kotlin-implementation",
+                "opentelemetry-kotlin-noop",
+            )
+            return@subprojects testCoverageProjects.contains(project.name)
+        }
+    }
+    reports {
+        filters {
+            excludes {
+                androidGeneratedClasses()
+                classes("*.BuildConfig")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
@@ -10,6 +10,7 @@ class BuildPlugin : Plugin<Project> {
         val kotlin = project.project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         project.configureKotlin(kotlin)
         project.configureDetekt()
+        project.configureKover()
         project.configureBinaryCompatValidation()
         project.configureExplicitApiMode(kotlin)
         project.configurePublishing()

--- a/buildSrc/src/main/kotlin/io/embrace/otel/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KoverConfig.kt
@@ -1,0 +1,7 @@
+package io.embrace.otel
+
+import org.gradle.api.Project
+
+fun Project.configureKover() {
+    project.pluginManager.apply("org.jetbrains.kotlinx.kover")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ nexus = "2.0.0"
 junit4 = "4.13.2"
 junit5 = "5.13.4"
 kotlinExposed = "1.8.22"
+koverGradlePlugin = "0.9.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -36,3 +37,4 @@ vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }


### PR DESCRIPTION
## Goal

Sets up code coverage to run automatically on CI and upload to codecov. This can be run locally with `./gradlew koverHtmlReport`.

This _should_ start working on subsequent PRs once this PR is merged.
