### PR TITLE
Improve span model

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -3,9 +3,10 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+import io.embrace.opentelemetry.kotlin.tracing.model.CreatedSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanImpl
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanRecord
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
 @Suppress("unused")
@@ -21,6 +22,7 @@ internal class TracerImpl(private val key: ApiProviderKey) : Tracer {
     ): Span {
         val spanRelationships = SpanRelationshipsImpl()
         action(spanRelationships)
-        return SpanImpl(spanRelationships.attrs)
+        val spanRecord = SpanRecord(spanRelationships.attrs)
+        return CreatedSpan(spanRecord)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/CreatedSpan.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/CreatedSpan.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A view of [SpanRecord] that is returned after creating a span. State is largely read-only,
+ * excepting the ability to add links, events, attributes, and alter name/status. Resource/scope
+ * information is not available.
+ */
+@OptIn(ExperimentalApi::class)
+internal class CreatedSpan(private val record: SpanRecord) : Span by record

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanImpl.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A view of [SpanRecord] that is returned when read-write operations are permissible on a span.
+ * Currently this is just in [io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor].
+ */
+@OptIn(ExperimentalApi::class)
+internal class ReadWriteSpanImpl(private val record: SpanRecord) : ReadWriteSpan by record

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanImpl.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.tracing.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A view of [SpanRecord] that is returned when only read operations are permissible on a span.
+ * Currently this is just in [io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor].
+ */
+@OptIn(ExperimentalApi::class)
+internal class ReadableSpanImpl(private val record: SpanRecord) : ReadWriteSpan by record

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
@@ -1,17 +1,24 @@
 package io.embrace.opentelemetry.kotlin.tracing.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 
+/**
+ * The single source of truth for span state. This is not exposed to consumers of the API - they
+ * are presented with views such as [CreatedSpan], depending on which API call they make.
+ */
 @OptIn(ExperimentalApi::class)
-internal class SpanImpl(
+internal class SpanRecord(
     private val attrs: MutableAttributeContainer = MutableAttributeContainerImpl()
-) : Span {
+) : ReadWriteSpan {
 
     private val lock = ReentrantReadWriteLock()
 
@@ -66,6 +73,22 @@ internal class SpanImpl(
     ) {
         throw UnsupportedOperationException()
     }
+
+    override fun toSpanData(): SpanData {
+        throw UnsupportedOperationException()
+    }
+
+    override val endTimestamp: Long?
+        get() = throw UnsupportedOperationException()
+
+    override val resource: Resource
+        get() = throw UnsupportedOperationException()
+
+    override val instrumentationScopeInfo: InstrumentationScopeInfo
+        get() = throw UnsupportedOperationException()
+
+    override val hasEnded: Boolean
+        get() = throw UnsupportedOperationException()
 
     override val attributes: Map<String, Any>
         get() = readSpan {


### PR DESCRIPTION
## Goal

Makes the `SpanRecord` the single source of truth, and creates several views onto that truth in the form of read-only/write implementations that will be used in the processor/export cycle.
