### PR TITLE
Rename span record

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.CreatedSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanRecord
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanModel
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanRelationships
 
 @Suppress("unused")
@@ -32,7 +32,7 @@ internal class TracerImpl(
     ): Span {
         val spanRelationships = SpanRelationshipsImpl(clock)
         action(spanRelationships)
-        val spanRecord = SpanRecord(
+        val spanModel = SpanModel(
             clock = clock,
             processor = processor,
             parentContext = parentContext ?: objectCreator.context.root(),
@@ -43,6 +43,6 @@ internal class TracerImpl(
             instrumentationScopeInfo = scope,
             resource = resource,
         )
-        return CreatedSpan(spanRecord)
+        return CreatedSpan(spanModel)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/CreatedSpan.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/CreatedSpan.kt
@@ -3,9 +3,9 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 /**
- * A view of [SpanRecord] that is returned after creating a span. State is largely read-only,
+ * A view of [SpanModel] that is returned after creating a span. State is largely read-only,
  * excepting the ability to add links, events, attributes, and alter name/status. Resource/scope
  * information is not available.
  */
 @OptIn(ExperimentalApi::class)
-internal class CreatedSpan(private val record: SpanRecord) : Span by record
+internal class CreatedSpan(private val model: SpanModel) : Span by model

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanImpl.kt
@@ -3,8 +3,8 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 /**
- * A view of [SpanRecord] that is returned when read-write operations are permissible on a span.
+ * A view of [SpanModel] that is returned when read-write operations are permissible on a span.
  * Currently this is just in [io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor].
  */
 @OptIn(ExperimentalApi::class)
-internal class ReadWriteSpanImpl(private val record: SpanRecord) : ReadWriteSpan by record
+internal class ReadWriteSpanImpl(private val model: SpanModel) : ReadWriteSpan by model

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanImpl.kt
@@ -3,8 +3,8 @@ package io.embrace.opentelemetry.kotlin.tracing.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 /**
- * A view of [SpanRecord] that is returned when only read operations are permissible on a span.
+ * A view of [SpanModel] that is returned when only read operations are permissible on a span.
  * Currently this is just in [io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor].
  */
 @OptIn(ExperimentalApi::class)
-internal class ReadableSpanImpl(private val record: SpanRecord) : ReadWriteSpan by record
+internal class ReadableSpanImpl(private val model: SpanModel) : ReadWriteSpan by model

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -22,7 +22,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
  * are presented with views such as [CreatedSpan], depending on which API call they make.
  */
 @OptIn(ExperimentalApi::class)
-internal class SpanRecord(
+internal class SpanModel(
     private val clock: Clock,
     private val processor: SpanProcessor,
     private val parentContext: Context,


### PR DESCRIPTION
## Goal

Renames `SpanRecord` to `SpanModel`.
