### PR TITLE
SpanModel span context

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
@@ -16,7 +16,7 @@ internal class ObjectCreatorImpl : ObjectCreator {
     private val contextCreatorImpl = ContextCreatorImpl()
     override val context: ContextCreator = contextCreatorImpl
 
-    override val span: SpanCreator = SpanCreatorImpl(contextCreatorImpl.spanKey)
+    override val span: SpanCreator = SpanCreatorImpl(spanContext, contextCreatorImpl.spanKey)
 
     override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImpl.kt
@@ -3,18 +3,22 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.ContextKey
+import io.embrace.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-internal class SpanCreatorImpl(private val spanKey: ContextKey<Span>) : SpanCreator {
+internal class SpanCreatorImpl(
+    spanContextCreator: SpanContextCreator,
+    private val spanKey: ContextKey<Span>
+) : SpanCreator {
 
-    override val invalid: Span
-        get() = throw UnsupportedOperationException()
+    private val invalidSpanContext = spanContextCreator.invalid
 
-    override fun fromSpanContext(spanContext: SpanContext): Span {
-        throw UnsupportedOperationException()
-    }
+    override val invalid: Span = NonRecordingSpan(invalidSpanContext, invalidSpanContext)
+
+    override fun fromSpanContext(spanContext: SpanContext): Span =
+        NonRecordingSpan(invalidSpanContext, spanContext)
 
     override fun fromContext(context: Context): Span {
         return context.get(spanKey) ?: invalid

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 
 @ExperimentalApi
 internal class TraceFlagsCreatorImpl : TraceFlagsCreator {
-    override val default: TraceFlags = TraceFlagsImpl(isSampled = false, isRandom = false)
+    override val default: TraceFlags = TraceFlagsImpl(isSampled = true, isRandom = false)
 
     override fun create(sampled: Boolean, random: Boolean): TraceFlags {
         return TraceFlagsImpl(isSampled = sampled, isRandom = random)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -32,6 +32,8 @@ internal class SpanModel(
     override val startTimestamp: Long,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,
     override val resource: Resource,
+    override val parent: SpanContext,
+    override val spanContext: SpanContext,
 ) : ReadWriteSpan {
 
     private enum class State {
@@ -88,12 +90,6 @@ internal class SpanModel(
     }
 
     override fun isRecording(): Boolean = state != State.ENDED
-
-    override val parent: SpanContext
-        get() = throw UnsupportedOperationException()
-
-    override val spanContext: SpanContext
-        get() = throw UnsupportedOperationException()
 
     private val eventsList = spanRelationships.events.toMutableList()
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
@@ -1,0 +1,28 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalApi::class)
+internal class SpanCreatorImplTest {
+
+    private val objectCreatorImpl = ObjectCreatorImpl()
+    private val creator = objectCreatorImpl.span
+
+    @Test
+    fun `invalid span`() {
+        assertFalse(creator.invalid.spanContext.isValid)
+    }
+
+    @Test
+    fun `from span context`() {
+        val spanContext = FakeSpanContext(
+            traceId = "12345678901234567890123456789012",
+            spanId = "1234567890123456",
+        )
+        assertEquals(spanContext, creator.fromSpanContext(spanContext).spanContext)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TraceFlagsCreatorImplTest.kt
@@ -15,9 +15,9 @@ internal class TraceFlagsCreatorImplTest {
     fun `default property`() {
         val flags = creator.default
 
-        assertFalse(flags.isSampled)
+        assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
+        assertEquals("01", flags.hex)
     }
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -1,0 +1,82 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class TracerSpanContextTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private lateinit var tracer: TracerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeSpanProcessor
+    private lateinit var objectCreator: ObjectCreator
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeSpanProcessor()
+        objectCreator = ObjectCreatorImpl()
+        tracer = TracerImpl(
+            clock,
+            processor,
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+    }
+
+    @Test
+    fun `test span with no explicit parent context`() {
+        val span = tracer.createSpan("test")
+        assertFalse(span.parent.isValid)
+        val spanContext = span.spanContext
+        assertValidSpanContext(spanContext)
+    }
+
+    @Test
+    fun `test span with explicit parent context, invalid span`() {
+        val invalidSpan = objectCreator.span.invalid
+        assertFalse(invalidSpan.spanContext.isValid)
+        val parentCtx = objectCreator.context.storeSpan(objectCreator.context.root(), invalidSpan)
+        val span = tracer.createSpan("test", parentContext = parentCtx)
+
+        assertFalse(span.parent.isValid)
+        val spanContext = span.spanContext
+        assertValidSpanContext(spanContext)
+    }
+
+    @Test
+    fun `test span with explicit parent context, valid span`() {
+        val parentSpan = tracer.createSpan("parent")
+        val parentCtx = objectCreator.context.storeSpan(objectCreator.context.root(), parentSpan)
+        val span = tracer.createSpan("test", parentContext = parentCtx)
+
+        assertTrue(span.parent.isValid)
+        val spanContext = span.spanContext
+        assertValidSpanContext(spanContext)
+        assertEquals(parentSpan.spanContext.traceId, spanContext.traceId)
+        assertNotEquals(parentSpan.spanContext.spanId, spanContext.spanId)
+    }
+
+    private fun assertValidSpanContext(spanContext: SpanContext) {
+        assertTrue(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+        assertNotEquals(objectCreator.idCreator.invalidTraceId, spanContext.traceId)
+        assertNotEquals(objectCreator.idCreator.invalidSpanId, spanContext.spanId)
+        assertEquals(emptyMap(), spanContext.traceState.asMap())
+        assertEquals("01", spanContext.traceFlags.hex)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeTracingIdCreator.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/FakeTracingIdCreator.kt
@@ -4,8 +4,8 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class FakeTracingIdCreator : TracingIdCreator {
-    override fun generateSpanId(): String = "0000000000000000"
-    override fun generateTraceId(): String = "00000000000000000000000000000000"
+    override fun generateSpanId(): String = "1234561234561234"
+    override fun generateTraceId(): String = "12345612345612341234561234561234"
     override val invalidTraceId: String = "0000000000000000"
     override val invalidSpanId: String = "00000000000000000000000000000000"
 }


### PR DESCRIPTION
## Goal

Supports populating the spanContext/parent properties on `SpanModel` with actual values.

## Testing

Added unit tests.
