### PR TITLE
Use consistent trace IDs in integration tests

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
@@ -54,7 +54,8 @@ public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
     objectCreator: ObjectCreator = createCompatObjectCreator(),
 ): OpenTelemetry {
-    val tracerCfg = TracerProviderConfigImpl(clock).apply(tracerProvider)
+    objectCreator.idCreator
+    val tracerCfg = TracerProviderConfigImpl(clock, objectCreator).apply(tracerProvider)
     val loggerCfg = LoggerProviderConfigImpl(clock).apply(loggerProvider)
 
     return OpenTelemetryImpl(

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
@@ -3,11 +3,12 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class CompatObjectCreator : ObjectCreator {
+internal class CompatObjectCreator(
+    override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
+) : ObjectCreator {
     override val spanContext: SpanContextCreator by lazy { SpanContextCreatorImpl() }
     override val traceFlags: TraceFlagsCreator by lazy { TraceFlagsCreatorImpl() }
     override val traceState: TraceStateCreator by lazy { TraceStateCreatorImpl() }
     override val context: ContextCreator by lazy { ContextCreatorImpl() }
     override val span: SpanCreator by lazy { SpanCreatorImpl(spanContext) }
-    override val idCreator: TracingIdCreator by lazy { TracingIdCreatorImpl() }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -2,11 +2,13 @@ package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
 import io.embrace.opentelemetry.kotlin.tracing.export.OtelJavaSpanProcessorAdapter
@@ -14,13 +16,19 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 @ExperimentalApi
 internal class TracerProviderConfigImpl(
-    private val clock: Clock
+    private val clock: Clock,
+    objectCreator: ObjectCreator,
 ) : TracerProviderConfigDsl {
 
     private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
 
     init {
         builder.setClock(OtelJavaClockWrapper(clock))
+
+        val idGenerator = objectCreator.idCreator
+        if (idGenerator is OtelJavaIdGenerator) {
+            builder.setIdGenerator(idGenerator)
+        }
     }
 
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -20,14 +20,14 @@
     },
     "startTimestamp": 0,
     "attributes": {
-      "bool_key":"true",
-      "bool_list_key":"[true]",
-      "double_key":"3.14",
-      "double_list_key":"[3.14]",
-      "long_key":"42",
-      "long_list_key":"[42]",
-      "string_key":"second_value",
-      "string_list_key":"[a]"
+      "long_key": "42",
+      "bool_list_key": "[true]",
+      "bool_key": "true",
+      "string_list_key": "[a]",
+      "string_key": "second_value",
+      "double_key": "3.14",
+      "long_list_key": "[42]",
+      "double_list_key": "[3.14]"
     },
     "events": [],
     "links": [],

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
@@ -7,8 +7,8 @@
       "description": "bad_err"
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -20,14 +20,14 @@
     },
     "startTimestamp": 0,
     "attributes": {
-      "bool": "false",
-      "boolList": "[false]",
       "double": "5.4",
-      "doubleList": "[5.4]",
-      "long": "5",
-      "longList": "[5]",
       "string": "value",
-      "stringList": "[value]"
+      "bool": "false",
+      "doubleList": "[5.4]",
+      "stringList": "[value]",
+      "longList": "[5]",
+      "boolList": "[false]",
+      "long": "5"
     },
     "events": [
       {
@@ -69,8 +69,8 @@
       "description": "bad_err"
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "f9a51310c8eed9889d46ef3bafda11b1",
+      "spanId": "ac2c315346a8f5dc",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -82,14 +82,14 @@
     },
     "startTimestamp": 0,
     "attributes": {
-      "bool": "false",
-      "boolList": "[false]",
       "double": "5.4",
-      "doubleList": "[5.4]",
-      "long": "5",
-      "longList": "[5]",
       "string": "value",
-      "stringList": "[value]"
+      "bool": "false",
+      "doubleList": "[5.4]",
+      "stringList": "[value]",
+      "longList": "[5]",
+      "boolList": "[false]",
+      "long": "5"
     },
     "events": [
       {
@@ -104,8 +104,8 @@
     "links": [
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+          "spanId": "2cc2b48c50aefe53",
           "traceFlags": "01",
           "traceState": {}
         },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_edge_case_attributes.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_edge_case_attributes.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -20,13 +20,13 @@
     },
     "startTimestamp": 0,
     "attributes": {
-      "empty_string": "",
-      "empty_string_list": "[]",
-      "empty_bool_list": "[]",
       "empty_long_list": "[]",
       "empty_double_list": "[]",
+      "empty_string": "",
       "whitespace_only": " ",
-      "list_with_empty": "[, non-empty, , another-value]"
+      "empty_string_list": "[]",
+      "list_with_empty": "[, non-empty, , another-value]",
+      "empty_bool_list": "[]"
     },
     "events": [],
     "links": [],

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_events.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_events.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_limits.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_limits.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -51,8 +51,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "f9a51310c8eed9889d46ef3bafda11b1",
+      "spanId": "ac2c315346a8f5dc",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -95,8 +95,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "68c4b09c566976e517765490bce89c73",
+      "spanId": "64f6c8f22faf620c",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -121,13 +121,13 @@
     "links": [
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+          "spanId": "2cc2b48c50aefe53",
           "traceFlags": "01",
           "traceState": {}
         },
-        "totalAttributeCount": 0,
-        "attributes": {}
+        "attributes": {},
+        "totalAttributeCount": 0
       }
     ],
     "endTimestamp": 0,
@@ -148,8 +148,7 @@
       "name": "test_tracer",
       "version": "0.1.0",
       "schemaUrl": "null",
-      "attributes": {
-      }
+      "attributes": {}
     }
   }
 ]

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "f9a51310c8eed9889d46ef3bafda11b1",
+      "spanId": "ac2c315346a8f5dc",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -24,8 +24,8 @@
     "links": [
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+          "spanId": "2cc2b48c50aefe53",
           "traceFlags": "01",
           "traceState": {}
         },
@@ -71,8 +71,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_multiple_operations.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_multiple_operations.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "8972f4289e11b22e3bd72e515007f15a",
+      "spanId": "5c0c5f7b97527985",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -23,30 +23,30 @@
     "events": [
       {
         "name": "event_1",
-        "timestamp": 100,
         "attributes": {},
+        "timestamp": 100,
         "totalAttributesCount": 0
       },
       {
         "name": "event_2",
-        "timestamp": 200,
         "attributes": {
           "event_attr": "value"
         },
+        "timestamp": 200,
         "totalAttributesCount": 1
       },
       {
         "name": "event_3",
-        "timestamp": 300,
         "attributes": {},
+        "timestamp": 300,
         "totalAttributesCount": 0
       }
     ],
     "links": [
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+          "spanId": "2cc2b48c50aefe53",
           "traceFlags": "01",
           "traceState": {}
         },
@@ -55,8 +55,8 @@
       },
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "f9a51310c8eed9889d46ef3bafda11b1",
+          "spanId": "ac2c315346a8f5dc",
           "traceFlags": "01",
           "traceState": {}
         },
@@ -67,8 +67,8 @@
       },
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "68c4b09c566976e517765490bce89c73",
+          "spanId": "64f6c8f22faf620c",
           "traceFlags": "01",
           "traceState": {}
         },
@@ -105,8 +105,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -149,8 +149,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "f9a51310c8eed9889d46ef3bafda11b1",
+      "spanId": "ac2c315346a8f5dc",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -193,8 +193,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "68c4b09c566976e517765490bce89c73",
+      "spanId": "64f6c8f22faf620c",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_resource.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_resource.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorImpl.kt
@@ -3,7 +3,9 @@ package io.embrace.opentelemetry.kotlin.creator
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class ObjectCreatorImpl : ObjectCreator {
+internal class ObjectCreatorImpl(
+    override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
+) : ObjectCreator {
 
     override val spanContext: SpanContextCreator = SpanContextCreatorImpl()
 
@@ -17,6 +19,4 @@ internal class ObjectCreatorImpl : ObjectCreator {
     override val context: ContextCreator = contextCreatorImpl
 
     override val span: SpanCreator = SpanCreatorImpl(spanContext, contextCreatorImpl.spanKey)
-
-    override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
 }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -3,8 +3,11 @@ package io.embrace.opentelemetry.kotlin.integration.test
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.creator.TracingIdCreatorImpl
 import io.embrace.opentelemetry.kotlin.default
 import io.embrace.opentelemetry.kotlin.framework.OtelKotlinTestRule
+import kotlin.random.Random
 
 /**
  * Configures opentelemetry-kotlin to run for integration tests so that exported logs/traces
@@ -17,6 +20,7 @@ internal class IntegrationTestHarness : OtelKotlinTestRule() {
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
             clock = clock,
+            objectCreator = ObjectCreatorImpl(idCreator = TracingIdCreatorImpl(Random(0)))
         )
     }
 }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_ancestry.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_ancestry.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -46,14 +46,14 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "ac2c315346a8f5dc",
       "traceFlags": "01",
       "traceState": {}
     },
     "parentSpanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_attrs.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_attrs.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_basic_props.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_basic_props.json
@@ -7,8 +7,8 @@
       "description": "Whoops"
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_event.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_event.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_links.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_links.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -46,8 +46,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "ac2c315346a8f5dcc0a79602f9a51310",
+      "spanId": "9d46ef3bafda11b1",
       "traceFlags": "01",
       "traceState": {}
     },
@@ -63,8 +63,8 @@
     "links": [
       {
         "spanContext": {
-          "traceId": "00000000000000000000000000000000",
-          "spanId": "0000000000000000",
+          "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+          "spanId": "e77bcc2f537f0b02",
           "traceFlags": "01",
           "traceState": {}
         },

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_minimal.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/span_minimal.json
@@ -7,8 +7,8 @@
       "description": ""
     },
     "spanContext": {
-      "traceId": "00000000000000000000000000000000",
-      "spanId": "0000000000000000",
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
       "traceFlags": "01",
       "traceState": {}
     },

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLinkData.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLinkData.kt
@@ -5,8 +5,8 @@ import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableLinkD
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 
 @OptIn(ExperimentalApi::class)
-fun LinkData.toSerializable(sanitizeSpanContextIds: Boolean = true) = SerializableLinkData(
-    spanContext = spanContext.toSerializable(sanitizeSpanContextIds),
+fun LinkData.toSerializable() = SerializableLinkData(
+    spanContext = spanContext.toSerializable(),
     attributes = attributes.toSerializable(),
     totalAttributeCount = attributes.size,
 )

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
@@ -5,12 +5,12 @@ import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableLogRe
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
 @OptIn(ExperimentalApi::class)
-fun ReadableLogRecord.toSerializable(sanitizeSpanContextIds: Boolean = true) = SerializableLogRecordData(
+fun ReadableLogRecord.toSerializable() = SerializableLogRecordData(
     resource = resource?.toSerializable(),
     instrumentationScopeInfo = instrumentationScopeInfo?.toSerializable(),
     timestampEpochNanos = timestamp ?: 0,
     observedTimestampEpochNanos = observedTimestamp ?: 0,
-    spanContext = spanContext.toSerializable(sanitizeSpanContextIds),
+    spanContext = spanContext.toSerializable(),
     severity = severityNumber?.name.orEmpty(),
     severityText = severityText,
     body = body,

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
@@ -5,17 +5,9 @@ import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanC
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-fun SpanContext.toSerializable(sanitizeSpanContextIds: Boolean) = SerializableSpanContext(
-    traceId = if (sanitizeSpanContextIds) {
-        "0".repeat(32)
-    } else {
-        traceId
-    },
-    spanId = if (sanitizeSpanContextIds) {
-        "0".repeat(16)
-    } else {
-        spanId
-    },
+fun SpanContext.toSerializable() = SerializableSpanContext(
+    traceId = traceId,
+    spanId = spanId,
     traceFlags = traceFlags.hex,
     traceState = traceState.asMap(),
 )

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanData.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanData.kt
@@ -5,12 +5,12 @@ import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableSpanD
 import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 
 @OptIn(ExperimentalApi::class)
-fun SpanData.toSerializable(sanitizeSpanContextIds: Boolean = true) = SerializableSpanData(
+fun SpanData.toSerializable() = SerializableSpanData(
     name = name,
     kind = spanKind.name,
     statusData = status.toSerializable(),
-    spanContext = spanContext.toSerializable(sanitizeSpanContextIds),
-    parentSpanContext = parent.toSerializable(sanitizeSpanContextIds),
+    spanContext = spanContext.toSerializable(),
+    parentSpanContext = parent.toSerializable(),
     startTimestamp = startTimestamp,
     attributes = attributes.toSerializable(),
     events = events.map { it.toSerializable() },


### PR DESCRIPTION
## Goal

Updates the integration tests to use consistent IDs for tracing by supplying a seed to the underlying random number generators for both the implementation + compat modules. This is a trade-off - on balance I think it's better to assert that the traceId/spanId matches an expected output in the JSON than it is to assert the compat module is using a specific implementation of `IdGenerator`.
