### PR TITLE
Refactor attributes/link/event during span creation

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
@@ -1,21 +1,30 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.threadSafeList
+import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
 @OptIn(ExperimentalApi::class)
 internal class SpanRelationshipsImpl(
+    val clock: Clock,
     val attrs: MutableAttributeContainer = MutableAttributeContainerImpl()
 ) : SpanRelationships, MutableAttributeContainer by attrs {
+
+    val links = threadSafeList<LinkData>()
+    val events = threadSafeList<EventData>()
 
     override fun addLink(
         spanContext: SpanContext,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        throw UnsupportedOperationException()
+        val attrs = MutableAttributeContainerImpl().apply(attributes)
+        links.add(LinkImpl(spanContext, attrs))
     }
 
     override fun addEvent(
@@ -23,6 +32,7 @@ internal class SpanRelationshipsImpl(
         timestamp: Long?,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        throw UnsupportedOperationException()
+        val attrs = MutableAttributeContainerImpl().apply(attributes)
+        events.add(SpanEventImpl(name, timestamp ?: clock.now(), attrs))
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -30,14 +30,14 @@ internal class TracerImpl(
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit
     ): Span {
-        val spanRelationships = SpanRelationshipsImpl()
+        val spanRelationships = SpanRelationshipsImpl(clock)
         action(spanRelationships)
         val spanRecord = SpanRecord(
             clock = clock,
             processor = processor,
             parentContext = parentContext ?: objectCreator.context.root(),
             name = name,
-            attrs = spanRelationships.attrs,
+            spanRelationships = spanRelationships,
             spanKind = spanKind,
             startTimestamp = startTimestamp ?: clock.now(),
             instrumentationScopeInfo = scope,

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRecord.kt
@@ -10,6 +10,7 @@ import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.LinkImpl
 import io.embrace.opentelemetry.kotlin.tracing.SpanEventImpl
+import io.embrace.opentelemetry.kotlin.tracing.SpanRelationshipsImpl
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
@@ -26,7 +27,7 @@ internal class SpanRecord(
     private val processor: SpanProcessor,
     private val parentContext: Context,
     name: String,
-    private val attrs: MutableAttributeContainer = MutableAttributeContainerImpl(),
+    spanRelationships: SpanRelationshipsImpl,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,
@@ -94,12 +95,12 @@ internal class SpanRecord(
     override val spanContext: SpanContext
         get() = throw UnsupportedOperationException()
 
-    private val eventsList = mutableListOf<EventData>()
+    private val eventsList = spanRelationships.events.toMutableList()
 
     override val events: List<EventData>
         get() = readSpan { eventsList.toList() }
 
-    private val linksList = mutableListOf<LinkData>()
+    private val linksList = spanRelationships.links.toMutableList()
 
     override val links: List<LinkData>
         get() = readSpan { linksList.toList() }
@@ -136,32 +137,34 @@ internal class SpanRecord(
     override val hasEnded: Boolean
         get() = state == State.ENDED
 
+    private val attrs: MutableMap<String, Any> = spanRelationships.attributes.toMutableMap()
+
     override val attributes: Map<String, Any>
         get() = readSpan {
-            attrs.attributes
+            attrs.toMap()
         }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         writeSpan {
-            attrs.setBooleanAttribute(key, value)
+            attrs[key] = value
         }
     }
 
     override fun setStringAttribute(key: String, value: String) {
         writeSpan {
-            attrs.setStringAttribute(key, value)
+            attrs[key] = value
         }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
         writeSpan {
-            attrs.setLongAttribute(key, value)
+            attrs[key] = value
         }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
         writeSpan {
-            attrs.setDoubleAttribute(key, value)
+            attrs[key] = value
         }
     }
 
@@ -170,7 +173,7 @@ internal class SpanRecord(
         value: List<Boolean>
     ) {
         writeSpan {
-            attrs.setBooleanListAttribute(key, value)
+            attrs[key] = value
         }
     }
 
@@ -179,7 +182,7 @@ internal class SpanRecord(
         value: List<String>
     ) {
         writeSpan {
-            attrs.setStringListAttribute(key, value)
+            attrs[key] = value
         }
     }
 
@@ -188,7 +191,7 @@ internal class SpanRecord(
         value: List<Long>
     ) {
         writeSpan {
-            attrs.setLongListAttribute(key, value)
+            attrs[key] = value
         }
     }
 
@@ -197,7 +200,7 @@ internal class SpanRecord(
         value: List<Double>
     ) {
         writeSpan {
-            attrs.setDoubleListAttribute(key, value)
+            attrs[key] = value
         }
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -71,6 +71,25 @@ internal class SpanEventTest {
         retrieveEvents(0)
     }
 
+    @Test
+    fun `test span event added in creation`() {
+        clock.time = 2
+        tracer.createSpan("test", action = {
+            addEvent("event")
+            addEvent("event2", 5)
+            addEvent("event3", 10) {
+                setStringAttribute("foo", "bar")
+            }
+        }).apply {
+            end()
+        }
+
+        val events = retrieveEvents(3)
+        assertEventData(events[0], "event", clock.time, emptyMap())
+        assertEventData(events[1], "event2", 5, emptyMap())
+        assertEventData(events[2], "event3", 10, mapOf("foo" to "bar"))
+    }
+
     private fun retrieveEvents(expected: Int): List<EventData> {
         val events = processor.endCalls.single().events
         assertEquals(expected, events.size)

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -72,6 +72,22 @@ internal class SpanLinkTest {
         retrieveLinks(0)
     }
 
+    @Test
+    fun `test span link added in creation`() {
+        tracer.createSpan("test", action = {
+            addLink(fakeSpanContext)
+            addLink(otherFakeSpanContext) {
+                setStringAttribute("foo", "bar")
+            }
+        }).apply {
+            end()
+        }
+
+        val links = retrieveLinks(2)
+        assertLinkData(links[0], fakeSpanContext, emptyMap())
+        assertLinkData(links[1], otherFakeSpanContext, mapOf("foo" to "bar"))
+    }
+
     private fun retrieveLinks(expected: Int): List<LinkData> {
         val links = processor.endCalls.single().links
         assertEquals(expected, links.size)

--- a/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
+++ b/opentelemetry-kotlin-primitives/api/opentelemetry-kotlin-primitives.api
@@ -8,6 +8,10 @@ public final class io/embrace/opentelemetry/kotlin/Sync_jvmKt {
 	public static final fun sync (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
+public final class io/embrace/opentelemetry/kotlin/ThreadSafeList_jvmKt {
+	public static final fun threadSafeList ()Ljava/util/List;
+}
+
 public final class io/embrace/opentelemetry/kotlin/ThreadSafeMap_jvmKt {
 	public static final fun threadSafeMap ()Ljava/util/Map;
 }

--- a/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.apple.kt
+++ b/opentelemetry-kotlin-primitives/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.apple.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin
+
+public actual fun <T> threadSafeList(): MutableList<T> {
+    throw UnsupportedOperationException()
+}

--- a/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.kt
+++ b/opentelemetry-kotlin-primitives/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Creates a thread-safe list - i.e. it's possible to concurrently modify the collection without
+ * crashing. There may be platform-specific concerns around consistency of the collection.
+ */
+public expect fun <T> threadSafeList(): MutableList<T>

--- a/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.jvm.kt
+++ b/opentelemetry-kotlin-primitives/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.jvm.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+public actual fun <T> threadSafeList(): MutableList<T> = CopyOnWriteArrayList()


### PR DESCRIPTION
## Goal

Implements the addition of links/events when they are created in the lambda parameter of the `Tracer#createSpan()` function. Additionally I altered the implementation of attributes within `SpanRecord` as these are now behind a lock and their use of locking within `MutableAttributeContainer` is now redundant.

## Testing

Added unit tests.
