### PR TITLE
Support timestamp supplied via instant

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
@@ -28,6 +28,9 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
     }
 
     override fun setTimestamp(instant: Instant): OtelJavaLogRecordBuilder {
+        runCatching {
+            this.timestamp = instant.convertToNanos()
+        }
         return this
     }
 
@@ -37,6 +40,9 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
     }
 
     override fun setObservedTimestamp(instant: Instant): OtelJavaLogRecordBuilder {
+        runCatching {
+            this.observedTimestamp = instant.convertToNanos()
+        }
         return this
     }
 
@@ -79,5 +85,14 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
         ) {
             attrs.forEach { setStringAttribute(it.key, it.value) }
         }
+    }
+
+    private fun Instant.convertToNanos(): Long? {
+        runCatching {
+            val seconds: Long = epochSecond
+            val nanos: Int = nano
+            return seconds * 1000000000L + nanos
+        }
+        return null
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
@@ -1,0 +1,39 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.context.ContextKeyAdapter
+import org.junit.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaLogRecordBuilderAdapterTest {
+
+    @Test
+    fun `test log record builder adapter`() {
+        val impl = FakeLogger("logger")
+        val adapter = OtelJavaLogRecordBuilderAdapter(impl)
+
+        val now = Instant.now()
+        adapter.setObservedTimestamp(now)
+        adapter.setTimestamp(now)
+
+        val key = OtelJavaContextKey.named<String>("key")
+        val ctx = OtelJavaContext.root().with(key, "value")
+        adapter.setContext(ctx)
+        val body = "Hello, World!"
+        adapter.setBody(body)
+        adapter.emit()
+
+        val log = impl.logs.single()
+        assertEquals(body, log.body)
+        val ctxValue = log.context?.get<String>(ContextKeyAdapter(key))
+        assertEquals("value", ctxValue)
+
+        val expected = now.toEpochMilli() * 1000000
+        assertEquals(expected, log.timestamp)
+        assertEquals(expected, log.observedTimestamp)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -3,12 +3,15 @@ package io.embrace.opentelemetry.kotlin.logging
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
 @OptIn(ExperimentalApi::class)
 class FakeLogger(
     val name: String
 ) : Logger {
+
+    val logs: MutableList<FakeReadableLogRecord> = mutableListOf()
 
     override fun log(
         body: String?,
@@ -19,5 +22,15 @@ class FakeLogger(
         severityText: String?,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
+        logs.add(
+            FakeReadableLogRecord(
+                timestamp,
+                observedTimestamp,
+                context,
+                severityNumber,
+                severityText,
+                body
+            )
+        )
     }
 }


### PR DESCRIPTION
## Goal

Supports timestamps added with an `Instant` type. Some methods on this type is only available in Android API >=26 so I've surrounded this with a try-catch to avoid throwing, given we don't have access to Android API annotations in this module.

