### PR TITLE
Tweak limits for default spans/logs

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
@@ -4,6 +4,6 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class LogLimitsConfigImpl : LogLimitsConfigDsl {
-    override var attributeCountLimit: Int = 1000
-    override var attributeValueLengthLimit: Int = 1000
+    override var attributeCountLimit: Int = 128
+    override var attributeValueLengthLimit: Int = Int.MAX_VALUE
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
@@ -4,9 +4,9 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class SpanLimitsConfigImpl : SpanLimitsConfigDsl {
-    override var attributeCountLimit: Int = 1000
-    override var linkCountLimit: Int = 1000
-    override var eventCountLimit: Int = 1000
-    override var attributeCountPerEventLimit: Int = 1000
-    override var attributeCountPerLinkLimit: Int = 1000
+    override var attributeCountLimit: Int = 128
+    override var linkCountLimit: Int = 128
+    override var eventCountLimit: Int = 128
+    override var attributeCountPerEventLimit: Int = 128
+    override var attributeCountPerLinkLimit: Int = 128
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -18,8 +18,8 @@ internal class LoggerProviderConfigImplTest {
         assertNull(cfg.resource.schemaUrl)
 
         with(cfg.logLimits) {
-            assertEquals(1000, attributeCountLimit)
-            assertEquals(1000, attributeValueLengthLimit)
+            assertEquals(128, attributeCountLimit)
+            assertEquals(Int.MAX_VALUE, attributeValueLengthLimit)
         }
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -18,11 +18,11 @@ internal class TracerProviderConfigImplTest {
         assertNull(cfg.resource.schemaUrl)
 
         with(cfg.spanLimits) {
-            assertEquals(1000, linkCountLimit)
-            assertEquals(1000, eventCountLimit)
-            assertEquals(1000, attributeCountLimit)
-            assertEquals(1000, attributeCountPerLinkLimit)
-            assertEquals(1000, attributeCountPerEventLimit)
+            assertEquals(128, linkCountLimit)
+            assertEquals(128, eventCountLimit)
+            assertEquals(128, attributeCountLimit)
+            assertEquals(128, attributeCountPerLinkLimit)
+            assertEquals(128, attributeCountPerEventLimit)
         }
     }
 


### PR DESCRIPTION
## Goal

Tweaks the default limits for spans/logs to match otel-java.
