### PR TITLE
Span exporter implementation

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/SdkErrorHandler.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/SdkErrorHandler.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.error
+
+/**
+ * Handles errors and misuse of the SDK.
+ */
+internal interface SdkErrorHandler {
+
+    /**
+     * Called when the API was misused (e.g. passing an empty string to something that requires non-empty)
+     */
+    fun onApiMisuse(api: String, details: String, severity: SdkErrorSeverity)
+
+    /**
+     * Called when user-supplied code throws
+     */
+    fun onUserCodeError(exc: Throwable, details: String, severity: SdkErrorSeverity)
+
+    /**
+     * Called when SDK code throws
+     */
+    fun onSdkCodeError(exc: Throwable, details: String, severity: SdkErrorSeverity)
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/SdkErrorSeverity.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/SdkErrorSeverity.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin.error
+
+internal enum class SdkErrorSeverity {
+    INFO,
+    WARNING,
+    ERROR
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/BatchExportOperation.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/BatchExportOperation.kt
@@ -1,0 +1,36 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
+import io.embrace.opentelemetry.kotlin.error.SdkErrorSeverity
+
+/**
+ * Performs an export operation on each element in a List and returns a success code if each
+ * operation is successful, or a failure code if any operation fails.
+ */
+@OptIn(ExperimentalApi::class)
+internal fun <T> batchExportOperation(
+    elements: List<T>,
+    sdkErrorHandler: SdkErrorHandler,
+    action: (T) -> OperationResultCode
+): OperationResultCode {
+    var success = true
+
+    elements.forEach {
+        try {
+            val exportResult = action(it)
+            success = success && exportResult == OperationResultCode.Success
+        } catch (exc: Throwable) {
+            success = false
+            sdkErrorHandler.onUserCodeError(
+                exc,
+                "Export operation failed",
+                SdkErrorSeverity.WARNING
+            )
+        }
+    }
+    return when {
+        success -> OperationResultCode.Success
+        else -> OperationResultCode.Failure
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeTelemetryCloseable(
+    private val closeables: List<TelemetryCloseable>,
+    private val sdkErrorHandler: SdkErrorHandler,
+) : TelemetryCloseable {
+
+    override fun forceFlush(): OperationResultCode =
+        batchExportOperation(closeables, sdkErrorHandler, TelemetryCloseable::forceFlush)
+
+    override fun shutdown(): OperationResultCode =
+        batchExportOperation(closeables, sdkErrorHandler, TelemetryCloseable::shutdown)
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanExporter.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanExporter.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
+import io.embrace.opentelemetry.kotlin.export.CompositeTelemetryCloseable
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
+import io.embrace.opentelemetry.kotlin.export.batchExportOperation
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeSpanExporter(
+    private val exporters: List<SpanExporter>,
+    private val sdkErrorHandler: SdkErrorHandler,
+    private val telemetryCloseable: CompositeTelemetryCloseable = CompositeTelemetryCloseable(
+        exporters,
+        sdkErrorHandler,
+    )
+) : SpanExporter, TelemetryCloseable by telemetryCloseable {
+
+    override fun export(telemetry: List<SpanData>): OperationResultCode =
+        batchExportOperation(exporters, sdkErrorHandler) {
+            it.export(telemetry)
+        }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/error/FakeSdkErrorHandler.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/error/FakeSdkErrorHandler.kt
@@ -1,0 +1,46 @@
+package io.embrace.opentelemetry.kotlin.error
+
+internal class FakeSdkErrorHandler : SdkErrorHandler {
+
+    class ApiMisuseDetails(
+        val api: String,
+        val details: String,
+        val severity: SdkErrorSeverity
+    )
+
+    class SdkErrorDetails(
+        val exc: Throwable,
+        val details: String,
+        val severity: SdkErrorSeverity
+    )
+
+    val apiMisuses = mutableListOf<ApiMisuseDetails>()
+    val userCodeErrors = mutableListOf<SdkErrorDetails>()
+    val sdkCodeErrors = mutableListOf<SdkErrorDetails>()
+
+    fun hasErrors(): Boolean = apiMisuses.isNotEmpty() || userCodeErrors.isNotEmpty() || sdkCodeErrors.isNotEmpty()
+
+    override fun onApiMisuse(
+        api: String,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+        apiMisuses.add(ApiMisuseDetails(api, details, severity))
+    }
+
+    override fun onUserCodeError(
+        exc: Throwable,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+        userCodeErrors.add(SdkErrorDetails(exc, details, severity))
+    }
+
+    override fun onSdkCodeError(
+        exc: Throwable,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+        sdkCodeErrors.add(SdkErrorDetails(exc, details, severity))
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
@@ -1,0 +1,157 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode.Failure
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode.Success
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeSpanData
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeSpanExporterTest {
+
+    private val fakeTelemetry = listOf(FakeSpanData())
+    private lateinit var errorHandler: FakeSdkErrorHandler
+
+    @BeforeTest
+    fun setUp() {
+        errorHandler = FakeSdkErrorHandler()
+    }
+
+    @Test
+    fun `test no span exporters`() {
+        val exporter = CompositeSpanExporter(emptyList(), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Success,
+            Success
+        )
+        assertFalse(errorHandler.hasErrors())
+    }
+
+    @Test
+    fun `test multiple span exporters`() {
+        val first = FakeSpanExporter()
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Success,
+            Success
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one exporter export fails`() {
+        val first = FakeSpanExporter(exportReturnValue = { Failure })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Failure,
+            Success,
+            Success
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one exporter flush fails`() {
+        val first = FakeSpanExporter(forceFlushReturnValue = { Failure })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Failure,
+            Success
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one exporter shutdown fails`() {
+        val first = FakeSpanExporter(shutdownReturnValue = { Failure })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Success,
+            Failure
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one exporter throws exception in export`() {
+        val first = FakeSpanExporter(exportReturnValue = { throw IllegalStateException() })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Failure,
+            Success,
+            Success
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    @Test
+    fun `test one exporter throws exception in flush`() {
+        val first = FakeSpanExporter(forceFlushReturnValue = { throw IllegalStateException() })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Failure,
+            Success
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    @Test
+    fun `test one exporter throws exception in shutdown`() {
+        val first = FakeSpanExporter(shutdownReturnValue = { throw IllegalStateException() })
+        val second = FakeSpanExporter()
+        val exporter = CompositeSpanExporter(listOf(first, second), errorHandler)
+        exporter.assertReturnValuesMatch(
+            Success,
+            Success,
+            Failure
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    private fun CompositeSpanExporter.assertReturnValuesMatch(
+        export: OperationResultCode,
+        flush: OperationResultCode,
+        shutdown: OperationResultCode
+    ) {
+        assertEquals(shutdown, shutdown())
+        assertEquals(flush, forceFlush())
+        assertEquals(export, export(fakeTelemetry))
+    }
+
+    private fun assertTelemetryCapturedSuccess(
+        first: FakeSpanExporter,
+        second: FakeSpanExporter
+    ) {
+        assertFalse(errorHandler.hasErrors())
+        assertSame(fakeTelemetry.single(), first.exports.single())
+        assertSame(fakeTelemetry.single(), second.exports.single())
+    }
+
+    private fun assertTelemetryCapturedFailure(
+        first: FakeSpanExporter,
+        second: FakeSpanExporter
+    ) {
+        assertTrue(errorHandler.hasErrors())
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertSame(fakeTelemetry.single(), first.exports.single())
+        assertSame(fakeTelemetry.single(), second.exports.single())
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanExporter.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanExporter.kt
@@ -1,0 +1,23 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+
+@OptIn(ExperimentalApi::class)
+class FakeSpanExporter(
+    val exportReturnValue: (List<SpanData>) -> OperationResultCode = { OperationResultCode.Success },
+    val forceFlushReturnValue: () -> OperationResultCode = { OperationResultCode.Success },
+    val shutdownReturnValue: () -> OperationResultCode = { OperationResultCode.Success },
+) : SpanExporter {
+
+    val exports = mutableListOf<SpanData>()
+
+    override fun export(telemetry: List<SpanData>): OperationResultCode {
+        exports += telemetry
+        return exportReturnValue(telemetry)
+    }
+
+    override fun forceFlush(): OperationResultCode = forceFlushReturnValue()
+    override fun shutdown(): OperationResultCode = shutdownReturnValue()
+}


### PR DESCRIPTION
## Goal

Implements a composite `SpanExporter` that will be used to join exporters supplied by the end-user together.

## Testing

Added unit tests.
