### PR TITLE
Alter resource DSL

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -122,11 +122,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProvi
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
-	public abstract fun resource (Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
+	public abstract fun resource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl$DefaultImpls {
-	public static synthetic fun resource$default (Lio/embrace/opentelemetry/kotlin/init/ResourceConfigDsl;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun resource$default (Lio/embrace/opentelemetry/kotlin/init/ResourceConfigDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigDsl {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -5,5 +5,5 @@ import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
 @ExperimentalApi
 public interface ResourceConfigDsl {
-    public fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String? = null)
+    public fun resource(schemaUrl: String? = null, attributes: MutableAttributeContainer.() -> Unit)
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -23,7 +23,7 @@ internal class LoggerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String?) {
+    override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs, schemaUrl))
     }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -23,7 +23,7 @@ internal class TracerProviderConfigImpl(
         builder.setClock(OtelJavaClockWrapper(clock))
     }
 
-    override fun resource(attributes: MutableAttributeContainer.() -> Unit, schemaUrl: String?) {
+    override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
         builder.setResource(Resource.create(attrs, schemaUrl))
     }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -40,13 +40,13 @@ internal class OtelKotlinHarness {
         OpenTelemetryInstance.createOpenTelemetryKotlin(
             clock = FakeClock(),
             tracerProvider = {
-                config.attributes?.let { resource(it, config.schemaUrl) }
+                config.attributes?.let { resource(config.schemaUrl, it) }
                 addSpanProcessor(InMemorySpanProcessor(spanExporter))
                 config.spanProcessors.forEach { addSpanProcessor(it) }
                 spanLimits(config.spanLimits)
             },
             loggerProvider = {
-                config.attributes?.let { resource(it, config.schemaUrl) }
+                config.attributes?.let { resource(config.schemaUrl, it) }
                 addLogRecordProcessor(InMemoryLogRecordProcessor(logRecordExporter))
                 config.logRecordProcessors.forEach { addLogRecordProcessor(it) }
                 logLimits(config.logLimits)


### PR DESCRIPTION
## Goal

Alters the DSL for setting resources so that the lambda parameter is the last function, as syntactically this allows specifying the lambda out of the parentheses & is more idiomatic Kotlin.
