### PR TITLE
Improve span conversion function

### DIFF
--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
@@ -1,7 +1,16 @@
 package io.embrace.opentelemetry.kotlin.integration.test.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanContext
+import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanData
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeEventData
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeLinkData
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,9 +20,109 @@ internal class ReadableSpanConversionTest {
     @Test
     fun `test conversion`() {
         val original = FakeReadWriteSpan(
-            attributes = mapOf("foo" to "bar")
+            name = "name",
+            spanKind = SpanKind.PRODUCER,
+            startTimestamp = 500,
+            endTimestamp = 1000,
+            attributes = mapOf("foo" to "bar"),
+            links = listOf(
+                FakeLinkData(
+                    FakeSpanContext(),
+                    mapOf("foo" to "bar")
+                )
+            ),
+            events = listOf(
+                FakeEventData(
+                    "fake_event",
+                    500,
+                    mapOf("foo" to "bar")
+                )
+            ),
+            resource = FakeResource(
+                mapOf("foo" to "bar"),
+                "fake_resource",
+            ),
+            status = StatusData.Error("whoops")
         )
         val observed = original.toSerializable()
+        assertEquals(original.name, observed.name)
+        assertEquals(original.spanKind.name, observed.kind)
+        assertEquals(original.startTimestamp, observed.startTimestamp)
+        assertEquals(original.endTimestamp, observed.endTimestamp)
+        assertEquals(original.hasEnded, observed.ended)
+        assertEquals(original.status.statusCode.name, observed.statusData.name)
+        assertEquals(original.status.description, observed.statusData.description)
+        assertResource(original, observed)
+        assertInstrumentationScopeInfo(original, observed)
+        assertAttributes(original, observed)
+        assertEvents(original, observed)
+        assertLinks(original, observed)
+    }
+
+    private fun assertResource(
+        original: FakeReadWriteSpan,
+        observed: SerializableSpanData
+    ) {
+        assertEquals(original.resource.schemaUrl, observed.resource.schemaUrl)
+        assertEquals(original.resource.attributes, observed.resource.attributes)
+    }
+
+    private fun assertInstrumentationScopeInfo(
+        original: FakeReadWriteSpan,
+        observed: SerializableSpanData
+    ) {
+        assertEquals(original.instrumentationScopeInfo.name, observed.instrumentationScopeInfo.name)
+        assertEquals(
+            original.instrumentationScopeInfo.schemaUrl,
+            observed.instrumentationScopeInfo.schemaUrl
+        )
+        assertEquals(
+            original.instrumentationScopeInfo.attributes,
+            observed.instrumentationScopeInfo.attributes
+        )
+    }
+
+    private fun assertAttributes(
+        original: FakeReadWriteSpan,
+        observed: SerializableSpanData
+    ) {
+        assertEquals(original.attributes.size, observed.totalAttributeCount)
         assertEquals(original.attributes, observed.attributes)
+    }
+
+    private fun assertEvents(
+        original: FakeReadWriteSpan,
+        observed: SerializableSpanData
+    ) {
+        assertEquals(original.events.size, observed.totalRecordedEvents)
+        val origEvent = original.events.single()
+        val obsEvent = observed.events.single()
+        assertEquals(origEvent.name, obsEvent.name)
+        assertEquals(origEvent.timestamp, obsEvent.timestamp)
+        assertEquals(origEvent.attributes, obsEvent.attributes)
+    }
+
+    private fun assertLinks(
+        original: FakeReadWriteSpan,
+        observed: SerializableSpanData
+    ) {
+        assertEquals(original.links.size, observed.totalRecordedLinks)
+        val origLink = original.links.single()
+        val obsLink = observed.links.single()
+        assertEquals(origLink.attributes, obsLink.attributes)
+
+        val origSpanContext = origLink.spanContext
+        val obsSpanContext = obsLink.spanContext
+        assertSpanContext(origSpanContext, obsSpanContext)
+    }
+
+    private fun assertSpanContext(
+        lhs: SpanContext,
+        rhs: SerializableSpanContext
+    ) {
+        assertEquals(lhs.traceId, rhs.traceId)
+        assertEquals(lhs.spanId, rhs.spanId)
+        assertEquals(lhs.traceFlags.hex, rhs.traceFlags)
+        assertEquals(lhs.traceState.asMap(), rhs.traceState)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
@@ -1,29 +1,82 @@
 package io.embrace.opentelemetry.kotlin.integration.test.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableEventData
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableLinkData
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableResource
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanContext
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanData
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanStatusData
+import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
 internal fun ReadableSpan.toSerializable(): SerializableSpanData = SerializableSpanData(
-    name = "",
-    kind = "",
-    statusData = SerializableSpanStatusData("", ""),
+    name = name,
+    kind = spanKind.name,
+    statusData = status.toSerializable(),
     spanContext = SerializableSpanContext("", "", "", emptyMap()),
     parentSpanContext = SerializableSpanContext("", "", "", emptyMap()),
-    startTimestamp = -1,
-    attributes = attributes.mapValues { it.value.toString() },
-    events = emptyList(),
-    links = emptyList(),
-    endTimestamp = -1,
-    ended = false,
-    totalRecordedEvents = -1,
-    totalRecordedLinks = -1,
-    totalAttributeCount = -1,
-    resource = SerializableResource("", emptyMap()),
-    instrumentationScopeInfo = SerializableInstrumentationScopeInfo("", "", "", emptyMap())
+    startTimestamp = startTimestamp,
+    attributes = attributes.toSerializable(),
+    events = events.map(EventData::toSerializable),
+    links = links.map(LinkData::toSerializable),
+    endTimestamp = endTimestamp ?: -1,
+    ended = hasEnded,
+    totalRecordedEvents = events.size,
+    totalRecordedLinks = links.size,
+    totalAttributeCount = attributes.size,
+    resource = resource.toSerializable(),
+    instrumentationScopeInfo = instrumentationScopeInfo.toSerializable(),
+)
+
+private fun Map<String, Any>.toSerializable(): Map<String, String> =
+    mapValues { it.value.toString() }
+
+@OptIn(ExperimentalApi::class)
+private fun StatusData.toSerializable(): SerializableSpanStatusData =
+    SerializableSpanStatusData(statusCode.name, description.toString())
+
+@OptIn(ExperimentalApi::class)
+private fun Resource.toSerializable(): SerializableResource = SerializableResource(
+    schemaUrl.toString(),
+    attributes.toSerializable()
+)
+
+@OptIn(ExperimentalApi::class)
+private fun InstrumentationScopeInfo.toSerializable(): SerializableInstrumentationScopeInfo =
+    SerializableInstrumentationScopeInfo(
+        name,
+        version.toString(),
+        schemaUrl.toString(),
+        attributes.toSerializable()
+    )
+
+@OptIn(ExperimentalApi::class)
+private fun EventData.toSerializable(): SerializableEventData = SerializableEventData(
+    name,
+    attributes.toSerializable(),
+    timestamp,
+    attributes.size
+)
+
+@OptIn(ExperimentalApi::class)
+private fun LinkData.toSerializable(): SerializableLinkData = SerializableLinkData(
+    spanContext.toSerializable(),
+    attributes.toSerializable(),
+    attributes.size,
+)
+
+@OptIn(ExperimentalApi::class)
+private fun SpanContext.toSerializable(): SerializableSpanContext = SerializableSpanContext(
+    traceId,
+    spanId,
+    traceFlags.hex,
+    traceState.asMap()
 )

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_minimal.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_minimal.json
@@ -1,10 +1,10 @@
 [
   {
-    "name": "",
-    "kind": "",
+    "name": "test",
+    "kind": "INTERNAL",
     "statusData": {
-      "name": "",
-      "description": ""
+      "name": "UNSET",
+      "description": "null"
     },
     "spanContext": {
       "traceId": "",
@@ -18,25 +18,25 @@
       "traceFlags": "",
       "traceState": {}
     },
-    "startTimestamp": -1,
+    "startTimestamp": 0,
     "attributes": {
       "foo": "bar"
     },
     "events": [],
     "links": [],
-    "endTimestamp": -1,
-    "ended": false,
-    "totalRecordedEvents": -1,
-    "totalRecordedLinks": -1,
-    "totalAttributeCount": -1,
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 0,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 1,
     "resource": {
-      "schemaUrl": "",
+      "schemaUrl": "null",
       "attributes": {}
     },
     "instrumentationScopeInfo": {
-      "name": "",
-      "version": "",
-      "schemaUrl": "",
+      "name": "key",
+      "version": "null",
+      "schemaUrl": "null",
       "attributes": {}
     }
   }


### PR DESCRIPTION
## Goal

Improves the function that converts `ReadableSpan` into `SerializableSpanData` in the integration tests. This adds a bit more coverage when using the integration test frameworks as we have implemented more functionality that can be tested.
