### PR TITLE
Pass through pre-requisites for span processing

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin
 import io.embrace.opentelemetry.kotlin.clock.ClockImpl
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigImpl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
@@ -22,9 +23,10 @@ public fun OpenTelemetryInstance.default(
 ): OpenTelemetry {
     val tracingConfig = TracerProviderConfigImpl().apply(tracerProvider).generateTracingConfig()
     val loggingConfig = LoggerProviderConfigImpl().apply(loggerProvider).generateLoggingConfig()
+    val sdkErrorHandler = NoopSdkErrorHandler
     return OpenTelemetryImpl(
-        tracerProvider = TracerProviderImpl(tracingConfig),
-        loggerProvider = LoggerProviderImpl(loggingConfig),
+        tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkErrorHandler),
+        loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkErrorHandler),
         clock = clock,
         objectCreator = objectCreator
     )

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/NoopSdkErrorHandler.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/error/NoopSdkErrorHandler.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin.error
+
+internal object NoopSdkErrorHandler : SdkErrorHandler {
+
+    override fun onApiMisuse(
+        api: String,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+    }
+
+    override fun onUserCodeError(
+        exc: Throwable,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+    }
+
+    override fun onSdkCodeError(
+        exc: Throwable,
+        details: String,
+        severity: SdkErrorSeverity
+    ) {
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.logging
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
@@ -8,7 +9,10 @@ import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
 
 @Suppress("unused")
 @OptIn(ExperimentalApi::class)
-internal class LoggerImpl(private val key: ApiProviderKey) : Logger {
+internal class LoggerImpl(
+    private val clock: Clock,
+    private val key: ApiProviderKey
+) : Logger {
 
     override fun log(
         body: String?,

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -1,17 +1,23 @@
 package io.embrace.opentelemetry.kotlin.logging
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
 
+@Suppress("UNUSED_PARAMETER")
 @OptIn(ExperimentalApi::class)
 internal class LoggerProviderImpl(
-    @Suppress("UNUSED_PARAMETER") loggingConfig: LoggingConfig
+    private val clock: Clock,
+    loggingConfig: LoggingConfig,
+    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : LoggerProvider {
 
     private val apiProvider = ApiProviderImpl<Logger> { key ->
-        LoggerImpl(key)
+        LoggerImpl(clock, key)
     }
 
     override fun getLogger(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.CreatedSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
@@ -11,7 +13,11 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
 @Suppress("unused")
 @OptIn(ExperimentalApi::class)
-internal class TracerImpl(private val key: ApiProviderKey) : Tracer {
+internal class TracerImpl(
+    private val clock: Clock,
+    private val processor: SpanProcessor,
+    private val key: ApiProviderKey
+) : Tracer {
 
     override fun createSpan(
         name: String,
@@ -22,7 +28,7 @@ internal class TracerImpl(private val key: ApiProviderKey) : Tracer {
     ): Span {
         val spanRelationships = SpanRelationshipsImpl()
         action(spanRelationships)
-        val spanRecord = SpanRecord(spanRelationships.attrs)
+        val spanRecord = SpanRecord(clock, processor, spanRelationships.attrs)
         return CreatedSpan(spanRecord)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -1,17 +1,24 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
+import io.embrace.opentelemetry.kotlin.tracing.export.CompositeSpanProcessor
 
 @OptIn(ExperimentalApi::class)
 internal class TracerProviderImpl(
-    @Suppress("UNUSED_PARAMETER") tracingConfig: TracingConfig
+    private val clock: Clock,
+    tracingConfig: TracingConfig,
+    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : TracerProvider {
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
-        TracerImpl(key)
+        val processor = CompositeSpanProcessor(tracingConfig.processors, sdkErrorHandler)
+        TracerImpl(clock, processor, key)
     }
 
     override fun getTracer(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.tracing.model
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.ReentrantReadWriteLock
@@ -10,6 +11,7 @@ import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 /**
  * The single source of truth for span state. This is not exposed to consumers of the API - they
@@ -17,6 +19,8 @@ import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
  */
 @OptIn(ExperimentalApi::class)
 internal class SpanRecord(
+    @Suppress("unused") private val clock: Clock,
+    @Suppress("unused") private val processor: SpanProcessor,
     private val attrs: MutableAttributeContainer = MutableAttributeContainerImpl()
 ) : ReadWriteSpan {
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
@@ -12,6 +13,7 @@ import kotlin.test.assertSame
 @OptIn(ExperimentalApi::class)
 internal class LoggerProviderImplTest {
 
+    private val clock = FakeClock()
     private val loggingConfig = LoggingConfig(
         emptyList(),
         LogLimitConfig(100, 100),
@@ -20,13 +22,13 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test minimal logger provider`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         assertNotNull(impl.getLogger(name = ""))
     }
 
     @Test
     fun `test full logger provider`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         val first = impl.getLogger(
             name = "name",
             version = "0.1.0",
@@ -39,7 +41,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider name`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         val first = impl.getLogger(name = "name")
         val second = impl.getLogger(name = "name")
         val third = impl.getLogger(name = "other")
@@ -49,7 +51,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider version`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         val first = impl.getLogger(name = "name", version = "0.1.0")
         val second = impl.getLogger(name = "name", version = "0.1.0")
         val third = impl.getLogger(name = "name", version = "0.2.0")
@@ -59,7 +61,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider schemaUrl`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         val first = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val second = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val third = impl.getLogger(name = "name", schemaUrl = "https://example.com/bar")
@@ -69,7 +71,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider attributes`() {
-        val impl = LoggerProviderImpl(loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig)
         val first = impl.getLogger(name = "name") {
             setStringAttribute("key", "value")
         }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImplTest.kt
@@ -2,7 +2,9 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,7 +29,7 @@ internal class TracerImplTest {
 
     @BeforeTest
     fun setUp() {
-        tracer = TracerImpl(key)
+        tracer = TracerImpl(FakeClock(), FakeSpanProcessor(), key)
     }
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
@@ -12,6 +13,7 @@ import kotlin.test.assertSame
 @OptIn(ExperimentalApi::class)
 internal class TracerProviderImplTest {
 
+    private val clock: FakeClock = FakeClock()
     private val tracingConfig = TracingConfig(
         emptyList(),
         SpanLimitConfig(100, 100, 100, 100, 100),
@@ -20,13 +22,13 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test minimal tracer provider`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         assertNotNull(impl.getTracer(name = ""))
     }
 
     @Test
     fun `test full tracer provider`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(
             name = "name",
             version = "0.1.0",
@@ -39,7 +41,7 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider name`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name")
         val second = impl.getTracer(name = "name")
         val third = impl.getTracer(name = "other")
@@ -49,7 +51,7 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider version`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name", version = "0.1.0")
         val second = impl.getTracer(name = "name", version = "0.1.0")
         val third = impl.getTracer(name = "name", version = "0.2.0")
@@ -59,7 +61,7 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider schemaUrl`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
         val second = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
         val third = impl.getTracer(name = "name", schemaUrl = "https://example.com/bar")
@@ -69,7 +71,7 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider attributes`() {
-        val impl = TracerProviderImpl(tracingConfig)
+        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name") {
             setStringAttribute("key", "value")
         }


### PR DESCRIPTION
## Goal

Passes through some pre-requisite objects for span processing to `SpanRecord`, such as the `Clock` and `SpanProcessor` implementations.

