### PR TITLE
Tweak codecov setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,14 +11,7 @@ version = project.version
 kover {
     merge {
         subprojects { project ->
-            val testCoverageProjects = listOf(
-                "opentelemetry-kotlin-api",
-                "opentelemetry-kotlin-api-ext",
-                "opentelemetry-kotlin-compat",
-                "opentelemetry-kotlin-implementation",
-                "opentelemetry-kotlin-noop",
-            )
-            return@subprojects testCoverageProjects.contains(project.name)
+            project.findProperty("io.embrace.enableCodeCoverage")?.toString()?.toBoolean() ?: true
         }
     }
     reports {

--- a/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/BuildPlugin.kt
@@ -10,7 +10,6 @@ class BuildPlugin : Plugin<Project> {
         val kotlin = project.project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         project.configureKotlin(kotlin)
         project.configureDetekt()
-        project.configureKover()
         project.configureBinaryCompatValidation()
         project.configureExplicitApiMode(kotlin)
         project.configurePublishing()

--- a/buildSrc/src/main/kotlin/io/embrace/otel/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KoverConfig.kt
@@ -1,7 +1,0 @@
-package io.embrace.otel
-
-import org.gradle.api.Project
-
-fun Project.configureKover() {
-    project.pluginManager.apply("org.jetbrains.kotlinx.kover")
-}

--- a/examples/android-app-java-api/gradle.properties
+++ b/examples/android-app-java-api/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/android-app-kotlin-api/gradle.properties
+++ b/examples/android-app-kotlin-api/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/example-shared/gradle.properties
+++ b/examples/example-shared/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/jvm-app-java-api/gradle.properties
+++ b/examples/jvm-app-java-api/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/jvm-app-kotlin-api/gradle.properties
+++ b/examples/jvm-app-kotlin-api/gradle.properties
@@ -1,2 +1,1 @@
-io.embrace.javaSdkCompatModule=true
 io.embrace.enableCodeCoverage=false

--- a/examples/telescope-app/gradle.properties
+++ b/examples/telescope-app/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+io.embrace.enableCodeCoverage=false

--- a/opentelemetry-java-typealiases/gradle.properties
+++ b/opentelemetry-java-typealiases/gradle.properties
@@ -1,2 +1,3 @@
 io.embrace.containsPublicApi=false
 io.embrace.javaSdkCompatModule=true
+io.embrace.enableCodeCoverage=false

--- a/opentelemetry-kotlin-api-ext/build.gradle.kts
+++ b/opentelemetry-kotlin-api-ext/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("io.embrace.otel.build-logic")
     id("signing")
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 kotlin {

--- a/opentelemetry-kotlin-api/build.gradle.kts
+++ b/opentelemetry-kotlin-api/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("io.embrace.otel.build-logic")
     id("signing")
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }

--- a/opentelemetry-kotlin-compat/build.gradle.kts
+++ b/opentelemetry-kotlin-compat/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("signing")
     id("com.vanniktech.maven.publish")
     alias(libs.plugins.kotlin.serialization)
+    id("org.jetbrains.kotlinx.kover")
 }
 
 kotlin {

--- a/opentelemetry-kotlin-implementation/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("io.embrace.otel.build-logic")
     id("signing")
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 kotlin {

--- a/opentelemetry-kotlin-noop/build.gradle.kts
+++ b/opentelemetry-kotlin-noop/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("io.embrace.otel.build-logic")
     id("signing")
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 kotlin {

--- a/opentelemetry-kotlin-testing/gradle.properties
+++ b/opentelemetry-kotlin-testing/gradle.properties
@@ -1,2 +1,3 @@
 io.embrace.containsPublicApi=false
+io.embrace.enableCodeCoverage=false
 io.embrace.javaSdkCompatModule=true


### PR DESCRIPTION
## Goal

Alters the setup of codecov so that adding a property to the gradle.properties of a module can disable it if needed. The `opentelemetry-kotlin-testing` and various other unwanted modules were reporting code coverage data, when we don't really mind about them given they're not production code.

