### PR TITLE
Add unit tests for conversion functions

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/ContextKeyExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/ContextKeyExtTest.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.context.ContextKeyAdapter
+import org.junit.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class ContextKeyExtTest {
+
+    @Test
+    fun toOtelJavaContextKey() {
+        val impl = OtelJavaContextKey.named<String>("test")
+        val adapter = ContextKeyAdapter(impl)
+        assertSame(impl, adapter.toOtelJavaContextKey())
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaSpanContextExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaSpanContextExtTest.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaSpanContextExtTest {
+
+    @Test
+    fun toOtelKotlinSpanContext() {
+        val impl = OtelJavaSpanContext.create(
+            "12345678901234567890123456789012",
+            "1234567890123456",
+            OtelJavaTraceFlags.getDefault(),
+            OtelJavaTraceState.getDefault()
+        )
+        val spanContext = impl.toOtelKotlinSpanContext()
+        assertEquals(impl.spanId, spanContext.spanId)
+        assertEquals(impl.traceId, spanContext.traceId)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaSpanKindExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaSpanKindExtTest.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaSpanKindExtTest {
+
+    @Test
+    fun toOtelKotlinSpanKind() {
+        val expected = mapOf(
+            OtelJavaSpanKind.INTERNAL to SpanKind.INTERNAL,
+            OtelJavaSpanKind.CLIENT to SpanKind.CLIENT,
+            OtelJavaSpanKind.SERVER to SpanKind.SERVER,
+            OtelJavaSpanKind.PRODUCER to SpanKind.PRODUCER,
+            OtelJavaSpanKind.CONSUMER to SpanKind.CONSUMER,
+        )
+        expected.forEach {
+            assertEquals(it.key.toOtelKotlinSpanKind(), it.value)
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaStatusCodeExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/OtelJavaStatusCodeExtTest.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaStatusCodeExtTest {
+
+    @Test
+    fun toOtelKotlinStatusData() {
+        val map = mapOf(
+            OtelJavaStatusCode.UNSET to StatusData.Unset,
+            OtelJavaStatusCode.OK to StatusData.Ok,
+            OtelJavaStatusCode.ERROR to StatusData.Error(""),
+        )
+        map.forEach {
+            val observed = it.key.toOtelKotlinStatusData("")
+            val expected = it.value
+            assertEquals(expected.statusCode, observed.statusCode)
+            assertEquals(expected.description, observed.description)
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/SpanContextExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/SpanContextExtTest.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class SpanContextExtTest {
+
+    @Test
+    fun toOtelJavaSpanContext() {
+        val impl = FakeSpanContext()
+        val spanContext = impl.toOtelJavaSpanContext()
+        assertEquals(impl.spanId, spanContext.spanId)
+        assertEquals(impl.traceId, spanContext.traceId)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/SpanKindExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/SpanKindExtTest.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class SpanKindExtTest {
+
+    @Test
+    fun toOtelJavaSpanKind() {
+        val expected = mapOf(
+            SpanKind.INTERNAL to OtelJavaSpanKind.INTERNAL,
+            SpanKind.CLIENT to OtelJavaSpanKind.CLIENT,
+            SpanKind.SERVER to OtelJavaSpanKind.SERVER,
+            SpanKind.PRODUCER to OtelJavaSpanKind.PRODUCER,
+            SpanKind.CONSUMER to OtelJavaSpanKind.CONSUMER,
+        )
+        expected.forEach {
+            assertEquals(it.key.toOtelJavaSpanKind(), it.value)
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExtTest.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.tracing.StatusCode
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StatusCodeExtTest {
+
+    @Test
+    fun toOtelJavaStatusCode() {
+        val expected = mapOf(
+            StatusCode.Unset to OtelJavaStatusCode.UNSET,
+            StatusCode.Error to OtelJavaStatusCode.ERROR,
+            StatusCode.Ok to OtelJavaStatusCode.OK,
+        )
+        expected.forEach {
+            assertEquals(it.key.toOtelJavaStatusCode(), it.value)
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusDataExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusDataExtTest.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StatusDataExtTest {
+
+    @Test
+    fun toOtelJavaStatusData() {
+        val expected = mapOf(
+            StatusData.Unset to OtelJavaStatusData.unset(),
+            StatusData.Ok to OtelJavaStatusData.ok(),
+            StatusData.Error("Whoops") to OtelJavaStatusData.create(
+                OtelJavaStatusCode.ERROR,
+                "Whoops"
+            ),
+        )
+        expected.forEach {
+            assertEquals(it.key.toOtelJavaStatusData(), it.value)
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.FakeTraceFlags
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class TraceFlagsExtTest {
+
+    @Test
+    fun toOtelJavaTraceFlags() {
+        val expected = FakeTraceFlags()
+        val observed = expected.toOtelJavaTraceFlags()
+        assertEquals(expected.hex, observed.asHex())
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/TraceStateExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/TraceStateExtTest.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.tracing.ext
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.FakeTraceState
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TraceStateExtTest {
+
+    @Test
+    fun toOtelJavaTraceState() {
+        val expected = FakeTraceState()
+        val observed = expected.toOtelJavaTraceState()
+        assertEquals(expected.asMap(), observed.asMap())
+    }
+}


### PR DESCRIPTION
## Goal

Adds unit tests for some of the functions that convert between OTel Java and Kotlin.
