### PR TITLE
Implement mutable attribute container

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
@@ -1,0 +1,59 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.threadSafeMap
+
+@OptIn(ExperimentalApi::class)
+@ThreadSafe
+internal class MutableAttributeContainerImpl : MutableAttributeContainer {
+
+    private val attrs: MutableMap<String, Any> = threadSafeMap()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        attrs[key] = value
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        attrs[key] = value
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        attrs[key] = value
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        attrs[key] = value
+    }
+
+    override fun setBooleanListAttribute(
+        key: String,
+        value: List<Boolean>
+    ) {
+        attrs[key] = value
+    }
+
+    override fun setStringListAttribute(
+        key: String,
+        value: List<String>
+    ) {
+        attrs[key] = value
+    }
+
+    override fun setLongListAttribute(
+        key: String,
+        value: List<Long>
+    ) {
+        attrs[key] = value
+    }
+
+    override fun setDoubleListAttribute(
+        key: String,
+        value: List<Double>
+    ) {
+        attrs[key] = value
+    }
+
+    override val attributes: Map<String, Any>
+        get() = attrs.toMap()
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
@@ -1,0 +1,33 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class MutableAttributeContainerImplTest {
+
+    @Test
+    fun `test attributes`() {
+        val attrs = MutableAttributeContainerImpl().apply {
+            setStringAttribute("string", "value")
+            setBooleanAttribute("boolean", true)
+            setDoubleAttribute("double", 5.2)
+            setLongAttribute("long", 123L)
+            setStringListAttribute("stringList", listOf("a", "b", "c"))
+            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 3.5))
+            setLongListAttribute("longList", listOf(4L, 5L, 6L))
+            setBooleanListAttribute("booleanList", listOf(true, false, true))
+        }.attributes
+
+        val expected = mapOf(
+            "string" to "value",
+            "boolean" to true,
+            "double" to 5.2,
+            "long" to 123L,
+            "stringList" to listOf("a", "b", "c"),
+            "doubleList" to listOf(1.5, 2.5, 3.5),
+            "longList" to listOf(4L, 5L, 6L),
+            "booleanList" to listOf(true, false, true),
+        )
+        assertEquals(expected, attrs)
+    }
+}

--- a/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/resource/ResourceImpl.kt
+++ b/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/resource/ResourceImpl.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.resource
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+class ResourceImpl(
+    override val attributes: Map<String, Any>,
+    override val schemaUrl: String?,
+) : Resource

--- a/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
+++ b/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
@@ -1,0 +1,8 @@
+public final class io/embrace/opentelemetry/kotlin/Sync_jvmKt {
+	public static final fun sync (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class io/embrace/opentelemetry/kotlin/ThreadSafeMap_jvmKt {
+	public static final fun threadSafeMap ()Ljava/util/Map;
+}
+

--- a/opentelemetry-kotlin-primitives/build.gradle.kts
+++ b/opentelemetry-kotlin-primitives/build.gradle.kts
@@ -10,14 +10,10 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":opentelemetry-kotlin-api"))
-                implementation(project(":opentelemetry-kotlin-model"))
-                implementation(project(":opentelemetry-kotlin-primitives"))
             }
         }
         val commonTest by getting {
             dependencies {
-                implementation(project(":opentelemetry-kotlin-test-fakes"))
             }
         }
     }

--- a/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.apple.kt
+++ b/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.apple.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin
+
+public actual inline fun <R> sync(lock: Any, block: () -> R): R {
+    throw UnsupportedOperationException()
+}

--- a/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.apple.kt
+++ b/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.apple.kt
@@ -1,0 +1,3 @@
+package io.embrace.opentelemetry.kotlin
+
+public actual fun <K, V> threadSafeMap(): MutableMap<K, V> = throw UnsupportedOperationException()

--- a/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.kt
+++ b/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Executes the block synchronously with an exclusion lock.
+ */
+public expect inline fun <R> sync(lock: Any, block: () -> R): R

--- a/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.kt
+++ b/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Creates a thread-safe map - i.e. it's possible to concurrently modify the collection without
+ * crashing. There may be platform-specific concerns around consistency of the collection.
+ */
+public expect fun <K, V> threadSafeMap(): MutableMap<K, V>

--- a/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.jvm.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.jvm.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin
+
+public actual inline fun <R> sync(lock: Any, block: () -> R): R =
+    synchronized(lock) {
+        block()
+    }

--- a/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.jvm.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.jvm.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin
+
+import java.util.concurrent.ConcurrentHashMap
+
+public actual fun <K, V> threadSafeMap(): MutableMap<K, V> = ConcurrentHashMap()

--- a/opentelemetry-kotlin-primitives/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/SyncTest.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/SyncTest.kt
@@ -1,0 +1,33 @@
+package io.embrace.opentelemetry.kotlin
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class SyncTest {
+
+    @Test
+    fun test() {
+        val expected = "value"
+        val observed = sync(this) {
+            expected
+        }
+        assertEquals(expected, observed)
+    }
+
+    @Test
+    fun `test order`() {
+        val latch = CountDownLatch(1)
+        val values = mutableListOf<Int>()
+
+        sync(this) {
+            latch.await(10, TimeUnit.MILLISECONDS)
+            values.add(1)
+        }
+        sync(this) {
+            values.add(2)
+        }
+        assertEquals(listOf(1, 2), values)
+    }
+}

--- a/opentelemetry-kotlin-primitives/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapTest.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapTest.kt
@@ -1,0 +1,13 @@
+package io.embrace.opentelemetry.kotlin
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.ConcurrentHashMap
+
+internal class ThreadSafeMapTest {
+
+    @Test
+    fun `test threadSafeMap`() {
+        assertTrue(threadSafeMap<String, String>() is ConcurrentHashMap)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(
     ":opentelemetry-kotlin-implementation",
     ":opentelemetry-kotlin-model",
     ":opentelemetry-kotlin-compat",
+    ":opentelemetry-kotlin-primitives",
     ":opentelemetry-kotlin-testing",
     ":opentelemetry-kotlin-test-fakes",
     ":opentelemetry-java-typealiases",


### PR DESCRIPTION
## Goal

Implements `MutableAttributeContainer`. This was reasonably straightforward although it did require defining our first KMP functions that differ depending on the platform, as various concurrency APIs are Java-specific. For now I've separated this into a module named `opentelemetry-kotlin-primitives` and have provided a JVM-only implementation.

## Testing

Added unit tests.

