### PR TITLE
Implement composite span processor

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
@@ -1,0 +1,46 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
+import io.embrace.opentelemetry.kotlin.export.CompositeTelemetryCloseable
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.TelemetryCloseable
+import io.embrace.opentelemetry.kotlin.export.batchExportOperation
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeSpanProcessor(
+    private val processors: List<SpanProcessor>,
+    private val sdkErrorHandler: SdkErrorHandler,
+    private val telemetryCloseable: TelemetryCloseable = CompositeTelemetryCloseable(
+        processors,
+        sdkErrorHandler
+    ),
+) : SpanProcessor, TelemetryCloseable by telemetryCloseable {
+
+    override fun onStart(
+        span: ReadWriteSpan,
+        parentContext: Context
+    ) {
+        batchExportOperation(processors, sdkErrorHandler) {
+            if (it.isStartRequired()) {
+                it.onStart(span, parentContext)
+            }
+            OperationResultCode.Success
+        }
+    }
+
+    override fun onEnd(span: ReadableSpan) {
+        batchExportOperation(processors, sdkErrorHandler) {
+            if (it.isEndRequired()) {
+                it.onEnd(span)
+            }
+            OperationResultCode.Success
+        }
+    }
+
+    override fun isStartRequired(): Boolean = true
+    override fun isEndRequired(): Boolean = true
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
@@ -1,0 +1,172 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.FakeContext
+import io.embrace.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode.Failure
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode.Success
+import io.embrace.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeSpanProcessorTest {
+
+    private val fakeSpan = FakeReadWriteSpan()
+    private val fakeContext = FakeContext()
+    private lateinit var errorHandler: FakeSdkErrorHandler
+
+    @BeforeTest
+    fun setUp() {
+        errorHandler = FakeSdkErrorHandler()
+    }
+
+    @Test
+    fun `test no span processors`() {
+        val processor = CompositeSpanProcessor(emptyList(), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Success,
+        )
+        assertFalse(errorHandler.hasErrors())
+        assertTrue(processor.isStartRequired())
+        assertTrue(processor.isEndRequired())
+    }
+
+    @Test
+    fun `test processor not invoked`() {
+        val impl = FakeSpanProcessor(startRequired = false, endRequired = false)
+        val other = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(impl, other), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Success,
+        )
+        assertTrue(impl.startCalls.isEmpty())
+        assertTrue(impl.endCalls.isEmpty())
+        assertEquals(1, other.startCalls.size)
+        assertEquals(1, other.endCalls.size)
+    }
+
+    @Test
+    fun `test multiple span processors`() {
+        val first = FakeSpanProcessor()
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Success,
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one processor flush fails`() {
+        val first = FakeSpanProcessor(flushCode = { Failure })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Failure,
+            Success,
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one processor shutdown fails`() {
+        val first = FakeSpanProcessor(shutdownCode = { Failure })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Failure,
+        )
+        assertTelemetryCapturedSuccess(first, second)
+    }
+
+    @Test
+    fun `test one processor throws exception in onStart`() {
+        val first = FakeSpanProcessor(startAction = { _, _ -> throw IllegalStateException() })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Success,
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    @Test
+    fun `test one processor throws exception in onEnd`() {
+        val first = FakeSpanProcessor(endAction = { throw IllegalStateException() })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Success,
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    @Test
+    fun `test one processor throws exception in flush`() {
+        val first = FakeSpanProcessor(flushCode = { throw IllegalStateException() })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Failure,
+            Success,
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    @Test
+    fun `test one processor throws exception in shutdown`() {
+        val first = FakeSpanProcessor(shutdownCode = { throw IllegalStateException() })
+        val second = FakeSpanProcessor()
+        val processor = CompositeSpanProcessor(listOf(first, second), errorHandler)
+        processor.assertReturnValuesMatch(
+            Success,
+            Failure,
+        )
+        assertTelemetryCapturedFailure(first, second)
+    }
+
+    private fun CompositeSpanProcessor.assertReturnValuesMatch(
+        flush: OperationResultCode,
+        shutdown: OperationResultCode
+    ) {
+        assertEquals(shutdown, shutdown())
+        assertEquals(flush, forceFlush())
+        onStart(fakeSpan, fakeContext)
+        onEnd(fakeSpan)
+    }
+
+    private fun assertTelemetryCapturedSuccess(
+        first: FakeSpanProcessor,
+        second: FakeSpanProcessor
+    ) {
+        assertFalse(errorHandler.hasErrors())
+        assertSame(fakeSpan, first.startCalls.single())
+        assertSame(fakeSpan, first.endCalls.single())
+        assertSame(fakeSpan, second.startCalls.single())
+        assertSame(fakeSpan, second.endCalls.single())
+    }
+
+    private fun assertTelemetryCapturedFailure(
+        first: FakeSpanProcessor,
+        second: FakeSpanProcessor
+    ) {
+        assertTrue(errorHandler.hasErrors())
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertSame(fakeSpan, first.startCalls.single())
+        assertSame(fakeSpan, first.endCalls.single())
+        assertSame(fakeSpan, second.startCalls.single())
+        assertSame(fakeSpan, second.endCalls.single())
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
@@ -1,0 +1,104 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+@OptIn(ExperimentalApi::class)
+class FakeReadWriteSpan(
+    override var name: String = "fake_span",
+    override var status: StatusData = StatusData.Unset,
+    override val parent: SpanContext = FakeSpanContext(),
+    override val spanContext: SpanContext = FakeSpanContext(),
+    override val spanKind: SpanKind = SpanKind.INTERNAL,
+    override val startTimestamp: Long = 0,
+    override val events: List<EventData> = emptyList(),
+    override val links: List<LinkData> = emptyList(),
+    override val attributes: Map<String, Any> = emptyMap(),
+    override val endTimestamp: Long? = 0,
+    override val resource: Resource = FakeResource(),
+    override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo(),
+    override val hasEnded: Boolean = false
+) : ReadWriteSpan {
+
+    override fun end() {
+    }
+
+    override fun end(timestamp: Long) {
+    }
+
+    override fun isRecording(): Boolean = true
+
+    override fun addLink(
+        spanContext: SpanContext,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun addEvent(
+        name: String,
+        timestamp: Long?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setBooleanListAttribute(
+        key: String,
+        value: List<Boolean>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setStringListAttribute(
+        key: String,
+        value: List<String>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setLongListAttribute(
+        key: String,
+        value: List<Long>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setDoubleListAttribute(
+        key: String,
+        value: List<Double>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun toSpanData(): SpanData {
+        throw UnsupportedOperationException()
+    }
+}


### PR DESCRIPTION
## Goal

Implements a composite `SpanProcessor` that will be used to join processors supplied by the end-user together.

## Testing

Added unit tests.
