### PR TITLE
Consolidate interfaces of links, span events, and attributes

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -3,8 +3,8 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryExtKt {
 	public static final fun getTracer (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/Tracer;
 }
 
-public final class io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtKt {
-	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/Map;)V
+public final class io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerExtKt {
+	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer;Ljava/util/Map;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerExt.kt
@@ -4,14 +4,14 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
- * Sets attributes on an [AttributeContainer] from a [Map]. Only values in the map of a type supported by the
+ * Sets attributes on an [MutableAttributeContainer] from a [Map]. Only values in the map of a type supported by the
  * OpenTelemetry API will be set. Other values will be ignored.
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
 @ExperimentalApi
 @ThreadSafe
-public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
+public fun MutableAttributeContainer.setAttributes(attributes: Map<String, Any>) {
     attributes.forEach {
         when (val input = it.value) {
             is String -> setStringAttribute(it.key, input)
@@ -27,7 +27,7 @@ public fun AttributeContainer.setAttributes(attributes: Map<String, Any>) {
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(ExperimentalApi::class)
-private fun AttributeContainer.handleCollection(key: String, input: List<*>) {
+private fun MutableAttributeContainer.handleCollection(key: String, input: List<*>) {
     when {
         input.all { it is String } -> setStringListAttribute(key, input as List<String>)
         input.all { it is Boolean } -> setBooleanListAttribute(key, input as List<Boolean>)

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 
 /**
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.Span
  */
 @ExperimentalApi
 @ThreadSafe
-public fun Span.recordException(exception: Throwable, attributes: AttributeContainer.() -> Unit = {}) {
+public fun Span.recordException(exception: Throwable, attributes: MutableAttributeContainer.() -> Unit = {}) {
     addEvent("exception") {
         setStringAttribute("exception.stacktrace", exception.stackTraceToString())
         exception.message?.let {

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
@@ -9,7 +9,7 @@ internal class AttributeContainerExtTest {
 
     @Test
     fun `set attributes`() {
-        val attrs = FakeAttributeContainer()
+        val attrs = FakeMutableAttributeContainer()
         val input = mapOf(
             "string" to "value",
             "long" to 5L,
@@ -33,7 +33,7 @@ internal class AttributeContainerExtTest {
             "complex" to "ComplexObject"
         )
         attrs.setAttributes(input)
-        val observed = attrs.attributes()
+        val observed = attrs.attributes
         assertEquals(expected, observed)
     }
 
@@ -41,9 +41,9 @@ internal class AttributeContainerExtTest {
         override fun toString(): String = "ComplexObject"
     }
 
-    private class FakeAttributeContainer(
-        private val attributes: MutableMap<String, Any> = mutableMapOf()
-    ) : AttributeContainer {
+    private class FakeMutableAttributeContainer(
+        override val attributes: MutableMap<String, Any> = mutableMapOf()
+    ) : MutableAttributeContainer {
         override fun setBooleanAttribute(key: String, value: Boolean) {
             attributes[key] = value
         }
@@ -75,7 +75,5 @@ internal class AttributeContainerExtTest {
         override fun setDoubleListAttribute(key: String, value: List<Double>) {
             attributes[key] = value
         }
-
-        override fun attributes(): Map<String, Any> = attributes
     }
 }

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -44,10 +44,10 @@ internal class SpanExtTest {
         val exc = object : IllegalArgumentException() {}
         span.recordException(exc)
 
-        val event = span.events().single()
+        val event = span.events.single()
         assertEquals("exception", event.name)
 
-        val simpleAttrs = event.attributes()
+        val simpleAttrs = event.attributes
         assertEquals(1, simpleAttrs.size)
         assertNull(simpleAttrs["exception.type"])
         assertNotNull(simpleAttrs["exception.stacktrace"])

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -12,25 +12,25 @@ internal class SpanExtTest {
     @Test
     fun `record exception`() {
         val span = FakeSpan()
-        assertEquals(0, span.events().size)
+        assertEquals(0, span.events.size)
 
         span.recordException(IllegalArgumentException())
         span.recordException(IllegalStateException("Whoops!")) {
             setStringAttribute("extra", "value")
         }
-        val events = span.events()
+        val events = span.events
         assertEquals(2, events.size)
 
         val simple = events.first()
         assertEquals("exception", simple.name)
-        val simpleAttrs = simple.attributes()
+        val simpleAttrs = simple.attributes
         assertEquals(2, simpleAttrs.size)
         assertEquals("java.lang.IllegalArgumentException", simpleAttrs["exception.type"])
         assertNotNull(simpleAttrs["exception.stacktrace"])
 
         val complex = events.last()
         assertEquals("exception", complex.name)
-        val complexAttrs = complex.attributes()
+        val complexAttrs = complex.attributes
         assertEquals(4, complexAttrs.size)
         assertEquals("java.lang.IllegalStateException", complexAttrs["exception.type"])
         assertEquals("Whoops!", complexAttrs["exception.message"])

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -273,14 +273,14 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/Lin
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanData : io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getEndTimestamp ()Ljava/lang/Long;
-	public abstract fun getEvents ()Ljava/util/List;
 	public abstract fun getHasEnded ()Z
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
-	public abstract fun getLinks ()Ljava/util/List;
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
+	public abstract fun getEvents ()Ljava/util/List;
+	public abstract fun getLinks ()Ljava/util/List;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
@@ -318,8 +318,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/S
 	public abstract fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
-	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/LinkData {
+	public abstract fun getAttributes ()Ljava/util/Map;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/model/Link$DefaultImpls {
+	public static fun getAttributes (Lio/embrace/opentelemetry/kotlin/tracing/model/Link;)Ljava/util/Map;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan : io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan, io/embrace/opentelemetry/kotlin/tracing/model/Span {
@@ -348,9 +352,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Sp
 	public abstract fun isValid ()Z
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
-	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun getTimestamp ()J
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/EventData {
+	public abstract fun getAttributes ()Ljava/util/Map;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent$DefaultImpls {
+	public static fun getAttributes (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanEvent;)Ljava/util/Map;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanKind : java/lang/Enum {
@@ -366,8 +373,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanKind : java
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
-	public abstract fun events ()Ljava/util/List;
-	public abstract fun links ()Ljava/util/List;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships$DefaultImpls {

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -27,7 +27,10 @@ public abstract interface annotation class io/embrace/opentelemetry/kotlin/Threa
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
-	public abstract fun attributes ()Ljava/util/Map;
+	public abstract fun getAttributes ()Ljava/util/Map;
+}
+
+public abstract interface class io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -168,7 +171,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/L
 	public abstract fun onEmit (Lio/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
+public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getBody ()Ljava/lang/String;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getSeverityNumber ()Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;
@@ -259,26 +262,23 @@ public final class io/embrace/opentelemetry/kotlin/tracing/TracerProvider$Defaul
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/tracing/TracingDsl : java/lang/annotation/Annotation {
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/EventData {
-	public abstract fun getAttributes ()Ljava/util/Map;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/EventData : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getTimestamp ()J
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/LinkData {
-	public abstract fun getAttributes ()Ljava/util/Map;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/LinkData : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanData : io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
-	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getEndTimestamp ()Ljava/lang/Long;
 	public abstract fun getHasEnded ()Z
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getEvents ()Ljava/util/List;
 	public abstract fun getLinks ()Ljava/util/List;
 	public abstract fun getName ()Ljava/lang/String;
@@ -318,12 +318,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/export/S
 	public abstract fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Link : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/LinkData {
-	public abstract fun getAttributes ()Ljava/util/Map;
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/model/Link$DefaultImpls {
-	public static fun getAttributes (Lio/embrace/opentelemetry/kotlin/tracing/model/Link;)Ljava/util/Map;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Link : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/LinkData {
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan : io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan, io/embrace/opentelemetry/kotlin/tracing/model/Span {
@@ -352,12 +347,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/Sp
 	public abstract fun isValid ()Z
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/EventData {
-	public abstract fun getAttributes ()Ljava/util/Map;
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent$DefaultImpls {
-	public static fun getAttributes (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanEvent;)Ljava/util/Map;
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/tracing/data/EventData {
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanKind : java/lang/Enum {
@@ -370,7 +360,7 @@ public final class io/embrace/opentelemetry/kotlin/tracing/model/SpanKind : java
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/model/SpanKind;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer {
+public abstract interface class io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -4,65 +4,16 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
- * Implementations of this interface hold 'attributes' as described in the OTel specification.
+ * Implementations of this interface returns a read-only snapshot of the 'attributes' as described in the OTel specification.
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
 @ExperimentalApi
 @ThreadSafe
 public interface AttributeContainer {
-
-    /**
-     * Sets an attribute with a boolean value.
-     */
-    @ThreadSafe
-    public fun setBooleanAttribute(key: String, value: Boolean)
-
-    /**
-     * Sets an attribute with a string value.
-     */
-    @ThreadSafe
-    public fun setStringAttribute(key: String, value: String)
-
-    /**
-     * Sets an attribute with a long value.
-     */
-    @ThreadSafe
-    public fun setLongAttribute(key: String, value: Long)
-
-    /**
-     * Sets an attribute with a double value.
-     */
-    @ThreadSafe
-    public fun setDoubleAttribute(key: String, value: Double)
-
-    /**
-     * Sets an attribute with a list of boolean values.
-     */
-    @ThreadSafe
-    public fun setBooleanListAttribute(key: String, value: List<Boolean>)
-
-    /**
-     * Sets an attribute with a list of string values.
-     */
-    @ThreadSafe
-    public fun setStringListAttribute(key: String, value: List<String>)
-
-    /**
-     * Sets an attribute with a list of long values.
-     */
-    @ThreadSafe
-    public fun setLongListAttribute(key: String, value: List<Long>)
-
-    /**
-     * Sets an attribute with a list of double values.
-     */
-    @ThreadSafe
-    public fun setDoubleListAttribute(key: String, value: List<Double>)
-
     /**
      * Returns a snapshot of the attributes as a map.
      */
     @ThreadSafe
-    public fun attributes(): Map<String, Any>
+    public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer.kt
@@ -1,0 +1,62 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Implementations of this interface hold 'attributes' as described in the OTel specification.
+ *
+ * https://opentelemetry.io/docs/specs/otel/common/#attribute
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface MutableAttributeContainer : AttributeContainer {
+
+    /**
+     * Sets an attribute with a boolean value.
+     */
+    @ThreadSafe
+    public fun setBooleanAttribute(key: String, value: Boolean)
+
+    /**
+     * Sets an attribute with a string value.
+     */
+    @ThreadSafe
+    public fun setStringAttribute(key: String, value: String)
+
+    /**
+     * Sets an attribute with a long value.
+     */
+    @ThreadSafe
+    public fun setLongAttribute(key: String, value: Long)
+
+    /**
+     * Sets an attribute with a double value.
+     */
+    @ThreadSafe
+    public fun setDoubleAttribute(key: String, value: Double)
+
+    /**
+     * Sets an attribute with a list of boolean values.
+     */
+    @ThreadSafe
+    public fun setBooleanListAttribute(key: String, value: List<Boolean>)
+
+    /**
+     * Sets an attribute with a list of string values.
+     */
+    @ThreadSafe
+    public fun setStringListAttribute(key: String, value: List<String>)
+
+    /**
+     * Sets an attribute with a list of long values.
+     */
+    @ThreadSafe
+    public fun setLongListAttribute(key: String, value: List<Long>)
+
+    /**
+     * Sets an attribute with a list of double values.
+     */
+    @ThreadSafe
+    public fun setDoubleListAttribute(key: String, value: List<Double>)
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -1,9 +1,9 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @ExperimentalApi
 public interface ResourceConfigDsl {
-    public fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String? = null)
+    public fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String? = null)
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
@@ -33,6 +33,6 @@ public interface Logger {
         context: Context? = null,
         severityNumber: SeverityNumber? = null,
         severityText: String? = null,
-        attributes: AttributeContainer.() -> Unit = {},
+        attributes: MutableAttributeContainer.() -> Unit = {},
     )
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProvider.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 /**
  * Provider for retrieving [Logger] instances.
@@ -24,6 +24,6 @@ public interface LoggerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: AttributeContainer.() -> Unit = {},
+        attributes: MutableAttributeContainer.() -> Unit = {},
     ): Logger
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
  * https://opentelemetry.io/docs/specs/otel/logs/sdk/#readablelogrecord
  */
 @ExperimentalApi
-public interface ReadWriteLogRecord : ReadableLogRecord, AttributeContainer {
+public interface ReadWriteLogRecord : ReadableLogRecord, MutableAttributeContainer {
 
     /**
      * The timestamp in nanoseconds at which the event occurred.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 /**
  * TracerProvider is a factory for retrieving instances of [Tracer].
@@ -24,6 +24,6 @@ public interface TracerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: AttributeContainer.() -> Unit = {},
+        attributes: MutableAttributeContainer.() -> Unit = {},
     ): Tracer
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
@@ -2,12 +2,13 @@ package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 
 /**
  * A read-only representation of a span event
  */
 @ExperimentalApi
-public interface EventData {
+public interface EventData : AttributeContainer {
     /**
      * The name of the event
      */
@@ -19,10 +20,4 @@ public interface EventData {
      */
     @ThreadSafe
     public val timestamp: Long
-
-    /**
-     * The attributes associated with the event.
-     */
-    @ThreadSafe
-    public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 
 /**
  * A read-only representation of a span event
@@ -10,15 +11,18 @@ public interface EventData {
     /**
      * The name of the event
      */
+    @ThreadSafe
     public val name: String
 
     /**
      * The timestamp of the event in nanoseconds
      */
+    @ThreadSafe
     public val timestamp: Long
 
     /**
      * The attributes associated with the event.
      */
+    @ThreadSafe
     public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
@@ -2,22 +2,17 @@ package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
  * A read-only representation of a Link
  */
 @ExperimentalApi
-public interface LinkData {
+public interface LinkData : AttributeContainer {
     /**
      * The span context of the link.
      */
     @ThreadSafe
     public val spanContext: SpanContext
-
-    /**
-     * The attributes associated with the link.
-     */
-    @ThreadSafe
-    public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
@@ -11,10 +12,12 @@ public interface LinkData {
     /**
      * The span context of the link.
      */
+    @ThreadSafe
     public val spanContext: SpanContext
 
     /**
      * The attributes associated with the link.
      */
+    @ThreadSafe
     public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
@@ -23,18 +23,6 @@ public interface SpanData : SpanSchema {
     public val attributes: Map<String, Any>
 
     /**
-     * A list of events associated with the span.
-     */
-    @ThreadSafe
-    public val events: List<EventData>
-
-    /**
-     * A list of links associated with the span.
-     */
-    @ThreadSafe
-    public val links: List<LinkData>
-
-    /**
      * The resource associated with the object
      */
     @ThreadSafe

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
@@ -17,12 +17,6 @@ public interface SpanData : SpanSchema {
     public val endTimestamp: Long?
 
     /**
-     * A map of attributes associated with the span.
-     */
-    @ThreadSafe
-    public val attributes: Map<String, Any>
-
-    /**
      * The resource associated with the object
      */
     @ThreadSafe

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
@@ -46,4 +46,16 @@ public interface SpanSchema {
      */
     @ThreadSafe
     public val startTimestamp: Long
+
+    /**
+     * A list of events associated with the span.
+     */
+    @ThreadSafe
+    public val events: List<EventData>
+
+    /**
+     * A list of links associated with the span.
+     */
+    @ThreadSafe
+    public val links: List<LinkData>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing.data
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
@@ -10,7 +11,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  * Mutability of the properties will the determined by the underlying implementation.
  */
 @ExperimentalApi
-public interface SpanSchema {
+public interface SpanSchema : AttributeContainer {
     /**
      * The span name
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Link.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Link.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 
 /**
  * Represents a link to a [SpanContext] and optional attributes further describing the link.
@@ -11,11 +12,7 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  */
 @ExperimentalApi
 @ThreadSafe
-public interface Link : AttributeContainer {
-
-    /**
-     * The [SpanContext] of the linked span.
-     */
-    @ThreadSafe
-    public val spanContext: SpanContext
+public interface Link : LinkData, AttributeContainer {
+    override val attributes: Map<String, Any>
+        get() = attributes()
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Link.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Link.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 
 /**
@@ -12,7 +12,4 @@ import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
  */
 @ExperimentalApi
 @ThreadSafe
-public interface Link : LinkData, AttributeContainer {
-    override val attributes: Map<String, Any>
-        get() = attributes()
-}
+public interface Link : LinkData, MutableAttributeContainer

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.TracingDsl
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 
@@ -14,7 +14,4 @@ import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface SpanEvent : EventData, AttributeContainer {
-    override val attributes: Map<String, Any>
-        get() = attributes()
-}
+public interface SpanEvent : EventData, MutableAttributeContainer

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.TracingDsl
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 
 /**
  * Represents an event that happened on a span
@@ -13,17 +14,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracingDsl
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface SpanEvent : AttributeContainer {
-
-    /**
-     * The name of the event
-     */
-    @ThreadSafe
-    public val name: String
-
-    /**
-     * The timestamp of the event in nanoseconds
-     */
-    @ThreadSafe
-    public val timestamp: Long
+public interface SpanEvent : EventData, AttributeContainer {
+    override val attributes: Map<String, Any>
+        get() = attributes()
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.ThreadSafe
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 /**
  * Provides operations that add relationships (events + links) to a span
@@ -10,13 +10,13 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  * https://opentelemetry.io/docs/specs/otel/trace/api/
  */
 @ExperimentalApi
-public interface SpanRelationships : AttributeContainer {
+public interface SpanRelationships : MutableAttributeContainer {
 
     /**
      * Adds a link to the span that associates it with another [SpanContext].
      */
     @ThreadSafe
-    public fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit = {})
+    public fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit = {})
 
     /**
      * Adds an event to the span.
@@ -25,6 +25,6 @@ public interface SpanRelationships : AttributeContainer {
     public fun addEvent(
         name: String,
         timestamp: Long? = null,
-        attributes: AttributeContainer.() -> Unit = {},
+        attributes: MutableAttributeContainer.() -> Unit = {},
     )
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
@@ -27,16 +27,4 @@ public interface SpanRelationships : AttributeContainer {
         timestamp: Long? = null,
         attributes: AttributeContainer.() -> Unit = {},
     )
-
-    /**
-     * Returns a snapshot of the events on this span.
-     */
-    @ThreadSafe
-    public fun events(): List<SpanEvent>
-
-    /**
-     * Returns a snapshot of the links on this span.
-     */
-    @ThreadSafe
-    public fun links(): List<Link>
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
@@ -6,9 +6,9 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributesBuilder
 
 @OptIn(ExperimentalApi::class)
-internal class AttributeContainerImpl(
+internal class MutableAttributeContainerImpl(
     private val attrs: OtelJavaAttributesBuilder = OtelJavaAttributes.builder()
-) : AttributeContainer {
+) : MutableAttributeContainer {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         attrs.put(key, value)
@@ -42,7 +42,8 @@ internal class AttributeContainerImpl(
         attrs.put(OtelJavaAttributeKey.doubleArrayKey(key), value)
     }
 
-    override fun attributes(): Map<String, Any> = attrs.build().toMap()
+    override val attributes: Map<String, Any>
+        get() = attrs.build().toMap()
 
     fun otelJavaAttributes(): OtelJavaAttributes = attrs.build()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -3,8 +3,8 @@ package io.embrace.opentelemetry.kotlin.init
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -23,8 +23,8 @@ internal class LoggerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String?) {
-        val attrs = AttributeContainerImpl().apply(attributes).otelJavaAttributes()
+    override fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String?) {
+        val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs, schemaUrl))
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -3,8 +3,8 @@ package io.embrace.opentelemetry.kotlin.init
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
 import io.embrace.opentelemetry.kotlin.tracing.export.OtelJavaSpanProcessorAdapter
@@ -23,8 +23,8 @@ internal class TracerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(attributes: AttributeContainer.() -> Unit, schemaUrl: String?) {
-        val attrs = AttributeContainerImpl().apply(attributes).otelJavaAttributes()
+    override fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String?) {
+        val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs, schemaUrl))
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -2,8 +2,8 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogger
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.OtelJavaContextAdapter
 import io.embrace.opentelemetry.kotlin.context.OtelJavaContextKeyRepository
@@ -23,7 +23,7 @@ internal class LoggerAdapter(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ) {
         val builder = impl.logRecordBuilder()
 
@@ -46,7 +46,7 @@ internal class LoggerAdapter(
             builder.setSeverityText(severityText)
         }
 
-        val container = AttributeContainerImpl()
+        val container = MutableAttributeContainerImpl()
         attributes(container)
         builder.setAllAttributes(container.otelJavaAttributes())
         builder.emit()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
@@ -14,7 +14,7 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Logger {
         val key = name.plus(version).plus(schemaUrl)
         return map.getOrPut(key) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -77,8 +77,6 @@ internal class ReadWriteLogRecordAdapter(
         impl.setAttribute(OtelJavaAttributeKey.doubleArrayKey(key), value)
     }
 
-    override fun attributes(): Map<String, Any> = impl.attributes.toMap()
-
     override val attributes: Map<String, Any>
         get() = impl.attributes.toMap()
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
@@ -18,7 +18,7 @@ internal class TracerProviderAdapter(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Tracer {
         val key = name.plus(version).plus(schemaUrl)
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -2,9 +2,8 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
-import io.embrace.opentelemetry.kotlin.attributes.toMap
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.TimeUnit
@@ -36,15 +35,15 @@ internal class ReadWriteSpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
-        val container = AttributeContainerImpl()
+    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
+        val container = MutableAttributeContainerImpl()
         attributes(container)
         val ctx = (spanContext as SpanContextAdapter).impl
         impl.addLink(ctx, container.otelJavaAttributes())
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
-        val container = AttributeContainerImpl()
+    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
+        val container = MutableAttributeContainerImpl()
         attributes(container)
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)
     }
@@ -80,6 +79,4 @@ internal class ReadWriteSpanAdapter(
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
         impl.setAttribute(AttributeKey.doubleArrayKey(key), value)
     }
-
-    override fun attributes(): Map<String, Any> = impl.attributes.toMap()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -4,10 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
-import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.embrace.opentelemetry.kotlin.attributes.toMap
-import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
-import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.TimeUnit
@@ -50,25 +47,6 @@ internal class ReadWriteSpanAdapter(
         val container = AttributeContainerImpl()
         attributes(container)
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)
-    }
-
-    override fun events(): List<SpanEvent> = readableSpan.events.map {
-        SpanEventImpl(
-            name = it.name,
-            timestamp = it.timestamp,
-            attributes = AttributeContainerImpl().apply {
-                setAttributes(it.attributes)
-            }
-        )
-    }
-
-    override fun links(): List<Link> = readableSpan.links.map {
-        LinkImpl(
-            spanContext = it.spanContext,
-            attributes = AttributeContainerImpl().apply {
-                setAttributes(it.attributes)
-            }
-        )
     }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -6,8 +6,8 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
 import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
@@ -61,6 +61,9 @@ internal class SpanAdapter(
 
     override val spanContext: SpanContext = SpanContextAdapter(impl.spanContext)
 
+    override val attributes: Map<String, Any>
+        get() = attrs.toMap()
+
     override val events: List<EventData>
         get() = eventsImpl.toList()
 
@@ -77,8 +80,8 @@ internal class SpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
-        val container = AttributeContainerImpl()
+    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
+        val container = MutableAttributeContainerImpl()
         attributes(container)
         linksImpl.add(LinkImpl(spanContext, container))
         impl.addLink(spanContext.toOtelJavaSpanContext(), container.otelJavaAttributes())
@@ -87,9 +90,9 @@ internal class SpanAdapter(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ) {
-        val container = AttributeContainerImpl()
+        val container = MutableAttributeContainerImpl()
         attributes(container)
         val time = timestamp ?: clock.now()
         eventsImpl.add(SpanEventImpl(name, time, container))
@@ -135,8 +138,6 @@ internal class SpanAdapter(
         impl.setAttribute(OtelJavaAttributeKey.doubleArrayKey(key), value)
         attrs[key] = value
     }
-
-    override fun attributes(): Map<String, Any> = attrs.toMap()
 
     override fun storeInContext(context: Context): Context? {
         return impl.storeInContext(context)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/TestHarnessConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/TestHarnessConfig.kt
@@ -1,14 +1,14 @@
 package io.embrace.opentelemetry.kotlin.framework
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 @OptIn(ExperimentalApi::class)
 internal data class TestHarnessConfig(
     val schemaUrl: String? = null,
-    val attributes: (AttributeContainer.() -> Unit)? = null,
+    val attributes: (MutableAttributeContainer.() -> Unit)? = null,
     val spanProcessors: List<SpanProcessor> = emptyList(),
     val logRecordProcessors: List<LogRecordProcessor> = emptyList()
 )

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
@@ -15,7 +15,7 @@ internal class NonRecordingSpanTest {
             FakeSpanContext(),
         )
         assertTrue(span.links.isEmpty())
-        assertTrue(span.attributes().isEmpty())
+        assertTrue(span.attributes.isEmpty())
         assertTrue(span.events.isEmpty())
         assertFalse(span.isRecording())
     }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpanTest.kt
@@ -14,9 +14,9 @@ internal class NonRecordingSpanTest {
             FakeSpanContext(),
             FakeSpanContext(),
         )
-        assertTrue(span.links().isEmpty())
+        assertTrue(span.links.isEmpty())
         assertTrue(span.attributes().isEmpty())
-        assertTrue(span.events().isEmpty())
+        assertTrue(span.events.isEmpty())
         assertFalse(span.isRecording())
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -102,7 +102,7 @@ internal class SpanExportTest {
     fun `test span events export`() {
         val spanName = "span_events"
         val span = tracer.createSpan(spanName).apply {
-            assertTrue(events().isEmpty())
+            assertTrue(events.isEmpty())
 
             val eventName = "my_event"
             val eventTimestamp = 150L
@@ -110,7 +110,7 @@ internal class SpanExportTest {
                 assertAttributes()
             }
 
-            val event = events().single()
+            val event = events.single()
             assertEquals(eventName, event.name)
             assertEquals(eventTimestamp, event.timestamp)
         }
@@ -193,13 +193,13 @@ internal class SpanExportTest {
     fun `test span links export`() {
         val linkedSpan = tracer.createSpan("linked_span")
         val span = tracer.createSpan("span_links").apply {
-            assertTrue(events().isEmpty())
+            assertTrue(events.isEmpty())
 
             addLink(linkedSpan.spanContext) {
                 assertAttributes()
             }
 
-            val link = links().single()
+            val link = links.single()
             assertEquals(linkedSpan.spanContext, link.spanContext)
         }
         span.end()
@@ -252,8 +252,8 @@ internal class SpanExportTest {
             addLink(linkedSpan3.spanContext)
 
             // Verify counts
-            assertEquals(3, events().size)
-            assertEquals(3, links().size)
+            assertEquals(3, events.size)
+            assertEquals(3, links.size)
         }
 
         span.end()

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.assertions.assertSpanContextsMatch
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.creator.current
@@ -341,8 +341,8 @@ internal class SpanExportTest {
         assertTrue(spanId.matches(hexPattern))
     }
 
-    private fun AttributeContainer.assertAttributes() {
-        assertTrue(attributes().isEmpty())
+    private fun MutableAttributeContainer.assertAttributes() {
+        assertTrue(attributes.isEmpty())
 
         // set attributes
         setStringAttribute("string_key", "value")
@@ -355,7 +355,7 @@ internal class SpanExportTest {
         setLongListAttribute("long_list_key", listOf(42))
         setDoubleListAttribute("double_list_key", listOf(3.14))
 
-        val observed = attributes()
+        val observed = attributes
         val expected = mapOf(
             "string_key" to "second_value",
             "bool_key" to true,

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -14,6 +14,7 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImplKt {
 public final class io/embrace/opentelemetry/kotlin/tracing/LinkImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/Link {
 	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
 	public fun attributes ()Ljava/util/Map;
+	public fun getAttributes ()Ljava/util/Map;
 	public fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
@@ -32,7 +33,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan : io
 	public fun attributes ()Ljava/util/Map;
 	public fun end ()V
 	public fun end (J)V
-	public fun events ()Ljava/util/List;
+	public fun getEvents ()Ljava/util/List;
+	public fun getLinks ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
 	public fun getParent ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
@@ -40,7 +42,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan : io
 	public fun getStartTimestamp ()J
 	public fun getStatus ()Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;
 	public fun isRecording ()Z
-	public fun links ()Ljava/util/List;
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -89,7 +90,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteSpanImpl : i
 	public fun attributes ()Ljava/util/Map;
 	public fun end ()V
 	public fun end (J)V
-	public fun events ()Ljava/util/List;
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getEndTimestamp ()Ljava/lang/Long;
 	public fun getEvents ()Ljava/util/List;
@@ -104,7 +104,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteSpanImpl : i
 	public fun getStartTimestamp ()J
 	public fun getStatus ()Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;
 	public fun isRecording ()Z
-	public fun links ()Ljava/util/List;
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -149,6 +148,7 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextImpl : io/
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent {
 	public fun <init> (Ljava/lang/String;JLio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
 	public fun attributes ()Ljava/util/Map;
+	public fun getAttributes ()Ljava/util/Map;
 	public fun getName ()Ljava/lang/String;
 	public fun getTimestamp ()J
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -11,9 +11,8 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImplKt {
 	public static synthetic fun default$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/creator/ObjectCreator;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/LinkImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/Link {
-	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
-	public fun attributes ()Ljava/util/Map;
+public final class io/embrace/opentelemetry/kotlin/tracing/LinkImpl : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/Link {
+	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer;)V
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public fun setBooleanAttribute (Ljava/lang/String;Z)V
@@ -30,9 +29,9 @@ public final class io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan : io
 	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)V
 	public fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
-	public fun attributes ()Ljava/util/Map;
 	public fun end ()V
 	public fun end (J)V
+	public fun getAttributes ()Ljava/util/Map;
 	public fun getEvents ()Ljava/util/List;
 	public fun getLinks ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
@@ -54,9 +53,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan : io
 	public fun setStringListAttribute (Ljava/lang/String;Ljava/util/List;)V
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteLogRecordImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord {
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/resource/Resource;Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;Lio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
-	public fun attributes ()Ljava/util/Map;
+public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteLogRecordImpl : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord {
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/resource/Resource;Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;Lio/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer;)V
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getBody ()Ljava/lang/String;
 	public fun getContext ()Lio/embrace/opentelemetry/kotlin/context/Context;
@@ -87,7 +85,6 @@ public final class io/embrace/opentelemetry/kotlin/tracing/ReadWriteSpanImpl : i
 	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan;Lio/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships;Ljava/lang/String;Lio/embrace/opentelemetry/kotlin/tracing/data/StatusData;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)V
 	public fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
-	public fun attributes ()Ljava/util/Map;
 	public fun end ()V
 	public fun end (J)V
 	public fun getAttributes ()Ljava/util/Map;
@@ -145,9 +142,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextImpl : io/
 	public fun isValid ()Z
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl : io/embrace/opentelemetry/kotlin/attributes/AttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent {
-	public fun <init> (Ljava/lang/String;JLio/embrace/opentelemetry/kotlin/attributes/AttributeContainer;)V
-	public fun attributes ()Ljava/util/Map;
+public final class io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/tracing/model/SpanEvent {
+	public fun <init> (Ljava/lang/String;JLio/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer;)V
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getName ()Ljava/lang/String;
 	public fun getTimestamp ()J

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
@@ -1,15 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.Link
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
 public class LinkImpl(
     override val spanContext: SpanContext,
-    private val attributesContainer: AttributeContainer
-) : Link, AttributeContainer by attributesContainer {
-    override val attributes: Map<String, Any>
-        get() = attributesContainer.attributes()
-}
+    private val attributesContainer: MutableAttributeContainer
+) : Link, MutableAttributeContainer by attributesContainer

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/LinkImpl.kt
@@ -8,5 +8,8 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 @OptIn(ExperimentalApi::class)
 public class LinkImpl(
     override val spanContext: SpanContext,
-    private val attributes: AttributeContainer
-) : Link, AttributeContainer by attributes
+    private val attributesContainer: AttributeContainer
+) : Link, AttributeContainer by attributesContainer {
+    override val attributes: Map<String, Any>
+        get() = attributesContainer.attributes()
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -2,11 +2,11 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
-import io.embrace.opentelemetry.kotlin.tracing.model.Link
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 /**
@@ -24,6 +24,8 @@ public class NonRecordingSpan(
     override var status: StatusData = StatusData.Unset
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = 0
+    override val events: List<EventData> = emptyList()
+    override val links: List<LinkData> = emptyList()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
     }
@@ -45,10 +47,6 @@ public class NonRecordingSpan(
         attributes: AttributeContainer.() -> Unit
     ) {
     }
-
-    override fun events(): List<SpanEvent> = emptyList()
-
-    override fun links(): List<Link> = emptyList()
 
     override fun setStringAttribute(key: String, value: String) {
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -24,6 +24,7 @@ public class NonRecordingSpan(
     override var status: StatusData = StatusData.Unset
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = 0
+    override val attributes: Map<String, Any> = emptyMap()
     override val events: List<EventData> = emptyList()
     override val links: List<LinkData> = emptyList()
 
@@ -38,13 +39,13 @@ public class NonRecordingSpan(
 
     override fun isRecording(): Boolean = false
 
-    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
     }
 
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ) {
     }
 
@@ -68,6 +69,4 @@ public class NonRecordingSpan(
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
     }
-
-    override fun attributes(): Map<String, Any> = emptyMap()
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadWriteLogRecordImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadWriteLogRecordImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
@@ -21,5 +21,5 @@ public class ReadWriteLogRecordImpl(
     override val context: Context?,
     override val resource: Resource?,
     override val instrumentationScopeInfo: InstrumentationScopeInfo?,
-    private val attributeContainer: AttributeContainer,
-) : ReadWriteLogRecord, AttributeContainer by attributeContainer
+    private val mutableAttributeContainer: MutableAttributeContainer,
+) : ReadWriteLogRecord, MutableAttributeContainer by mutableAttributeContainer

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadWriteSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ReadWriteSpanImpl.kt
@@ -16,6 +16,9 @@ public class ReadWriteSpanImpl(
     private val recording: () -> Boolean
 ) : ReadWriteSpan, ReadableSpan by readableSpan, SpanRelationships by spanRelationships {
 
+    override val attributes: Map<String, Any>
+        get() = readableSpan.attributes
+
     override fun end() {
         onEnd(null)
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
@@ -8,5 +8,8 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 public class SpanEventImpl(
     override val name: String,
     override val timestamp: Long,
-    private val attributes: AttributeContainer
-) : SpanEvent, AttributeContainer by attributes
+    private val attributesContainer: AttributeContainer
+) : SpanEvent, AttributeContainer by attributesContainer {
+    override val attributes: Map<String, Any>
+        get() = attributesContainer.attributes()
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventImpl.kt
@@ -1,15 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 
 @OptIn(ExperimentalApi::class)
 public class SpanEventImpl(
     override val name: String,
     override val timestamp: Long,
-    private val attributesContainer: AttributeContainer
-) : SpanEvent, AttributeContainer by attributesContainer {
-    override val attributes: Map<String, Any>
-        get() = attributesContainer.attributes()
-}
+    private val attributesContainer: MutableAttributeContainer
+) : SpanEvent, MutableAttributeContainer by attributesContainer

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
@@ -14,7 +14,7 @@ internal object NoopLogger : Logger {
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ) {
     }
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @ExperimentalApi
 internal object NoopLoggerProvider : LoggerProvider {
@@ -9,6 +9,6 @@ internal object NoopLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Logger = NoopLogger
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -2,11 +2,11 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
-import io.embrace.opentelemetry.kotlin.tracing.model.Link
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 @ExperimentalApi
@@ -18,6 +18,8 @@ internal object NoopSpan : Span {
     override val spanContext: SpanContext = NoopSpanContext
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = -1L
+    override val events: List<EventData> = emptyList()
+    override val links: List<LinkData> = emptyList()
 
     override fun end() {
     }
@@ -32,8 +34,6 @@ internal object NoopSpan : Span {
     }
 
     override fun isRecording(): Boolean = false
-    override fun events(): List<SpanEvent> = emptyList()
-    override fun links(): List<Link> = emptyList()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
     }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -18,6 +18,7 @@ internal object NoopSpan : Span {
     override val spanContext: SpanContext = NoopSpanContext
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = -1L
+    override val attributes: Map<String, Any> = emptyMap()
     override val events: List<EventData> = emptyList()
     override val links: List<LinkData> = emptyList()
 
@@ -27,10 +28,10 @@ internal object NoopSpan : Span {
     override fun end(timestamp: Long) {
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
     }
 
     override fun isRecording(): Boolean = false
@@ -58,6 +59,4 @@ internal object NoopSpan : Span {
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
     }
-
-    override fun attributes(): Map<String, Any> = emptyMap()
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @ExperimentalApi
 internal object NoopTracerProvider : TracerProvider {
@@ -9,6 +9,6 @@ internal object NoopTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Tracer = NoopTracer
 }

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -163,7 +163,7 @@ internal class NoopTests {
         // Verify no data is recorded
         assertTrue(span.events.isEmpty())
         assertTrue(span.links.isEmpty())
-        assertTrue(span.attributes().isEmpty())
+        assertTrue(span.attributes.isEmpty())
         assertFalse(span.isRecording())
         assertFalse(span.parent.isValid)
     }

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -161,8 +161,8 @@ internal class NoopTests {
         }
 
         // Verify no data is recorded
-        assertTrue(span.events().isEmpty())
-        assertTrue(span.links().isEmpty())
+        assertTrue(span.events.isEmpty())
+        assertTrue(span.links.isEmpty())
         assertTrue(span.attributes().isEmpty())
         assertFalse(span.isRecording())
         assertFalse(span.parent.isValid)

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
@@ -17,7 +17,7 @@ class FakeLogger(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ) {
     }
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @OptIn(ExperimentalApi::class)
 class FakeLoggerProvider : LoggerProvider {
@@ -12,7 +12,7 @@ class FakeLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Logger = map.getOrPut(name) {
         FakeLogger(name)
     }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -2,18 +2,19 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
-import io.embrace.opentelemetry.kotlin.tracing.model.Link
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 @Suppress("UNUSED_PARAMETER")
 @OptIn(ExperimentalApi::class)
 class FakeSpan : Span {
 
-    private val events = mutableListOf<SpanEvent>()
+    override val events: MutableList<EventData> = mutableListOf()
+    override val links: MutableList<LinkData> = mutableListOf()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         TODO("Not yet implemented")
@@ -52,12 +53,6 @@ class FakeSpan : Span {
 
     override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
         events.add(FakeSpanEvent(name, timestamp ?: 0).apply(attributes))
-    }
-
-    override fun events(): List<SpanEvent> = events.toList()
-
-    override fun links(): List<Link> {
-        TODO("Not yet implemented")
     }
 
     override fun setStringAttribute(key: String, value: String) {

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -47,11 +47,11 @@ class FakeSpan : Span {
         TODO("Not yet implemented")
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: AttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
         TODO("Not yet implemented")
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: AttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
         events.add(FakeSpanEvent(name, timestamp ?: 0).apply(attributes))
     }
 
@@ -83,7 +83,6 @@ class FakeSpan : Span {
         TODO("Not yet implemented")
     }
 
-    override fun attributes(): Map<String, Any> {
-        TODO("Not yet implemented")
-    }
+    override val attributes: Map<String, Any>
+        get() = TODO("Not yet implemented")
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpanEvent.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpanEvent.kt
@@ -9,39 +9,37 @@ class FakeSpanEvent(
     override val timestamp: Long
 ) : SpanEvent {
 
-    private val attrs = mutableMapOf<String, Any>()
+    override val attributes = mutableMapOf<String, Any>()
 
     override fun setStringAttribute(key: String, value: String) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setLongAttribute(key: String, value: Long) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setLongListAttribute(key: String, value: List<Long>) {
-        attrs[key] = value
+        attributes[key] = value
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
-        attrs[key] = value
+        attributes[key] = value
     }
-
-    override fun attributes(): Map<String, Any> = attrs.toMap()
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @OptIn(ExperimentalApi::class)
 class FakeTracerProvider : TracerProvider {
@@ -12,7 +12,7 @@ class FakeTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: AttributeContainer.() -> Unit
+        attributes: MutableAttributeContainer.() -> Unit
     ): Tracer = map.getOrPut(name) {
         FakeTracer(name)
     }


### PR DESCRIPTION
The read-only getters for the current set of events, links, and attributes are defined in a bunch of different places. 

Consolidate this by putting the event and link getters in `SpanSchema` and the setters on attributes in a new interface called `MutableAttributeContainer` which extends from the slimmed down `AttributeContainer`

Doing this allows for the `Link` and `SpanEvent` interfaces to extend from `LinkData` and `EventData`, further reducing duplication.
