### PR TITLE
Implement SpanContext Creator

### DIFF
--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreator.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreator.kt
@@ -18,6 +18,12 @@ public interface SpanContextCreator {
 
     /**
      * Creates a new SpanContext.
+     *
+     * A valid traceId is a 32-character hex string (16 bytes) with at least one non-zero byte.
+     * A valid spanId is a 16-character hex string (8 bytes) with at least one non-zero byte.
+     *
+     * If traceId or spanId are invalid (wrong format, length, or all zeros), they will be replaced with all zeros
+     * and the returned SpanContext will have isValid = false.
      */
     public fun create(
         traceId: String,

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/HexUtils.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/HexUtils.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+/**
+ * Utility functions for hex string validation.
+ */
+internal object HexUtils {
+
+    /**
+     * Returns true if the character is a valid hexadecimal digit (0-9, a-f, A-F).
+     */
+    fun Char.isHexDigit(): Boolean {
+        return this.isDigit() || this in 'a'..'f' || this in 'A'..'F'
+    }
+
+    /**
+     * Returns true if the string contains only valid hexadecimal characters.
+     */
+    fun String.isValidHex(): Boolean {
+        return this.all { it.isHexDigit() }
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.creator.HexUtils.isValidHex
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlagsAdapter
 
@@ -26,6 +27,6 @@ internal class TraceFlagsCreatorImpl : TraceFlagsCreator {
     }
 
     private fun String.isValid(): Boolean {
-        return this.length == 2 && this.all { it.isDigit() || it in 'A'..'F' || it in 'a'..'f' }
+        return this.length == 2 && this.isValidHex()
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/HexUtils.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/HexUtils.kt
@@ -1,0 +1,21 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+/**
+ * Utility functions for hex string validation.
+ */
+internal object HexUtils {
+
+    /**
+     * Returns true if the character is a valid hexadecimal digit (0-9, a-f, A-F).
+     */
+    fun Char.isHexDigit(): Boolean {
+        return this.isDigit() || this in 'a'..'f' || this in 'A'..'F'
+    }
+
+    /**
+     * Returns true if the string contains only valid hexadecimal characters.
+     */
+    fun String.isValidHex(): Boolean {
+        return this.all { it.isHexDigit() }
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
@@ -5,8 +5,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 @OptIn(ExperimentalApi::class)
 internal class ObjectCreatorImpl : ObjectCreator {
 
-    override val spanContext: SpanContextCreator
-        get() = throw UnsupportedOperationException()
+    override val spanContext: SpanContextCreator = SpanContextCreatorImpl()
 
     override val traceFlags: TraceFlagsCreator
         get() = TraceFlagsCreatorImpl()

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImpl.kt
@@ -1,0 +1,67 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creator.HexUtils.isValidHex
+import io.embrace.opentelemetry.kotlin.tracing.SpanContextImpl
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
+
+@OptIn(ExperimentalApi::class)
+internal class SpanContextCreatorImpl(
+    private val traceFlagsCreator: TraceFlagsCreator = TraceFlagsCreatorImpl(),
+    private val traceStateCreator: TraceStateCreator = TraceStateCreatorImpl()
+) : SpanContextCreator {
+
+    override val invalid: SpanContext by lazy {
+        SpanContextImpl(
+            traceId = "00000000000000000000000000000000",
+            spanId = "0000000000000000",
+            traceFlags = traceFlagsCreator.default,
+            isValid = false,
+            isRemote = false,
+            traceState = traceStateCreator.default
+        )
+    }
+
+    override fun create(
+        traceId: String,
+        spanId: String,
+        traceFlags: TraceFlags,
+        traceState: TraceState
+    ): SpanContext {
+        val isValidTraceId = isValidTraceId(traceId)
+        val isValidSpanId = isValidSpanId(spanId)
+
+        return SpanContextImpl(
+            traceId = if (isValidTraceId) traceId else "00000000000000000000000000000000",
+            spanId = if (isValidSpanId) spanId else "0000000000000000",
+            traceFlags = traceFlags,
+            isValid = isValidTraceId && isValidSpanId,
+            isRemote = false,
+            traceState = traceState
+        )
+    }
+
+    private fun isValidTraceId(traceId: String): Boolean {
+        // Must be 32 hex characters (16 bytes)
+        if (traceId.length != 32) return false
+
+        // Must be valid hex
+        if (!traceId.isValidHex()) return false
+
+        // Must have at least one non-zero byte (not all zeros)
+        return traceId != "00000000000000000000000000000000"
+    }
+
+    private fun isValidSpanId(spanId: String): Boolean {
+        // Must be 16 hex characters (8 bytes)
+        if (spanId.length != 16) return false
+
+        // Must be valid hex
+        if (!spanId.isValidHex()) return false
+
+        // Must have at least one non-zero byte (not all zeros)
+        return spanId != "0000000000000000"
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.creator.HexUtils.isValidHex
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 
@@ -13,11 +14,18 @@ internal class TraceFlagsCreatorImpl : TraceFlagsCreator {
     }
 
     override fun fromHex(hex: String): TraceFlags {
-        if (hex.length != 2) return TraceFlagsImpl(isSampled = false, isRandom = false)
+        if (!hex.isValid()) {
+            return TraceFlagsImpl(isSampled = false, isRandom = false)
+        }
 
-        val byte = hex.toIntOrNull(16)?.toByte() ?: return TraceFlagsImpl(isSampled = false, isRandom = false)
-        val isRandom = (byte.toInt() and 0b00000010) != 0
-        val isSampled = (byte.toInt() and 0b00000001) != 0
-        return TraceFlagsImpl(isSampled = isSampled, isRandom = isRandom)
+        val byte = hex.toInt(16)
+        return TraceFlagsImpl(
+            isSampled = (byte and 0b00000001) != 0,
+            isRandom = (byte and 0b00000010) != 0
+        )
+    }
+
+    private fun String.isValid(): Boolean {
+        return this.length == 2 && this.isValidHex()
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
@@ -1,0 +1,176 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class SpanContextCreatorImplTest {
+
+    private val traceFlagsCreator = TraceFlagsCreatorImpl()
+    private val traceStateCreator = TraceStateCreatorImpl()
+    private val creator = SpanContextCreatorImpl(traceFlagsCreator, traceStateCreator)
+
+    @Test
+    internal fun `invalid property`() {
+        val spanContext = creator.invalid
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertEquals(traceFlagsCreator.default, spanContext.traceFlags)
+        assertEquals(traceStateCreator.default, spanContext.traceState)
+        assertFalse(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+    }
+
+    @Test
+    internal fun `create valid span context`() {
+        val traceId = "12345678901234567890123456789012"
+        val spanId = "1234567890123456"
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(traceId, spanId, traceFlags, traceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertTrue(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+    }
+
+    @Test
+    internal fun `create with invalid trace ID`() {
+        val traceId = "00000000000000000000000000000000" // all zeros
+        val spanId = "1234567890123456"
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(traceId, spanId, traceFlags, traceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertFalse(spanContext.isValid) // invalid because trace ID is all zeros
+    }
+
+    @Test
+    internal fun `create with invalid span ID`() {
+        val traceId = "12345678901234567890123456789012"
+        val spanId = "0000000000000000" // all zeros
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(traceId, spanId, traceFlags, traceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertFalse(spanContext.isValid) // invalid because span ID is all zeros
+    }
+
+    @Test
+    internal fun `create with invalid length IDs`() {
+        val shortTraceId = "123"
+        val shortSpanId = "456"
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(shortTraceId, shortSpanId, traceFlags, traceState)
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertFalse(spanContext.isValid) // invalid because of wrong lengths
+    }
+
+    @Test
+    internal fun `create with invalid hex characters`() {
+        val invalidTraceId = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" // 32 chars but not hex
+        val invalidSpanId = "gggggggggggggggg" // 16 chars but not hex
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(invalidTraceId, invalidSpanId, traceFlags, traceState)
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertFalse(spanContext.isValid) // invalid because of non-hex characters
+    }
+
+    @Test
+    internal fun `create with valid uppercase hex`() {
+        val traceId = "ABCDEF1234567890ABCDEF1234567890" // uppercase hex
+        val spanId = "ABCDEF1234567890" // uppercase hex
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(traceId, spanId, traceFlags, traceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertTrue(spanContext.isValid) // valid because uppercase hex is accepted
+    }
+
+    @Test
+    internal fun `create with valid lowercase hex`() {
+        val traceId = "abcdef1234567890abcdef1234567890" // lowercase hex
+        val spanId = "abcdef1234567890" // lowercase hex
+        val traceFlags = traceFlagsCreator.default
+        val traceState = traceStateCreator.default
+
+        val spanContext = creator.create(traceId, spanId, traceFlags, traceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(traceFlags, spanContext.traceFlags)
+        assertEquals(traceState, spanContext.traceState)
+        assertTrue(spanContext.isValid) // valid hex
+    }
+
+    @Test
+    internal fun `create with custom trace flags and state`() {
+        val traceId = "12345678901234567890123456789012"
+        val spanId = "1234567890123456"
+        val customTraceFlags = traceFlagsCreator.create(sampled = true, random = true)
+        val customTraceState = traceStateCreator.default
+            .put("key1", "value1")
+            .put("key2", "value2")
+
+        val spanContext = creator.create(traceId, spanId, customTraceFlags, customTraceState)
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertEquals(customTraceFlags, spanContext.traceFlags)
+        assertEquals(customTraceState, spanContext.traceState)
+        assertTrue(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+    }
+
+    @Test
+    internal fun `create with custom flags and state preserved even with invalid IDs`() {
+        val invalidTraceId = "invalid"
+        val invalidSpanId = "bad"
+        val customTraceFlags = traceFlagsCreator.create(sampled = true, random = false)
+        val customTraceState = traceStateCreator.default.put("vendor", "embrace")
+
+        val spanContext = creator.create(invalidTraceId, invalidSpanId, customTraceFlags, customTraceState)
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertEquals(customTraceFlags, spanContext.traceFlags)
+        assertEquals(customTraceState, spanContext.traceState)
+        assertFalse(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+    }
+}


### PR DESCRIPTION
## Summary

  - Implement SpanContextCreator with OpenTelemetry-compliant trace/span ID validation
  - Create shared HexUtils for hex validation

##  Considerations

  - Should we preserve the original invalid IDs instead of replacing with zeros? Current approach follows Java OpenTelemetry behavior
  - HexUtils is duplicated in both modules to avoid cross-module dependencies - is this the preferred approach?
