### PR TITLE
Span locking model

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/otel/KotlinConfig.kt
@@ -49,4 +49,5 @@ private fun KotlinCommonCompilerOptions.configureCompiler() {
     allWarningsAsErrors.set(true)
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     languageVersion.set(KotlinVersion.KOTLIN_1_8)
+    freeCompilerArgs.add("-Xexpect-actual-classes")
 }

--- a/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
+++ b/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
@@ -1,3 +1,9 @@
+public final class io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock {
+	public fun <init> ()V
+	public final fun read (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun write (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
 public final class io/embrace/opentelemetry/kotlin/Sync_jvmKt {
 	public static final fun sync (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }

--- a/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.apple.kt
+++ b/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.apple.kt
@@ -3,3 +3,9 @@ package io.embrace.opentelemetry.kotlin
 public actual inline fun <R> sync(lock: Any, block: () -> R): R {
     throw UnsupportedOperationException()
 }
+
+public actual class ReentrantReadWriteLock {
+    public actual fun <T> write(action: () -> T): T = throw UnsupportedOperationException()
+    public actual fun <T> read(action: () -> T): T = throw UnsupportedOperationException()
+}
+

--- a/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.kt
+++ b/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.kt
@@ -4,3 +4,19 @@ package io.embrace.opentelemetry.kotlin
  * Executes the block synchronously with an exclusion lock.
  */
 public expect inline fun <R> sync(lock: Any, block: () -> R): R
+
+/**
+ * A reentrant implementation of a read-write lock.
+ */
+public expect class ReentrantReadWriteLock() {
+
+    /**
+     * Performs an operation behind the write lock.
+     */
+    public fun <T> write(action: () -> T): T
+
+    /**
+     * Performs an operation behind the read lock.
+     */
+    public fun <T> read(action: () -> T): T
+}

--- a/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.jvm.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/Sync.jvm.kt
@@ -1,6 +1,18 @@
 package io.embrace.opentelemetry.kotlin
 
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
 public actual inline fun <R> sync(lock: Any, block: () -> R): R =
     synchronized(lock) {
         block()
     }
+
+public actual class ReentrantReadWriteLock {
+    private val lock: ReentrantReadWriteLock = ReentrantReadWriteLock()
+
+    public actual fun <T> write(action: () -> T): T = lock.write { action() }
+
+    public actual fun <T> read(action: () -> T): T = lock.read { action() }
+}


### PR DESCRIPTION
## Goal

Implements a locking model for spans. The rules for this approach would be:

1. The span needs to be recording for any operation to take place
2. Any write operations must take place behind a lock
3. Read operations do not need to take place behind a lock, but must copy the collection/object if it's not immutable

The main consideration I had is whether _everything_ on the `Span` interface need to be behind the same lock? My default answer is yes, we could segment the locking if performance shows this is necessary later on.

The implementation of `doubleCheckedLockSync` also uses `synchronized` for the JVM. I wonder if `ReadWriteLock` would be a better fit, as that would allow multiple concurrent reads if no writes were happening.
