### PR TITLE
Add support for onStart call for span processors

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
@@ -25,7 +25,7 @@ public fun OpenTelemetryInstance.default(
     val loggingConfig = LoggerProviderConfigImpl().apply(loggerProvider).generateLoggingConfig()
     val sdkErrorHandler = NoopSdkErrorHandler
     return OpenTelemetryImpl(
-        tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkErrorHandler),
+        tracerProvider = TracerProviderImpl(clock, tracingConfig, objectCreator, sdkErrorHandler),
         loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkErrorHandler),
         clock = clock,
         objectCreator = objectCreator

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
@@ -1,0 +1,20 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+internal class ContextImpl : Context {
+
+    override fun <T> createKey(name: String): ContextKey<T> = ContextKeyImpl(name)
+
+    override fun <T> set(
+        key: ContextKey<T>,
+        value: T?
+    ): Context {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T> get(key: ContextKey<T>): T? {
+        throw UnsupportedOperationException()
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKeyImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextKeyImpl.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+internal class ContextKeyImpl<T>(override val name: String) : ContextKey<T>

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ContextCreatorImpl.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.ContextImpl
+
+@OptIn(ExperimentalApi::class)
+internal class ContextCreatorImpl : ContextCreator {
+
+    private val root = ContextImpl()
+
+    override fun root(): Context {
+        return root
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.CreatedSpan
@@ -16,6 +17,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 internal class TracerImpl(
     private val clock: Clock,
     private val processor: SpanProcessor,
+    private val objectCreator: ObjectCreator,
     private val key: ApiProviderKey
 ) : Tracer {
 
@@ -28,7 +30,12 @@ internal class TracerImpl(
     ): Span {
         val spanRelationships = SpanRelationshipsImpl()
         action(spanRelationships)
-        val spanRecord = SpanRecord(clock, processor, spanRelationships.attrs)
+        val spanRecord = SpanRecord(
+            clock,
+            processor,
+            parentContext ?: objectCreator.context.root(),
+            spanRelationships.attrs
+        )
         return CreatedSpan(spanRecord)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
@@ -13,12 +14,13 @@ import io.embrace.opentelemetry.kotlin.tracing.export.CompositeSpanProcessor
 internal class TracerProviderImpl(
     private val clock: Clock,
     tracingConfig: TracingConfig,
+    objectCreator: ObjectCreator,
     sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : TracerProvider {
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
         val processor = CompositeSpanProcessor(tracingConfig.processors, sdkErrorHandler)
-        TracerImpl(clock, processor, key)
+        TracerImpl(clock, processor, objectCreator, key)
     }
 
     override fun getTracer(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
@@ -6,6 +6,7 @@ import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
@@ -21,6 +22,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 internal class SpanRecord(
     private val clock: Clock,
     private val processor: SpanProcessor,
+    private val parentContext: Context,
     private val attrs: MutableAttributeContainer = MutableAttributeContainerImpl()
 ) : ReadWriteSpan {
 
@@ -45,6 +47,7 @@ internal class SpanRecord(
     private fun endInternal(timestamp: Long) {
         writeSpan {
             endTimestamp = timestamp
+            processor.onStart(ReadWriteSpanImpl(this), parentContext)
             processor.onEnd(ReadableSpanImpl(this))
             recording = false
         }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImplTest.kt
@@ -1,0 +1,49 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creator.ContextCreatorImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class ContextImplTest {
+
+    private lateinit var creator: ContextCreatorImpl
+
+    @BeforeTest
+    fun setUp() {
+        creator = ContextCreatorImpl()
+    }
+
+    @Test
+    fun `test context obtain root`() {
+        assertSame(creator.root(), creator.root())
+    }
+
+    @Test
+    fun `test context create context key`() {
+        val ctx = creator.root()
+        assertNotEquals(ctx.createKey<String>("my_key"), ctx.createKey("my_key"))
+    }
+
+    @Test
+    fun `test context get value`() {
+        assertFailsWith<UnsupportedOperationException> {
+            val ctx = creator.root()
+            val key = ctx.createKey<String>("my_key")
+            ctx.get(key)
+        }
+    }
+
+    @Test
+    fun `test context set value`() {
+        assertFailsWith<UnsupportedOperationException> {
+            val ctx = creator.root()
+            val key = ctx.createKey<String>("my_key")
+            ctx.set(key, "")
+        }
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -3,6 +3,7 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderKey
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import kotlin.test.BeforeTest
@@ -29,7 +30,12 @@ internal class SpanAttributesTest {
 
     @BeforeTest
     fun setUp() {
-        tracer = TracerImpl(FakeClock(), FakeSpanProcessor(), key)
+        tracer = TracerImpl(
+            FakeClock(),
+            FakeSpanProcessor(),
+            FakeObjectCreator(),
+            key
+        )
     }
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -2,9 +2,11 @@ package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
 import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -13,22 +15,26 @@ import kotlin.test.assertSame
 @OptIn(ExperimentalApi::class)
 internal class TracerProviderImplTest {
 
-    private val clock: FakeClock = FakeClock()
     private val tracingConfig = TracingConfig(
         emptyList(),
         SpanLimitConfig(100, 100, 100, 100, 100),
         ResourceImpl(emptyMap(), null)
     )
 
+    private lateinit var impl: TracerProvider
+
+    @BeforeTest
+    fun setUp() {
+        impl = TracerProviderImpl(FakeClock(), tracingConfig, FakeObjectCreator())
+    }
+
     @Test
     fun `test minimal tracer provider`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         assertNotNull(impl.getTracer(name = ""))
     }
 
     @Test
     fun `test full tracer provider`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(
             name = "name",
             version = "0.1.0",
@@ -41,7 +47,6 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider name`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name")
         val second = impl.getTracer(name = "name")
         val third = impl.getTracer(name = "other")
@@ -51,7 +56,6 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider version`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name", version = "0.1.0")
         val second = impl.getTracer(name = "name", version = "0.1.0")
         val third = impl.getTracer(name = "name", version = "0.2.0")
@@ -61,7 +65,6 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider schemaUrl`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
         val second = impl.getTracer(name = "name", schemaUrl = "https://example.com/foo")
         val third = impl.getTracer(name = "name", schemaUrl = "https://example.com/bar")
@@ -71,7 +74,6 @@ internal class TracerProviderImplTest {
 
     @Test
     fun `test dupe tracer provider attributes`() {
-        val impl = TracerProviderImpl(clock, tracingConfig)
         val first = impl.getTracer(name = "name") {
             setStringAttribute("key", "value")
         }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeContextCreator.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeContextCreator.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.FakeContext
+
+@OptIn(ExperimentalApi::class)
+internal class FakeContextCreator : ContextCreator {
+    override fun root(): Context = FakeContext()
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeObjectCreator.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeObjectCreator.kt
@@ -3,22 +3,16 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class ObjectCreatorImpl : ObjectCreator {
-
+class FakeObjectCreator : ObjectCreator {
     override val spanContext: SpanContextCreator
         get() = throw UnsupportedOperationException()
-
     override val traceFlags: TraceFlagsCreator
         get() = throw UnsupportedOperationException()
-
     override val traceState: TraceStateCreator
         get() = throw UnsupportedOperationException()
-
-    override val context: ContextCreator = ContextCreatorImpl()
-
+    override val context: ContextCreator = FakeContextCreator()
     override val span: SpanCreator
         get() = throw UnsupportedOperationException()
-
     override val idCreator: TracingIdCreator
         get() = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
## Goal

Adds support for calling `onStart` for `SpanProcessor` when a span ends. 

## Testing

Added unit tests.

