### PR TITLE
Add tests for SpanProcessor adapter

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
@@ -1,0 +1,131 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import fakeInProgressOtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
+import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import io.embrace.opentelemetry.kotlin.tracing.ext.storeInContext
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.Span
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaSpanProcessorAdapterTest {
+    private val rootContext = OtelJavaContext.root().toOtelKotlinContext()
+    private lateinit var harness: OtelKotlinHarness
+
+    @BeforeTest
+    fun setUp() {
+        harness = OtelKotlinHarness()
+    }
+
+    @Test
+    fun `span propagated correctly`() {
+        with(harness) {
+            val fakeTime = 5_000_000L
+            val span = tracer.createSpan(
+                name = "test",
+                spanKind = SpanKind.CLIENT,
+                startTimestamp = fakeTime,
+            ) {
+                setStringAttribute("key", "value")
+                addEvent("event", fakeTime) {
+                    setStringAttribute("eventAttr", "value")
+                }
+                addLink(fakeInProgressOtelJavaSpanData.spanContext.toOtelKotlinSpanContext()) {
+                    setStringAttribute("linkAttr", "value")
+                }
+            }
+            config.spanProcessors.add(
+                FakeSpanProcessor(
+                    startAction = assertInputForSpan(
+                        expectedName = "test",
+                        expectedParentSpanContextSupplier = { OtelJavaSpan.getInvalid().spanContext.toOtelKotlinSpanContext() },
+                    ),
+                    endAction = assertReadableSpan(
+                        expectedName = "test",
+                        expectedSpanSupplier = { span }
+                    )
+                )
+            )
+            span.end()
+        }
+    }
+
+    @Test
+    fun `parent context propagated correctly`() {
+        with(harness) {
+            val parentSpan = tracer.createSpan("parent")
+            val childSpan = tracer.createSpan(
+                name = "name",
+                parentContext = parentSpan.storeInContext(rootContext)
+            )
+
+            config.spanProcessors.add(
+                FakeSpanProcessor(
+                    startAction = assertInputForSpan(
+                        expectedName = "name",
+                        expectedParentSpanContextSupplier = { parentSpan.spanContext },
+                    ),
+                    endAction = assertReadableSpan(
+                        expectedName = "name",
+                        expectedSpanSupplier = { childSpan }
+                    )
+                )
+            )
+            childSpan.end()
+        }
+    }
+
+    private fun assertInputForSpan(
+        expectedName: String,
+        expectedParentSpanContextSupplier: () -> SpanContext? = { null },
+    ): (span: ReadWriteSpan, context: Context) -> Unit {
+        return fun(span: ReadWriteSpan, parentContext: Context) {
+            if (expectedName == span.name) {
+                val parentSpanContext = expectedParentSpanContextSupplier()
+                if (parentSpanContext != null) {
+                    with(parentSpanContext) {
+                        val spanContextFromContext = OtelJavaSpan.fromContext(parentContext.toOtelJavaContext()).spanContext
+                        assertEquals(spanId, spanContextFromContext.spanId)
+                        if (parentSpanContext.isValid) {
+                            assertEquals(traceId, span.spanContext.traceId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun assertReadableSpan(
+        expectedName: String,
+        expectedSpanSupplier: () -> Span
+    ): (span: ReadableSpan) -> Unit {
+        return fun(span: ReadableSpan) {
+            if (span.name == expectedName) {
+                with(expectedSpanSupplier()) {
+                    assertEquals(spanContext, span.spanContext)
+                    assertEquals(parent, span.parent)
+                    assertEquals(spanKind, span.spanKind)
+                    assertEquals(startTimestamp, span.startTimestamp)
+                    assertEquals(name, span.name)
+                    assertEquals(status, span.status)
+                    assertEquals(isRecording(), span.hasEnded)
+                    assertEquals(attributes.toMap(), span.attributes)
+                    assertEquals(events, span.events)
+                    assertEquals(links, span.links)
+                }
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
@@ -4,11 +4,13 @@ import fakeInProgressOtelJavaSpanData
 import fakeOtelJavaEventData
 import fakeOtelJavaLinkData
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import io.embrace.opentelemetry.kotlin.attributes.attrsFromMap
 import io.embrace.opentelemetry.kotlin.attributes.toMap
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanData
@@ -140,9 +142,12 @@ internal class ReadWriteSpanAdapterTest {
         expectedEvents: List<EventData>? = null,
         expectedLinks: List<LinkData>? = null,
     ): (span: ReadWriteSpan, _: Context) -> Unit {
-        @Suppress("UnusedParameter", "FunctionParameterNaming")
-        return fun(span: ReadWriteSpan, _: Context) {
+        return fun(span: ReadWriteSpan, context: Context) {
             updateCode(span)
+            assertEquals(
+                OtelJavaSpan.getInvalid().spanContext.spanId,
+                OtelJavaSpan.fromContext(context.toOtelJavaContext()).spanContext.spanId,
+            )
             assertReadableSpan(
                 expectedName = expectedName,
                 expectedStatus = expectedStatus,


### PR DESCRIPTION
Add to the `Span` interface that notion of the span's context at creation time. This is so it could be used in the API to create a span with this given span as a parent.

We can probably use a the root context as a basis but this is probably more complete.