### PR TITLE
Support onEnd for span processor

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
-internal class TracerImplTest {
+internal class SpanAttributesTest {
 
     private val expected = mapOf(
         "string" to "value",

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEndTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEndTest.kt
@@ -1,0 +1,75 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class SpanEndTest {
+
+    private val key = ApiProviderKey("key")
+    private lateinit var tracer: TracerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeSpanProcessor
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeSpanProcessor()
+        tracer = TracerImpl(clock, processor, key)
+    }
+
+    @Test
+    fun `test span end explicit timestamp`() {
+        val timestamp = 100L
+        val span = tracer.createSpan("test")
+        span.end(timestamp)
+
+        val endedSpan = processor.endCalls.single()
+        assertEquals(timestamp, endedSpan.endTimestamp)
+    }
+
+    @Test
+    fun `test span end implicit timestamp`() {
+        val timestamp = 50L
+        clock.time = timestamp
+        val span = tracer.createSpan("test")
+        span.end()
+
+        val endedSpan = processor.endCalls.single()
+        assertEquals(timestamp, endedSpan.endTimestamp)
+    }
+
+    @Test
+    fun `test span isRecording`() {
+        val span = tracer.createSpan("test")
+        assertTrue(span.isRecording())
+        span.end()
+        assertFalse(span.isRecording())
+    }
+
+    @Test
+    fun `test span multiple end calls`() {
+        val span = tracer.createSpan("test")
+        assertTrue(span.isRecording())
+
+        val timestamp = 100L
+        span.end(timestamp)
+        assertFalse(span.isRecording())
+
+        span.end(80)
+        assertFalse(span.isRecording())
+
+        span.end()
+        assertFalse(span.isRecording())
+
+        val endedSpan = processor.endCalls.single()
+        assertEquals(timestamp, endedSpan.endTimestamp)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/clock/FakeClock.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/clock/FakeClock.kt
@@ -4,6 +4,8 @@ import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-class FakeClock : Clock {
-    override fun now(): Long = 0
+class FakeClock(
+    var time: Long = 0
+) : Clock {
+    override fun now(): Long = time
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
@@ -16,7 +16,7 @@ class FakeSpanProcessor(
     var endAction: (ReadableSpan) -> Unit = {}
 ) : SpanProcessor {
 
-    val startCalls = mutableListOf<ReadableSpan>()
+    val startCalls = mutableListOf<ReadWriteSpan>()
     val endCalls = mutableListOf<ReadableSpan>()
 
     override fun onStart(


### PR DESCRIPTION
## Goal

Adds initial support for the `onEnd` callback in span processing.

## Testing

Added unit test coverage.
