### PR TITLE
Add fake processors for span/log

### DIFF
--- a/opentelemetry-kotlin-implementation/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation/build.gradle.kts
@@ -14,5 +14,10 @@ kotlin {
                 implementation(project(":opentelemetry-kotlin-model"))
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(project(":opentelemetry-kotlin-test-fakes"))
+            }
+        }
     }
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/FakeLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/FakeLogRecordProcessor.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+
+@OptIn(ExperimentalApi::class)
+class FakeLogRecordProcessor(
+    var flushCode: OperationResultCode = OperationResultCode.Success,
+    var shutdownCode: OperationResultCode = OperationResultCode.Success,
+    var action: (log: ReadWriteLogRecord, context: Context) -> Unit = { _, _ -> }
+) : LogRecordProcessor {
+
+    override fun onEmit(
+        log: ReadWriteLogRecord,
+        context: Context
+    ) = action(log, context)
+
+    override fun forceFlush(): OperationResultCode = flushCode
+    override fun shutdown(): OperationResultCode = shutdownCode
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
@@ -1,0 +1,29 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+
+@OptIn(ExperimentalApi::class)
+class FakeSpanProcessor(
+    var startRequired: Boolean = true,
+    var endRequired: Boolean = true,
+    var flushCode: OperationResultCode = OperationResultCode.Success,
+    var shutdownCode: OperationResultCode = OperationResultCode.Success,
+    var startAction: (ReadWriteSpan, Context) -> Unit = { _, _ -> },
+    var endAction: (ReadableSpan) -> Unit = {}
+) : SpanProcessor {
+
+    override fun onStart(
+        span: ReadWriteSpan,
+        parentContext: Context
+    ) = startAction(span, parentContext)
+
+    override fun onEnd(span: ReadableSpan) = endAction(span)
+    override fun isStartRequired(): Boolean = startRequired
+    override fun isEndRequired(): Boolean = endRequired
+    override fun forceFlush(): OperationResultCode = flushCode
+    override fun shutdown(): OperationResultCode = shutdownCode
+}


### PR DESCRIPTION
## Goal

Adds fake processors for spans/logs and ensures the implementation module can access them.