### PR TITLE
Use OtelJava Aliases for Java API/SDK symbols

### DIFF
--- a/opentelemetry-java-typealiases/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/opentelemetry-java-typealiases/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/aliases/Aliases.kt
@@ -39,6 +39,7 @@ import io.opentelemetry.sdk.logs.LogLimits
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
+import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
 import io.opentelemetry.sdk.logs.data.Body
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
@@ -48,6 +49,7 @@ import io.opentelemetry.sdk.trace.IdGenerator
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 import io.opentelemetry.sdk.trace.SpanLimits
 import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.data.EventData
@@ -92,7 +94,9 @@ typealias OtelJavaReadableSpan = ReadableSpan
 typealias OtelJavaSpanProcessor = SpanProcessor
 typealias OtelJavaOpenTelemetrySdk = OpenTelemetrySdk
 typealias OtelJavaSdkLoggerProvider = SdkLoggerProvider
+typealias OtelJavaSdkLoggerProviderBuilder = SdkLoggerProviderBuilder
 typealias OtelJavaSdkTracerProvider = SdkTracerProvider
+typealias OtelJavaSdkTracerProviderBuilder = SdkTracerProviderBuilder
 typealias OtelJavaBody = Body
 typealias OtelJavaInstrumentationLibraryInfo = InstrumentationLibraryInfo
 typealias OtelJavaAttributesBuilder = AttributesBuilder

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/CompleteableResultCodeExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/CompleteableResultCodeExt.kt
@@ -1,10 +1,10 @@
 package io.embrace.opentelemetry.kotlin
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.sdk.common.CompletableResultCode
 
 @OptIn(ExperimentalApi::class)
-internal fun CompletableResultCode.toOperationResultCode(): OperationResultCode = when (this) {
-    CompletableResultCode.ofSuccess() -> OperationResultCode.Success
+internal fun OtelJavaCompletableResultCode.toOperationResultCode(): OperationResultCode = when (this) {
+    OtelJavaCompletableResultCode.ofSuccess() -> OperationResultCode.Success
     else -> OperationResultCode.Failure
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
@@ -4,7 +4,6 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
-import io.opentelemetry.api.logs.LoggerProvider
 
 internal class OtelJavaOpenTelemetrySdk(
     private val tracerProvider: OtelJavaTracerProvider,
@@ -12,6 +11,6 @@ internal class OtelJavaOpenTelemetrySdk(
 ) : OtelJavaOpenTelemetry {
 
     override fun getTracerProvider(): OtelJavaTracerProvider = tracerProvider
-    override fun getLogsBridge(): LoggerProvider = loggerProvider
+    override fun getLogsBridge(): OtelJavaLoggerProvider = loggerProvider
     override fun getPropagators(): OtelJavaContextPropagators = OtelJavaContextPropagators.noop()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -2,22 +2,22 @@ package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderBuilder
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.export.OtelJavaLogRecordProcessorAdapter
-import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
-import io.opentelemetry.sdk.resources.Resource
 
 @ExperimentalApi
 internal class LoggerProviderConfigImpl(
     clock: Clock
 ) : LoggerProviderConfigDsl {
 
-    private val builder: SdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
+    private val builder: OtelJavaSdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
 
     init {
         builder.setClock(OtelJavaClockWrapper(clock))
@@ -25,7 +25,7 @@ internal class LoggerProviderConfigImpl(
 
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
-        builder.setResource(Resource.create(attrs, schemaUrl))
+        builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
     }
 
     override fun addLogRecordProcessor(processor: LogRecordProcessor) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -2,22 +2,22 @@ package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
 import io.embrace.opentelemetry.kotlin.tracing.export.OtelJavaSpanProcessorAdapter
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 
 @ExperimentalApi
 internal class TracerProviderConfigImpl(
     private val clock: Clock
 ) : TracerProviderConfigDsl {
 
-    private val builder: SdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
+    private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
 
     init {
         builder.setClock(OtelJavaClockWrapper(clock))
@@ -25,7 +25,7 @@ internal class TracerProviderConfigImpl(
 
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = MutableAttributeContainerImpl().apply(attributes).otelJavaAttributes()
-        builder.setResource(Resource.create(attrs, schemaUrl))
+        builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
     }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
@@ -1,11 +1,11 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.context.Context
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -16,8 +16,8 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
 
     private var timestamp: Long? = null
     private var observedTimestamp: Long? = null
-    private var context: Context? = null
-    private var severity: Severity? = null
+    private var context: OtelJavaContext? = null
+    private var severity: OtelJavaSeverity? = null
     private var severityText: String? = null
     private var body: String? = null
     private val attrs = ConcurrentHashMap<String, String>()
@@ -46,12 +46,12 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
         return this
     }
 
-    override fun setContext(context: Context): OtelJavaLogRecordBuilder {
+    override fun setContext(context: OtelJavaContext): OtelJavaLogRecordBuilder {
         this.context = context
         return this
     }
 
-    override fun setSeverity(severity: Severity): OtelJavaLogRecordBuilder {
+    override fun setSeverity(severity: OtelJavaSeverity): OtelJavaLogRecordBuilder {
         this.severity = severity
         return this
     }
@@ -67,7 +67,7 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
     }
 
     override fun <T : Any?> setAttribute(
-        key: AttributeKey<T>,
+        key: OtelJavaAttributeKey<T>,
         value: T?
     ): OtelJavaLogRecordBuilder {
         attrs[key.key] = value.toString()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordDataImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordDataImpl.kt
@@ -1,19 +1,14 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaBody
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo
-import io.opentelemetry.sdk.logs.data.Body
-import io.opentelemetry.sdk.resources.Resource
 
 /**
  * Implementation of [io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData] that we can construct new instances of. Required for
@@ -27,21 +22,21 @@ internal class OtelJavaLogRecordDataImpl(
     private val spanContextImpl: OtelJavaSpanContext,
     private val severityImpl: OtelJavaSeverity,
     private val severityTextImpl: String?,
-    private val bodyImpl: Body,
+    private val bodyImpl: OtelJavaBody,
     private val attributesImpl: OtelJavaAttributes,
 ) : OtelJavaLogRecordData {
 
-    override fun getResource(): Resource = resourceImpl
-    override fun getInstrumentationScopeInfo(): InstrumentationScopeInfo = scopeImpl
+    override fun getResource(): OtelJavaResource = resourceImpl
+    override fun getInstrumentationScopeInfo(): OtelJavaInstrumentationScopeInfo = scopeImpl
     override fun getTimestampEpochNanos(): Long = timestampNanos
     override fun getObservedTimestampEpochNanos(): Long = observedTimestampNanos
-    override fun getSpanContext(): SpanContext = spanContextImpl
-    override fun getSeverity(): Severity = severityImpl
+    override fun getSpanContext(): OtelJavaSpanContext = spanContextImpl
+    override fun getSeverity(): OtelJavaSeverity = severityImpl
     override fun getSeverityText(): String? = severityTextImpl
 
     @Deprecated("Deprecated in Java")
-    override fun getBody(): Body = bodyImpl
+    override fun getBody(): OtelJavaBody = bodyImpl
 
-    override fun getAttributes(): Attributes = attributesImpl
+    override fun getAttributes(): OtelJavaAttributes = attributesImpl
     override fun getTotalAttributeCount(): Int = attributesImpl.size()
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordProcessorAdapter.kt
@@ -1,10 +1,10 @@
 package io.embrace.opentelemetry.kotlin.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
-import io.opentelemetry.context.Context
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaLogRecordProcessorAdapter(
@@ -12,7 +12,7 @@ internal class OtelJavaLogRecordProcessorAdapter(
 ) : OtelJavaLogRecordProcessor {
 
     override fun onEmit(
-        context: Context,
+        context: OtelJavaContext,
         logRecord: OtelJavaReadWriteLogRecord
     ) {
         impl.onEmit(ReadWriteLogRecordAdapter(logRecord), context.toOtelKotlinContext())

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
@@ -1,10 +1,13 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package io.embrace.opentelemetry.kotlin.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaBody
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.attributes.attrsFromMap
 import io.embrace.opentelemetry.kotlin.attributes.resourceFromMap
 import io.embrace.opentelemetry.kotlin.logging.OtelJavaLogRecordDataImpl
@@ -12,19 +15,16 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.embrace.opentelemetry.kotlin.logging.toOtelJavaSeverityNumber
 import io.embrace.opentelemetry.kotlin.scope.toOtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
-import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.sdk.logs.data.Body
-import io.opentelemetry.sdk.logs.data.LogRecordData
 
 @OptIn(ExperimentalApi::class)
-internal fun ReadableLogRecord.toLogRecordData(): LogRecordData {
+internal fun ReadableLogRecord.toLogRecordData(): OtelJavaLogRecordData {
     return OtelJavaLogRecordDataImpl(
         timestampNanos = timestamp ?: 0,
         observedTimestampNanos = observedTimestamp ?: 0,
         spanContextImpl = spanContext.toOtelJavaSpanContext(),
         severityTextImpl = severityText,
-        severityImpl = severityNumber?.toOtelJavaSeverityNumber() ?: Severity.UNDEFINED_SEVERITY_NUMBER,
-        bodyImpl = body?.let(Body::string) ?: Body.empty(),
+        severityImpl = severityNumber?.toOtelJavaSeverityNumber() ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
+        bodyImpl = body?.let(OtelJavaBody::string) ?: OtelJavaBody.empty(),
         attributesImpl = attrsFromMap(attributes),
         resourceImpl = resource?.let(::resourceFromMap) ?: OtelJavaResource.empty(),
         scopeImpl = instrumentationScopeInfo?.toOtelJavaInstrumentationScopeInfo()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -15,7 +15,6 @@ import io.embrace.opentelemetry.kotlin.attributes.toMap
 import io.embrace.opentelemetry.kotlin.context.ContextAdapter
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanKind
 import io.embrace.opentelemetry.kotlin.tracing.model.OtelJavaSpanAdapter
-import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
@@ -36,7 +35,7 @@ internal class OtelJavaSpanBuilderAdapter(
     }
 
     override fun setNoParent(): OtelJavaSpanBuilder {
-        parent = Context.root()
+        parent = OtelJavaContext.root()
         return this
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/OtelJavaSpanDataImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/OtelJavaSpanDataImpl.kt
@@ -11,14 +11,6 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.data.EventData
-import io.opentelemetry.sdk.trace.data.LinkData
-import io.opentelemetry.sdk.trace.data.StatusData
 
 /**
  * Implementation of [io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData] that we can construct new instances of. Required for
@@ -42,14 +34,14 @@ internal class OtelJavaSpanDataImpl(
 ) : OtelJavaSpanData {
 
     override fun getName(): String = nameImpl
-    override fun getKind(): SpanKind = kindImpl
-    override fun getSpanContext(): SpanContext = spanContextImpl
-    override fun getParentSpanContext(): SpanContext = parentSpanContextImpl
-    override fun getStatus(): StatusData = statusImpl
+    override fun getKind(): OtelJavaSpanKind = kindImpl
+    override fun getSpanContext(): OtelJavaSpanContext = spanContextImpl
+    override fun getParentSpanContext(): OtelJavaSpanContext = parentSpanContextImpl
+    override fun getStatus(): OtelJavaStatusData = statusImpl
     override fun getStartEpochNanos(): Long = startEpochNanosImpl
-    override fun getAttributes(): Attributes = attributesImpl
-    override fun getEvents(): List<EventData> = eventsImpl
-    override fun getLinks(): List<LinkData> = linksImpl
+    override fun getAttributes(): OtelJavaAttributes = attributesImpl
+    override fun getEvents(): List<OtelJavaEventData> = eventsImpl
+    override fun getLinks(): List<OtelJavaLinkData> = linksImpl
     override fun getEndEpochNanos(): Long = endEpochNanosImpl
     override fun hasEnded(): Boolean = hasEndedImpl
     override fun getTotalRecordedEvents(): Int = eventsImpl.size
@@ -57,6 +49,6 @@ internal class OtelJavaSpanDataImpl(
     override fun getTotalAttributeCount(): Int = attributesImpl.size()
 
     @Deprecated("Deprecated in Java")
-    override fun getInstrumentationLibraryInfo(): InstrumentationLibraryInfo = scopeImpl
-    override fun getResource(): Resource = resourceImpl
+    override fun getInstrumentationLibraryInfo(): OtelJavaInstrumentationLibraryInfo = scopeImpl
+    override fun getResource(): OtelJavaResource = resourceImpl
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/OtelJavaSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/OtelJavaSpanAdapter.kt
@@ -3,6 +3,9 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaScope
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
@@ -10,15 +13,10 @@ import io.embrace.opentelemetry.kotlin.attributes.toMap
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinStatusData
 import io.embrace.opentelemetry.kotlin.tracing.recordException
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.ImplicitContextKeyed
-import io.opentelemetry.context.Scope
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, ImplicitContextKeyed {
+internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, OtelJavaImplicitContextKeyed {
 
     override fun <T : Any?> setAttribute(key: OtelJavaAttributeKey<T?>, value: T?): OtelJavaSpan {
         span.setStringAttribute(key.key, value.toString())
@@ -50,8 +48,8 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, Impli
     }
 
     override fun addLink(
-        spanContext: SpanContext,
-        attributes: Attributes
+        spanContext: OtelJavaSpanContext,
+        attributes: OtelJavaAttributes
     ): OtelJavaSpan {
         span.addLink(SpanContextAdapter(spanContext)) {
             attributes.toMap().forEach {
@@ -97,19 +95,19 @@ internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, Impli
 
     override fun isRecording(): Boolean = span.isRecording()
 
-    override fun storeInContext(context: Context): Context {
-        return if ((span is ImplicitContextKeyed)) {
+    override fun storeInContext(context: OtelJavaContext): OtelJavaContext {
+        return if ((span is OtelJavaImplicitContextKeyed)) {
             span.storeInContext(context)
         } else {
             super.storeInContext(context)
         }
     }
 
-    override fun makeCurrent(): Scope {
-        return if ((span is ImplicitContextKeyed)) {
+    override fun makeCurrent(): OtelJavaScope {
+        return if ((span is OtelJavaImplicitContextKeyed)) {
             span.makeCurrent()
         } else {
-            super<ImplicitContextKeyed>.makeCurrent()
+            super<OtelJavaImplicitContextKeyed>.makeCurrent()
         }
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/CompleteableResultCodeExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/CompleteableResultCodeExtTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.sdk.common.CompletableResultCode
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -12,11 +12,11 @@ internal class CompleteableResultCodeExtTest {
     fun `test conversion`() {
         assertEquals(
             OperationResultCode.Success,
-            CompletableResultCode.ofSuccess().toOperationResultCode()
+            OtelJavaCompletableResultCode.ofSuccess().toOperationResultCode()
         )
         assertEquals(
             OperationResultCode.Failure,
-            CompletableResultCode.ofFailure().toOperationResultCode()
+            OtelJavaCompletableResultCode.ofFailure().toOperationResultCode()
         )
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordExporter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordExporter.kt
@@ -1,27 +1,27 @@
 package io.embrace.opentelemetry.kotlin.fakes.otel.java
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
 
 internal class FakeOtelJavaLogRecordExporter : OtelJavaLogRecordExporter {
 
     var flushCount = 0
     var shutdownCount = 0
-    val exports: MutableList<LogRecordData> = mutableListOf()
+    val exports: MutableList<OtelJavaLogRecordData> = mutableListOf()
 
-    override fun export(logs: MutableCollection<LogRecordData>): CompletableResultCode {
+    override fun export(logs: MutableCollection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         exports += logs
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode {
+    override fun flush(): OtelJavaCompletableResultCode {
         flushCount += 1
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun shutdown(): CompletableResultCode {
+    override fun shutdown(): OtelJavaCompletableResultCode {
         shutdownCount += 1
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadWriteSpan.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadWriteSpan.kt
@@ -2,13 +2,13 @@
 
 package io.embrace.opentelemetry.kotlin.fakes.otel.java
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import java.util.concurrent.TimeUnit
 
 /**
@@ -18,49 +18,49 @@ internal class FakeOtelJavaReadWriteSpan(
     val readableSpan: OtelJavaReadableSpan = FakeOtelJavaReadableSpan()
 ) : OtelJavaReadWriteSpan, OtelJavaReadableSpan by readableSpan {
 
-    override fun getInstrumentationScopeInfo(): InstrumentationScopeInfo {
+    override fun getInstrumentationScopeInfo(): OtelJavaInstrumentationScopeInfo {
         return readableSpan.instrumentationScopeInfo
     }
 
-    override fun getAttributes(): Attributes {
+    override fun getAttributes(): OtelJavaAttributes {
         return readableSpan.attributes
     }
 
     override fun <T : Any?> setAttribute(
-        key: AttributeKey<T?>,
+        key: OtelJavaAttributeKey<T?>,
         value: T?
-    ): Span? {
+    ): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
-    override fun addEvent(name: String, attributes: Attributes): Span? {
+    override fun addEvent(name: String, attributes: OtelJavaAttributes): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
     override fun addEvent(
         name: String,
-        attributes: Attributes,
+        attributes: OtelJavaAttributes,
         timestamp: Long,
         unit: TimeUnit
-    ): Span? {
+    ): OtelJavaSpan? {
         TODO("Not yet implemented")
     }
 
     override fun setStatus(
-        statusCode: StatusCode,
+        statusCode: OtelJavaStatusCode,
         description: String
-    ): Span? {
+    ): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
     override fun recordException(
         exception: Throwable,
-        additionalAttributes: Attributes
-    ): Span? {
+        additionalAttributes: OtelJavaAttributes
+    ): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
-    override fun updateName(name: String): Span? {
+    override fun updateName(name: String): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadableSpan.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaReadableSpan.kt
@@ -1,38 +1,37 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package io.embrace.opentelemetry.kotlin.fakes.otel.java
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 
 internal class FakeOtelJavaReadableSpan(
     var otelJavaSpanData: OtelJavaSpanData = FakeOtelJavaSpanData()
 ) : OtelJavaReadableSpan {
 
-    override fun getSpanContext(): SpanContext = otelJavaSpanData.spanContext
+    override fun getSpanContext(): OtelJavaSpanContext = otelJavaSpanData.spanContext
 
-    override fun getParentSpanContext(): SpanContext = otelJavaSpanData.parentSpanContext
+    override fun getParentSpanContext(): OtelJavaSpanContext = otelJavaSpanData.parentSpanContext
 
     override fun getName(): String = otelJavaSpanData.name
 
     @Deprecated("Deprecated in Java")
-    override fun getInstrumentationLibraryInfo(): InstrumentationLibraryInfo = otelJavaSpanData.instrumentationLibraryInfo
+    override fun getInstrumentationLibraryInfo(): OtelJavaInstrumentationLibraryInfo = otelJavaSpanData.instrumentationLibraryInfo
 
     override fun hasEnded(): Boolean = otelJavaSpanData.hasEnded()
 
     override fun getLatencyNanos(): Long = otelJavaSpanData.endEpochNanos - otelJavaSpanData.startEpochNanos
 
-    override fun getKind(): SpanKind? = otelJavaSpanData.kind
+    override fun getKind(): OtelJavaSpanKind? = otelJavaSpanData.kind
 
-    override fun getAttributes(): Attributes = otelJavaSpanData.attributes
+    override fun getAttributes(): OtelJavaAttributes = otelJavaSpanData.attributes
 
-    override fun <T> getAttribute(key: AttributeKey<T>): T? = otelJavaSpanData.attributes.get(key)
+    override fun <T> getAttribute(key: OtelJavaAttributeKey<T>): T? = otelJavaSpanData.attributes.get(key)
 
-    override fun toSpanData(): SpanData = otelJavaSpanData
+    override fun toSpanData(): OtelJavaSpanData = otelJavaSpanData
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanExporter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanExporter.kt
@@ -1,27 +1,27 @@
 package io.embrace.opentelemetry.kotlin.fakes.otel.java
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
 
 internal class FakeOtelJavaSpanExporter : OtelJavaSpanExporter {
 
     var flushCount = 0
     var shutdownCount = 0
-    val exports: MutableList<SpanData> = mutableListOf()
+    val exports: MutableList<OtelJavaSpanData> = mutableListOf()
 
-    override fun export(logs: MutableCollection<SpanData>): CompletableResultCode {
+    override fun export(logs: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         exports += logs
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode {
+    override fun flush(): OtelJavaCompletableResultCode {
         flushCount += 1
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun shutdown(): CompletableResultCode {
+    override fun shutdown(): OtelJavaCompletableResultCode {
         shutdownCount += 1
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
@@ -4,13 +4,13 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogger
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.ContextAdapter
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
-import io.opentelemetry.api.logs.Severity
 import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -50,7 +50,7 @@ internal class OtelJavaLogExportTest {
             .setBody("Hello, world!")
             .setTimestamp(100L, TimeUnit.NANOSECONDS)
             .setObservedTimestamp(50L, TimeUnit.NANOSECONDS)
-            .setSeverity(Severity.ERROR2)
+            .setSeverity(OtelJavaSeverity.ERROR2)
             .setSeverityText("Error")
             .setAttribute("key2", "value2")
             .emit()


### PR DESCRIPTION
Always use the `OtelJava*` aliases for clarity
