### PR TITLE
Setup custom detekt rule for finding unwanted imports

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/otel/DetektConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/DetektConfig.kt
@@ -13,6 +13,10 @@ fun Project.configureDetekt() {
         "detektPlugins",
         project.findLibrary("detekt-formatting")
     )
+    project.dependencies.add(
+        "detektPlugins",
+        project(":custom-detekt-rules")
+    )
     val detekt = project.extensions.getByType(DetektExtension::class.java)
 
     detekt.apply {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -66,3 +66,13 @@ naming:
   ForbiddenClassName:
     active: true
     forbiddenName: ['*Embrace']
+
+# Custom rules defined in this project
+custom-rules:
+  DiscouragedImport:
+    active: true
+    restrictedPackages:
+      - "io.opentelemetry"
+    allowedFileIds:
+      - "io.embrace.opentelemetry.kotlin.aliases.Aliases"
+      - "io.embrace.opentelemetry.kotlin.creator.SpanCreatorImpl"

--- a/custom-detekt-rules/build.gradle.kts
+++ b/custom-detekt-rules/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    kotlin("jvm")
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    withSourcesJar()
+}
+
+dependencies {
+    implementation(libs.detekt.api)
+    testImplementation(libs.detekt.test)
+    testImplementation(kotlin("test"))
+}

--- a/custom-detekt-rules/src/main/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRule.kt
+++ b/custom-detekt-rules/src/main/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRule.kt
@@ -1,0 +1,54 @@
+package io.embrace.opentelemetry.kotlin.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
+
+/**
+ * Detects imports that are discouraged from use in the project. It's possible to configure an
+ * allowList of sourceFiles that can be skipped from this detection.
+ */
+class DiscouragedImportRule(config: Config) : Rule(config) {
+
+    override val issue: Issue = Issue(
+        id = "DiscouragedImport",
+        severity = Severity.CodeSmell,
+        description = "Detects usage of discouraged imports unless explicitly allowed by file path.",
+        debt = Debt.FIVE_MINS
+    )
+
+    private val restrictedPackages = valueOrDefault("restrictedPackages", emptyList<String>())
+    private val allowedFileIds = valueOrDefault("allowedFileIds", emptyList<String>())
+    private lateinit var fileId: String
+
+    override fun preVisit(root: KtFile) {
+        val relativeName = root.name.substringAfterLast("/").removeSuffix(".kt")
+        fileId = "${root.packageFqName.asString()}.$relativeName"
+        super.preVisit(root)
+    }
+
+    override fun visitImportDirective(importDirective: KtImportDirective) {
+        super.visitImportDirective(importDirective)
+        if (fileId in allowedFileIds) {
+            return
+        }
+
+        val import = importDirective.importPath?.pathStr ?: return
+
+        if (restrictedPackages.any(import::startsWith)) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(importDirective),
+                    message = "Import from discouraged package '$import' is not allowed."
+                )
+            )
+        }
+    }
+}

--- a/custom-detekt-rules/src/main/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRuleSetProvider.kt
+++ b/custom-detekt-rules/src/main/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRuleSetProvider.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+class DiscouragedImportRuleSetProvider : RuleSetProvider {
+
+    override fun instance(config: Config): RuleSet = RuleSet(
+        id = "discouraged-import",
+        rules = listOf(DiscouragedImportRule(config))
+    )
+
+    override val ruleSetId: String = "custom-rules"
+}

--- a/custom-detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/custom-detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+io.embrace.opentelemetry.kotlin.detekt.DiscouragedImportRuleSetProvider

--- a/custom-detekt-rules/src/test/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRuleTest.kt
+++ b/custom-detekt-rules/src/test/kotlin/io/embrace/opentelemetry/kotlin/detekt/DiscouragedImportRuleTest.kt
@@ -1,0 +1,70 @@
+package io.embrace.opentelemetry.kotlin.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.lint
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DiscouragedImportRuleTest {
+
+    @Test
+    fun `test default`() {
+        val rule = DiscouragedImportRule(Config.empty)
+        val code = readKotlinCodeFixture()
+        val findings = rule.lint(code)
+        assertTrue(findings.isEmpty())
+    }
+
+    @Test
+    fun `test forbidden import`() {
+        val config = TestConfig(
+            Pair("restrictedPackages", listOf("com.example")),
+        )
+        val rule = DiscouragedImportRule(config)
+        val code = readKotlinCodeFixture()
+        val findings = rule.lint(code)
+        assertDiscouragedImportFound(findings)
+    }
+
+    @Test
+    fun `test forbidden import, allowed class`() {
+        val config = TestConfig(
+            Pair("restrictedPackages", listOf("com.example")),
+            Pair("allowedFileIds", listOf("io.embrace.opentelemetry.kotlin.Test")),
+        )
+        val rule = DiscouragedImportRule(config)
+        val code = readKotlinCodeFixture()
+        val findings = rule.lint(code)
+        assertTrue(findings.isEmpty())
+    }
+
+    @Test
+    fun `test forbidden import, disallowed class`() {
+        val config = TestConfig(
+            Pair("restrictedPackages", listOf("com.example")),
+            Pair("allowedFileIds", listOf("io.embrace.opentelemetry.kotlin.SomeOtherTest")),
+        )
+        val rule = DiscouragedImportRule(config)
+        val code = readKotlinCodeFixture()
+        val findings = rule.lint(code)
+        assertDiscouragedImportFound(findings)
+    }
+
+    private fun assertDiscouragedImportFound(findings: List<Finding>) {
+        val finding = findings.single()
+        assertEquals("DiscouragedImport", finding.id)
+        assertEquals(
+            "Import from discouraged package 'com.example.discouraged.B' is not allowed.",
+            finding.message
+        )
+    }
+
+    private fun readKotlinCodeFixture(): String {
+        val classLoader = DiscouragedImportRule::class.java.classLoader
+        val res = checkNotNull(classLoader.getResource("DiscouragedImport.kt"))
+        return res.readText()
+    }
+}

--- a/custom-detekt-rules/src/test/resources/DiscouragedImport.kt
+++ b/custom-detekt-rules/src/test/resources/DiscouragedImport.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin
+
+import com.foo.allowed.A
+import com.example.discouraged.B
+
+class Foo

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ koverGradlePlugin = "0.9.1"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinMultiplatform = { module = "org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin", version.ref = "kotlin" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
+detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 binary-compatibility-validator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -1,20 +1,20 @@
 package io.embrace.opentelemetry.kotlin.tracing.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpanAdapter
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpanAdapter
-import io.opentelemetry.context.Context
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaSpanProcessorAdapter(
     private val impl: SpanProcessor
 ) : OtelJavaSpanProcessor {
 
-    override fun onStart(parentContext: Context, span: OtelJavaReadWriteSpan) {
+    override fun onStart(parentContext: OtelJavaContext, span: OtelJavaReadWriteSpan) {
         impl.onStart(ReadWriteSpanAdapter(span), parentContext.toOtelKotlinContext())
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -1,12 +1,12 @@
 package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusData
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
@@ -72,18 +72,18 @@ internal class ReadWriteSpanAdapter(
     }
 
     override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
-        impl.setAttribute(AttributeKey.booleanArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.booleanArrayKey(key), value)
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
-        impl.setAttribute(AttributeKey.stringArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.stringArrayKey(key), value)
     }
 
     override fun setLongListAttribute(key: String, value: List<Long>) {
-        impl.setAttribute(AttributeKey.longArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.longArrayKey(key), value)
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
-        impl.setAttribute(AttributeKey.doubleArrayKey(key), value)
+        impl.setAttribute(OtelJavaAttributeKey.doubleArrayKey(key), value)
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -4,6 +4,8 @@ import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaScope
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
@@ -15,9 +17,6 @@ import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusData
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.ImplicitContextKeyed
-import io.opentelemetry.context.Scope
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -29,7 +28,7 @@ internal class SpanAdapter(
     parentCtx: OtelJavaContext?,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,
-) : Span, ImplicitContextKeyed {
+) : Span, OtelJavaImplicitContextKeyed {
 
     private val attrs: MutableMap<String, Any> = ConcurrentHashMap()
     private val eventsImpl: ConcurrentLinkedQueue<EventData> = ConcurrentLinkedQueue()
@@ -139,11 +138,11 @@ internal class SpanAdapter(
         attrs[key] = value
     }
 
-    override fun storeInContext(context: Context): Context? {
+    override fun storeInContext(context: OtelJavaContext): OtelJavaContext? {
         return impl.storeInContext(context)
     }
 
-    override fun makeCurrent(): Scope? {
+    override fun makeCurrent(): OtelJavaScope? {
         return impl.makeCurrent()
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
     ":opentelemetry-kotlin-testing",
     ":opentelemetry-kotlin-test-fakes",
     ":opentelemetry-java-typealiases",
+    ":custom-detekt-rules",
     "examples:jvm-app-java-api",
     "examples:jvm-app-kotlin-api",
     "examples:android-app-java-api",


### PR DESCRIPTION
## Goal

Sets up a [custom detekt rule](https://detekt.dev/docs/introduction/extensions/) that finds when an unwanted import is used in a project. This is similar to `ForbiddenImport` built-in to detekt, but crucially allows for the behavior to be disabled on certain files.

In practice, we can use this to confine all uses of the OpenTelemetry Java API to a single file (Aliases.kt) and enforce the style convention of using `OtelJava*` when referring to opentelemetry-java symbols.
