### PR TITLE
Add provider implementation for tracer/logger

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+
+@Suppress("unused")
+@OptIn(ExperimentalApi::class)
+internal class LoggerImpl(private val key: ApiProviderKey) : Logger {
+
+    override fun log(
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
+        throw UnsupportedOperationException()
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
+
+@OptIn(ExperimentalApi::class)
+internal class LoggerProviderImpl : LoggerProvider {
+
+    private val apiProvider = ApiProviderImpl<Logger> { key ->
+        LoggerImpl(key)
+    }
+
+    override fun getLogger(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ): Logger {
+        val key = apiProvider.createKey(attributes, name, version, schemaUrl)
+        return apiProvider.getOrCreate(key)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
@@ -1,0 +1,45 @@
+package io.embrace.opentelemetry.kotlin.provider
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.sync
+
+/**
+ * Provides a tracer/logger implementation, creating a new instance via the supplier if nothing
+ * matches the key.
+ *
+ * The OTel spec states that if any of the TracerProvider/LoggerProvider parameters differ,
+ * a new Tracer/Logger instance should be returned.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
+ * https://opentelemetry.io/docs/specs/otel/logs/api/#loggerprovider
+ */
+@OptIn(ExperimentalApi::class)
+@ThreadSafe
+internal class ApiProviderImpl<T>(
+    val supplier: (key: ApiProviderKey) -> T
+) {
+
+    private val map = mutableMapOf<ApiProviderKey, T>()
+
+    fun getOrCreate(key: ApiProviderKey): T = sync(map) {
+        map.getOrPut(key) {
+            supplier(key)
+        }
+    }
+
+    fun createKey(
+        attributes: MutableAttributeContainer.() -> Unit,
+        name: String,
+        version: String?,
+        schemaUrl: String?
+    ): ApiProviderKey {
+        val attrs = MutableAttributeContainerImpl().apply {
+            attributes()
+        }.attributes
+        val key = ApiProviderKey(name, version, schemaUrl, attrs)
+        return key
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderKey.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderKey.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.provider
+
+/**
+ * A key for a tracer/logger provider. The OpenTelemetry spec
+ * states that if any of these parameters are different a new instance must be returned.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
+ * https://opentelemetry.io/docs/specs/otel/logs/api/#loggerprovider
+ */
+internal data class ApiProviderKey(
+    val name: String,
+    val version: String?,
+    val schemaUrl: String?,
+    val attributes: Map<String, Any>
+)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
+
+@Suppress("unused")
+@OptIn(ExperimentalApi::class)
+internal class TracerImpl(private val key: ApiProviderKey) : Tracer {
+
+    override fun createSpan(
+        name: String,
+        parentContext: Context?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: SpanRelationships.() -> Unit
+    ): Span {
+        throw UnsupportedOperationException()
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
+
+@OptIn(ExperimentalApi::class)
+internal class TracerProviderImpl : TracerProvider {
+
+    private val apiProvider = ApiProviderImpl<Tracer> { key ->
+        TracerImpl(key)
+    }
+
+    override fun getTracer(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ): Tracer {
+        val key = apiProvider.createKey(attributes, name, version, schemaUrl)
+        return apiProvider.getOrCreate(key)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -1,0 +1,76 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class LoggerProviderImplTest {
+
+    @Test
+    fun `test minimal logger provider`() {
+        val impl = LoggerProviderImpl()
+        assertNotNull(impl.getLogger(name = ""))
+    }
+
+    @Test
+    fun `test full logger provider`() {
+        val impl = LoggerProviderImpl()
+        val first = impl.getLogger(
+            name = "name",
+            version = "0.1.0",
+            schemaUrl = "https://example.com/foo"
+        ) {
+            setStringAttribute("key", "value")
+        }
+        assertNotNull(first)
+    }
+
+    @Test
+    fun `test dupe logger provider name`() {
+        val impl = LoggerProviderImpl()
+        val first = impl.getLogger(name = "name")
+        val second = impl.getLogger(name = "name")
+        val third = impl.getLogger(name = "other")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe logger provider version`() {
+        val impl = LoggerProviderImpl()
+        val first = impl.getLogger(name = "name", version = "0.1.0")
+        val second = impl.getLogger(name = "name", version = "0.1.0")
+        val third = impl.getLogger(name = "name", version = "0.2.0")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe logger provider schemaUrl`() {
+        val impl = LoggerProviderImpl()
+        val first = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
+        val second = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
+        val third = impl.getLogger(name = "name", schemaUrl = "https://example.com/bar")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe logger provider attributes`() {
+        val impl = LoggerProviderImpl()
+        val first = impl.getLogger(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val second = impl.getLogger(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val third = impl.getLogger(name = "name") {
+            setStringAttribute("foo", "bar")
+        }
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -1,0 +1,76 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class TracerProviderImplTest {
+
+    @Test
+    fun `test minimal tracer provider`() {
+        val impl = TracerProviderImpl()
+        assertNotNull(impl.getTracer(name = ""))
+    }
+
+    @Test
+    fun `test full tracer provider`() {
+        val impl = TracerProviderImpl()
+        val first = impl.getTracer(
+            name = "name",
+            version = "0.1.0",
+            schemaUrl = "https://example.com/foo"
+        ) {
+            setStringAttribute("key", "value")
+        }
+        assertNotNull(first)
+    }
+
+    @Test
+    fun `test dupe tracer provider name`() {
+        val impl = TracerProviderImpl()
+        val first = impl.getTracer(name = "name")
+        val second = impl.getTracer(name = "name")
+        val third = impl.getTracer(name = "other")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe tracer provider version`() {
+        val impl = TracerProviderImpl()
+        val first = impl.getTracer(name = "name", version = "0.1.0")
+        val second = impl.getTracer(name = "name", version = "0.1.0")
+        val third = impl.getTracer(name = "name", version = "0.2.0")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe tracer provider schemaUrl`() {
+        val impl = TracerProviderImpl()
+        val first = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
+        val second = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
+        val third = impl.getTracer(name = "name", schemaUrl = "https://example.com/bar")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test dupe tracer provider attributes`() {
+        val impl = TracerProviderImpl()
+        val first = impl.getTracer(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val second = impl.getTracer(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val third = impl.getTracer(name = "name") {
+            setStringAttribute("foo", "bar")
+        }
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+}


### PR DESCRIPTION
## Goal

Adds an implementation for both `TracerProvider` and `LoggerProvider` that ensures each returns identical instances whenever the parameters are the same, and distinct instances whenever they are different.

## Testing

Added unit tests.