### PR TITLE
Add integration tests for processors

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExtTest.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeSpanData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaSpanExporterExtTest {
+
+    @Test
+    fun toOtelKotlinSpanExporter() {
+        val impl = FakeOtelJavaSpanExporter()
+        val adapter = impl.toOtelKotlinSpanExporter()
+        adapter.export(mutableListOf(FakeSpanData()))
+
+        val export = impl.exports.single()
+        assertEquals("span", export.name)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/log_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/log_custom_processor.json
@@ -1,0 +1,41 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.52.0"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "severity": "UNDEFINED_SEVERITY_NUMBER",
+    "severityText": null,
+    "body": "Test",
+    "attributes": {
+      "bool": "false",
+      "boolList": "[false]",
+      "double": "5.4",
+      "doubleList": "[5.4]",
+      "long": "5",
+      "longList": "[5]",
+      "string": "value",
+      "stringList": "[value]"
+    },
+    "totalAttributeCount": 8
+  }
+]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
@@ -1,0 +1,139 @@
+[
+  {
+    "name": "other",
+    "kind": "INTERNAL",
+    "statusData": {
+      "name": "UNSET",
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "startTimestamp": 0,
+    "attributes": {
+      "bool": "false",
+      "boolList": "[false]",
+      "double": "5.4",
+      "doubleList": "[5.4]",
+      "long": "5",
+      "longList": "[5]",
+      "string": "value",
+      "stringList": "[value]"
+    },
+    "events": [
+      {
+        "name": "custom_event",
+        "attributes": {
+          "key": "value"
+        },
+        "timestamp": 30,
+        "totalAttributesCount": 1
+      }
+    ],
+    "links": [],
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 1,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 8,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.52.0"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_tracer",
+      "version": "0.1.0",
+      "schemaUrl": "null",
+      "attributes": {}
+    }
+  },
+  {
+    "name": "my_span",
+    "kind": "INTERNAL",
+    "statusData": {
+      "name": "UNSET",
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "startTimestamp": 0,
+    "attributes": {
+      "bool": "false",
+      "boolList": "[false]",
+      "double": "5.4",
+      "doubleList": "[5.4]",
+      "long": "5",
+      "longList": "[5]",
+      "string": "value",
+      "stringList": "[value]"
+    },
+    "events": [
+      {
+        "name": "custom_event",
+        "attributes": {
+          "key": "value"
+        },
+        "timestamp": 30,
+        "totalAttributesCount": 1
+      }
+    ],
+    "links": [
+      {
+        "spanContext": {
+          "traceId": "00000000000000000000000000000000",
+          "spanId": "0000000000000000",
+          "traceFlags": "01",
+          "traceState": {}
+        },
+        "attributes": {
+          "key": "value"
+        },
+        "totalAttributeCount": 1
+      }
+    ],
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 1,
+    "totalRecordedLinks": 1,
+    "totalAttributeCount": 8,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.52.0"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_tracer",
+      "version": "0.1.0",
+      "schemaUrl": "null",
+      "attributes": {}
+    }
+  }
+]


### PR DESCRIPTION
## Goal

Adds integration tests for span + log processors that asserts our API actually alters what gets sent to the exporters.