### PR TITLE
Implement tracing id creator

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
@@ -18,6 +18,5 @@ internal class ObjectCreatorImpl : ObjectCreator {
 
     override val span: SpanCreator = SpanCreatorImpl(contextCreatorImpl.spanKey)
 
-    override val idCreator: TracingIdCreator
-        get() = throw UnsupportedOperationException()
+    override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImpl.kt
@@ -1,0 +1,26 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.random.Random
+
+@OptIn(ExperimentalApi::class)
+internal class TracingIdCreatorImpl(
+    private val random: Random = Random.Default
+) : TracingIdCreator {
+
+    override fun generateTraceId(): String = randomHex(32)
+    override fun generateSpanId(): String = randomHex(16)
+
+    override val invalidTraceId: String = "00000000000000000000000000000000"
+    override val invalidSpanId: String = "0000000000000000"
+
+    private fun randomHex(count: Int): String {
+        val bytes = random.nextBytes(count / 2)
+        return buildString(count / 2) {
+            for (byte in bytes) {
+                val unsigned = byte.toInt() and 0xFF
+                append(unsigned.toString(16).padStart(2, '0'))
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/TracingIdCreatorImplTest.kt
@@ -1,0 +1,67 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class TracingIdCreatorImplTest {
+
+    private companion object {
+        private const val SPAN_ID_PATTERN = "^[0-9a-f]{16}$"
+        private const val TRACE_ID_PATTERN = "^[0-9a-f]{32}$"
+    }
+
+    private lateinit var creator: TracingIdCreator
+
+    @BeforeTest
+    fun setUp() {
+        creator = TracingIdCreatorImpl(Random(0))
+    }
+
+    @Test
+    fun `test invalid id creation`() {
+        assertEquals("00000000000000000000000000000000", creator.invalidTraceId)
+        assertEquals("0000000000000000", creator.invalidSpanId)
+    }
+
+    @Test
+    fun `spanId has correct length and hex format`() {
+        val spanId = creator.generateSpanId()
+        assertEquals(16, spanId.length)
+        assertTrue(spanId.matches(SPAN_ID_PATTERN.toRegex()))
+    }
+
+    @Test
+    fun `traceId has correct length and hex format`() {
+        val traceId = creator.generateTraceId()
+        assertEquals(32, traceId.length)
+        assertTrue(traceId.matches(TRACE_ID_PATTERN.toRegex()))
+    }
+
+    @Test
+    fun `distinct trace IDs are generated`() {
+        assertEquals(
+            "2cc2b48c50aefe53b3974ed91e6b4ea9",
+            creator.generateTraceId()
+        )
+        assertEquals(
+            "e77bcc2f537f0b02efe86030ac2c3153",
+            creator.generateTraceId()
+        )
+        assertEquals(
+            "c0a79602f9a51310c8eed9889d46ef3b",
+            creator.generateTraceId()
+        )
+    }
+
+    @Test
+    fun `distinct span IDs are generated`() {
+        assertEquals("2cc2b48c50aefe53", creator.generateSpanId())
+        assertEquals("1e6b4ea924f9baa8", creator.generateSpanId())
+        assertEquals("537f0b02efe86030", creator.generateSpanId())
+    }
+}


### PR DESCRIPTION
## Goal

Implements the TracingIdCreator interface in Kotlin.

## Testing

Added unit tests.
