### PR TITLE
Ensure ReadWriteSpan adapter updates the wrapped span

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -236,9 +236,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/resource/Resourc
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/StatusCode : java/lang/Enum {
-	public static final field Error Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
-	public static final field Ok Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
-	public static final field Unset Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
+	public static final field ERROR Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
+	public static final field OK Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
+	public static final field UNSET Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
 	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
 	public static fun values ()[Lio/embrace/opentelemetry/kotlin/tracing/StatusCode;
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/StatusCode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/StatusCode.kt
@@ -15,15 +15,15 @@ public enum class StatusCode {
     /**
      * Default status.
      */
-    Unset,
+    UNSET,
 
     /**
      * The operation completed successfully.
      */
-    Ok,
+    OK,
 
     /**
      * The operation completed with an error.
      */
-    Error
+    ERROR
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
@@ -16,17 +16,17 @@ public sealed class StatusData(
      * Default status.
      */
     @ThreadSafe
-    public object Unset : StatusData(StatusCode.Unset, null)
+    public object Unset : StatusData(StatusCode.UNSET, null)
 
     /**
      * The operation completed successfully.
      */
     @ThreadSafe
-    public object Ok : StatusData(StatusCode.Ok, null)
+    public object Ok : StatusData(StatusCode.OK, null)
 
     /**
      * The operation completed with an error. An optional description of the error may be provided.
      */
     @ThreadSafe
-    public class Error(description: String?) : StatusData(StatusCode.Error, description)
+    public class Error(description: String?) : StatusData(StatusCode.ERROR, description)
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/Span.kt
@@ -24,7 +24,7 @@ public interface Span : SpanSchema, SpanRelationships {
     public override var name: String
 
     /**
-     * Sets the status of the span. This defaults to [StatusCode.Unset].
+     * Sets the status of the span. This defaults to [StatusCode.UNSET].
      */
     @ThreadSafe
     public override var status: StatusData

--- a/opentelemetry-kotlin-compat/build.gradle.kts
+++ b/opentelemetry-kotlin-compat/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
+                implementation(project(":opentelemetry-kotlin-testing"))
                 implementation(project(":opentelemetry-kotlin-test-fakes"))
             }
         }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExt.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
 @OptIn(ExperimentalApi::class)
 internal fun StatusCode.toOtelJavaStatusCode(): OtelJavaStatusCode = when (this) {
-    StatusCode.Unset -> OtelJavaStatusCode.UNSET
-    StatusCode.Ok -> OtelJavaStatusCode.OK
-    StatusCode.Error -> OtelJavaStatusCode.ERROR
+    StatusCode.UNSET -> OtelJavaStatusCode.UNSET
+    StatusCode.OK -> OtelJavaStatusCode.OK
+    StatusCode.ERROR -> OtelJavaStatusCode.ERROR
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadWriteSpan.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadWriteSpan.kt
@@ -1,0 +1,82 @@
+@file:Suppress("DEPRECATION")
+
+package io.embrace.opentelemetry.kotlin.fakes.otel.java
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import java.util.concurrent.TimeUnit
+
+/**
+ * Only methods on the [readableSpan] interface are valid to call on this fake
+ */
+internal class FakeOtelJavaReadWriteSpan(
+    val readableSpan: OtelJavaReadableSpan = FakeOtelJavaReadableSpan()
+) : OtelJavaReadWriteSpan, OtelJavaReadableSpan by readableSpan {
+
+    override fun getInstrumentationScopeInfo(): InstrumentationScopeInfo {
+        return readableSpan.instrumentationScopeInfo
+    }
+
+    override fun getAttributes(): Attributes {
+        return readableSpan.attributes
+    }
+
+    override fun <T : Any?> setAttribute(
+        key: AttributeKey<T?>,
+        value: T?
+    ): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, attributes: Attributes): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(
+        name: String,
+        attributes: Attributes,
+        timestamp: Long,
+        unit: TimeUnit
+    ): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStatus(
+        statusCode: StatusCode,
+        description: String
+    ): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordException(
+        exception: Throwable,
+        additionalAttributes: Attributes
+    ): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateName(name: String): Span? {
+        TODO("Not yet implemented")
+    }
+
+    override fun end() {
+        TODO("Not yet implemented")
+    }
+
+    override fun end(timestamp: Long, unit: TimeUnit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRecording(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLatencyNanos(): Long {
+        TODO("Not yet implemented")
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/ext/StatusCodeExtTest.kt
@@ -12,9 +12,9 @@ internal class StatusCodeExtTest {
     @Test
     fun toOtelJavaStatusCode() {
         val expected = mapOf(
-            StatusCode.Unset to OtelJavaStatusCode.UNSET,
-            StatusCode.Error to OtelJavaStatusCode.ERROR,
-            StatusCode.Ok to OtelJavaStatusCode.OK,
+            StatusCode.UNSET to OtelJavaStatusCode.UNSET,
+            StatusCode.ERROR to OtelJavaStatusCode.ERROR,
+            StatusCode.OK to OtelJavaStatusCode.OK,
         )
         expected.forEach {
             assertEquals(it.key.toOtelJavaStatusCode(), it.value)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
@@ -1,0 +1,186 @@
+package io.embrace.opentelemetry.kotlin.tracing.model
+
+import fakeInProgressOtelJavaSpanData
+import fakeOtelJavaEventData
+import fakeOtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.attributes.attrsFromMap
+import io.embrace.opentelemetry.kotlin.attributes.toMap
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import io.embrace.opentelemetry.kotlin.scope.toOtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.testing.common.TestSpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaEventData
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusData
+import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class ReadWriteSpanAdapterTest {
+
+    private lateinit var harness: OtelKotlinHarness
+    private lateinit var adapter: ReadWriteSpanAdapter
+    private lateinit var fakeReadableSpan: FakeOtelJavaReadableSpan
+    private lateinit var fakeImpl: FakeOtelJavaReadWriteSpan
+
+    @BeforeTest
+    fun setUp() {
+        fakeReadableSpan = FakeOtelJavaReadableSpan(fakeInProgressOtelJavaSpanData)
+        fakeImpl = FakeOtelJavaReadWriteSpan(fakeReadableSpan)
+        adapter = ReadWriteSpanAdapter(fakeImpl)
+        harness = OtelKotlinHarness()
+    }
+
+    @Test
+    fun `pass through of initial state`() {
+        with(fakeImpl.toSpanData()) {
+            adapter.assertImmutableProperties(this)
+            adapter.assertMutableProperties(this)
+        }
+    }
+
+    @Test
+    fun `mutable properties change as implementation changes`() {
+        val initialState = fakeImpl.toSpanData()
+        fakeReadableSpan.otelJavaSpanData = FakeOtelJavaSpanData(
+            implName = "new${initialState.name}",
+            implSpanContext = initialState.spanContext,
+            implParentSpanContext = initialState.parentSpanContext,
+            implSpanKind = initialState.kind,
+            implAttributes = attrsFromMap(initialState.attributes.toMap() + mapOf("newattr" to "value")),
+            implEventData = initialState.events + fakeOtelJavaEventData,
+            implLinkData = initialState.links + fakeOtelJavaLinkData,
+            implStartNs = initialState.startEpochNanos,
+            implEndNs = initialState.startEpochNanos + 5_000_000,
+            implEnded = true,
+            implStatusData = OtelJavaStatusData.error(),
+            implResource = initialState.resource
+        )
+
+        val modifiedState = fakeImpl.toSpanData()
+
+        adapter.assertImmutableProperties(initialState)
+        adapter.assertMutableProperties(modifiedState)
+    }
+
+    @Test
+    fun `span updatable`() {
+        val newStatus = StatusData.Error("err")
+        val processor = TestSpanProcessor(
+            runOnStart = assertReadWriteSpan(
+                updateCode = { span ->
+                    span.apply {
+                        name = "new-name"
+                        status = newStatus
+                        setStringAttribute("key", "value")
+                    }
+                },
+                expectedName = "new-name",
+                expectedStatus = StatusData.Error("err"),
+                expectedAttributes = mapOf("key" to "value")
+            ),
+            runOnEnd = assertReadableSpan(
+                expectedName = "name",
+                expectedStatus = StatusData.Error("err"),
+                expectedAttributes = mapOf("key" to "value")
+            ),
+        )
+        harness.config.spanProcessors.add(processor)
+        harness.tracer.createSpan("name").end()
+        harness.assertSpans(
+            expectedCount = 1,
+            assertions = { spans ->
+                with(spans.single()) {
+                    assertEquals("name", name)
+                    assertEquals(newStatus.statusCode.name, statusData.name)
+                    assertEquals(newStatus.description, statusData.description)
+                    assertEquals(mapOf("key" to "value"), attributes)
+                }
+            }
+        )
+    }
+
+    private fun ReadWriteSpanAdapter.assertImmutableProperties(expected: OtelJavaSpanData) {
+        assertEquals(expected.spanContext, spanContext.toOtelJavaSpanContext())
+        assertEquals(expected.parentSpanContext, parent.toOtelJavaSpanContext())
+        assertEquals(expected.kind, spanKind.toOtelJavaSpanKind())
+        assertEquals(expected.startEpochNanos, startTimestamp)
+        assertEquals(expected.resource.attributes.toMap(), resource.attributes)
+        assertEquals(expected.resource.schemaUrl, resource.schemaUrl)
+        assertEquals(expected.instrumentationScopeInfo, instrumentationScopeInfo.toOtelJavaInstrumentationScopeInfo())
+    }
+
+    private fun ReadWriteSpanAdapter.assertMutableProperties(expected: OtelJavaSpanData) {
+        assertEquals(expected.name, name)
+        assertEquals(expected.status, status.toOtelJavaStatusData())
+        assertEquals(expected.hasEnded(), hasEnded)
+        assertEquals(expected.endEpochNanos, endTimestamp)
+        assertEquals(expected.attributes.toMap(), attributes)
+        assertEquals(expected.events, events.map { it.toOtelJavaEventData() })
+        assertEquals(expected.links, links.map { it.toOtelJavaLinkData() })
+    }
+
+    private fun assertReadWriteSpan(
+        updateCode: (span: ReadWriteSpan) -> Unit,
+        expectedName: String? = null,
+        expectedStatus: StatusData? = null,
+        expectedAttributes: Map<String, Any>? = null,
+        expectedEvents: List<EventData>? = null,
+        expectedLinks: List<LinkData>? = null,
+    ): (span: ReadWriteSpan) -> Unit {
+        return fun(span: ReadWriteSpan) {
+            updateCode(span)
+            assertReadableSpan(
+                expectedName = expectedName,
+                expectedStatus = expectedStatus,
+                expectedAttributes = expectedAttributes,
+                expectedEvents = expectedEvents,
+                expectedLinks = expectedLinks
+            ).invoke(span)
+        }
+    }
+
+    private fun assertReadableSpan(
+        expectedName: String? = null,
+        expectedStatus: StatusData? = null,
+        expectedAttributes: Map<String, Any>? = null,
+        expectedEvents: List<EventData>? = null,
+        expectedLinks: List<LinkData>? = null,
+    ): (span: ReadableSpan) -> Unit {
+        return fun(readableSpan: ReadableSpan) {
+            with(readableSpan) {
+                if (expectedName != null) {
+                    assertEquals(expectedName, name)
+                }
+
+                if (expectedStatus != null) {
+                    assertEquals(expectedStatus.statusCode, status.statusCode)
+                    assertEquals(expectedStatus.description, status.description)
+                }
+
+                if (expectedAttributes != null) {
+                    assertEquals(expectedAttributes, attributes)
+                }
+
+                if (expectedEvents != null) {
+                    assertEquals(expectedEvents, events)
+                }
+
+                if (expectedLinks != null) {
+                    assertEquals(expectedLinks, links)
+                }
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
@@ -3,8 +3,8 @@
     "name": "other",
     "kind": "INTERNAL",
     "statusData": {
-      "name": "UNSET",
-      "description": ""
+      "name": "ERROR",
+      "description": "bad_err"
     },
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
@@ -65,8 +65,8 @@
     "name": "my_span",
     "kind": "INTERNAL",
     "statusData": {
-      "name": "UNSET",
-      "description": ""
+      "name": "ERROR",
+      "description": "bad_err"
     },
     "spanContext": {
       "traceId": "00000000000000000000000000000000",

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/common/TestSpanProcessor.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/common/TestSpanProcessor.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.testing.common
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+
+@OptIn(ExperimentalApi::class)
+class TestSpanProcessor(
+    private val runOnStart: (readWriteSpan: ReadWriteSpan) -> Unit = {},
+    private val runOnEnd: (readableSpan: ReadableSpan) -> Unit = {},
+) : SpanProcessor {
+    override fun onStart(span: ReadWriteSpan, parentContext: Context) = runOnStart(span)
+
+    override fun onEnd(span: ReadableSpan) = runOnEnd(span)
+
+    override fun isStartRequired(): Boolean = true
+
+    override fun isEndRequired(): Boolean = true
+
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+}


### PR DESCRIPTION
Make the adapter call into the wrapped method to do updating and add tests to verify this in the `SpanProcessor` and `SpanExporter` layers where these objects are created. Previously, they were no-ops so updates were discarded.

Also, make the enum names consistent with Java because why not.