### PR TITLE
Implement log model classes

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -179,13 +179,11 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getSeverityNumber ()Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;
 	public abstract fun getSeverityText ()Ljava/lang/String;
-	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;
 	public abstract fun getTimestamp ()Ljava/lang/Long;
 	public abstract fun setBody (Ljava/lang/String;)V
 	public abstract fun setObservedTimestamp (Ljava/lang/Long;)V
 	public abstract fun setSeverityNumber (Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;)V
 	public abstract fun setSeverityText (Ljava/lang/String;)V
-	public abstract fun setSpanContext (Lio/embrace/opentelemetry/kotlin/tracing/model/SpanContext;)V
 	public abstract fun setTimestamp (Ljava/lang/Long;)V
 }
 

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -192,7 +192,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getBody ()Ljava/lang/String;
-	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/context/Context;
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -2,7 +2,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
  * A read-write representation of a log record.
@@ -37,9 +36,4 @@ public interface ReadWriteLogRecord : ReadableLogRecord, MutableAttributeContain
      * Contains the body of the log message - i.e. a human-readable string or free-form string data.
      */
     public override var body: String?
-
-    /**
-     * The span context associated with the log record
-     */
-    public override var spanContext: SpanContext
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -56,12 +56,12 @@ public interface ReadableLogRecord {
     public val spanContext: SpanContext
 
     /**
-     * The resource associated with the log record, if any.
+     * The resource associated with the log record
      */
-    public val resource: Resource?
+    public val resource: Resource
 
     /**
-     * The instrumentation scope information associated with the log record, if any.
+     * The instrumentation scope information associated with the log record
      */
-    public val instrumentationScopeInfo: InstrumentationScopeInfo?
+    public val instrumentationScopeInfo: InstrumentationScopeInfo
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -2,7 +2,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
@@ -23,11 +22,6 @@ public interface ReadableLogRecord {
      * The timestamp in nanoseconds at which the event was entered into the OpenTelemetry API.
      */
     public val observedTimestamp: Long?
-
-    /**
-     * The context in which the log was emitted.
-     */
-    public val context: Context?
 
     /**
      * The severity of the log.

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -5,7 +5,6 @@ import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.attributes.toMap
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.logging.toOtelKotlinSeverityNumber
@@ -83,9 +82,6 @@ internal class ReadWriteLogRecordAdapter(
     override var spanContext: SpanContext
         get() = SpanContextAdapter(impl.spanContext)
         set(value) {}
-
-    override val context: Context?
-        get() = null
 
     override val resource: Resource
         get() = ResourceAdapter(impl.toLogRecordData().resource)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
@@ -4,9 +4,7 @@ package io.embrace.opentelemetry.kotlin.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaBody
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.attributes.attrsFromMap
 import io.embrace.opentelemetry.kotlin.attributes.resourceFromMap
@@ -23,11 +21,11 @@ internal fun ReadableLogRecord.toLogRecordData(): OtelJavaLogRecordData {
         observedTimestampNanos = observedTimestamp ?: 0,
         spanContextImpl = spanContext.toOtelJavaSpanContext(),
         severityTextImpl = severityText,
-        severityImpl = severityNumber?.toOtelJavaSeverityNumber() ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
+        severityImpl = severityNumber?.toOtelJavaSeverityNumber()
+            ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
         bodyImpl = body?.let(OtelJavaBody::string) ?: OtelJavaBody.empty(),
         attributesImpl = attrsFromMap(attributes),
-        resourceImpl = resource?.let(::resourceFromMap) ?: OtelJavaResource.empty(),
-        scopeImpl = instrumentationScopeInfo?.toOtelJavaInstrumentationScopeInfo()
-            ?: OtelJavaInstrumentationScopeInfo.empty()
+        resourceImpl = resourceFromMap(resource),
+        scopeImpl = instrumentationScopeInfo.toOtelJavaInstrumentationScopeInfo()
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -8,7 +8,6 @@ import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
-import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -148,7 +147,6 @@ internal class LogExportTest {
             with(log) {
                 timestamp = 5
                 observedTimestamp = 10
-                spanContext = FakeSpanContext("1".repeat(32), "2".repeat(16))
 
                 setStringAttribute("string", "value")
                 setBooleanAttribute("bool", false)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
-import io.embrace.opentelemetry.kotlin.context.ContextKeyAdapter
 import org.junit.Test
 import java.time.Instant
 import kotlin.test.assertEquals
@@ -29,8 +28,6 @@ internal class OtelJavaLogRecordBuilderAdapterTest {
 
         val log = impl.logs.single()
         assertEquals(body, log.body)
-        val ctxValue = log.context?.get<String>(ContextKeyAdapter(key))
-        assertEquals("value", ctxValue)
 
         val expected = now.toEpochMilli() * 1000000
         assertEquals(expected, log.timestamp)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
@@ -45,14 +45,14 @@ internal class OtelJavaLogRecordExporterAdapterTest {
         assertEquals(original.severityNumber?.severityNumber, observed.severity.severityNumber)
         assertEquals(original.body, observed.bodyValue?.asString())
         assertEquals(original.attributes, observed.attributes.toMap())
-        assertEquals(original.resource?.attributes, observed.resource.attributes.toMap())
+        assertEquals(original.resource.attributes, observed.resource.attributes.toMap())
         assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
 
         val originalScope = original.instrumentationScopeInfo
         val observedScope = observed.instrumentationScopeInfo
-        assertEquals(originalScope?.name, observedScope.name)
-        assertEquals(originalScope?.version, observedScope.version)
-        assertEquals(originalScope?.schemaUrl, observedScope.schemaUrl)
-        assertEquals(originalScope?.attributes, observedScope.attributes.toMap())
+        assertEquals(originalScope.name, observedScope.name)
+        assertEquals(originalScope.version, observedScope.version)
+        assertEquals(originalScope.schemaUrl, observedScope.schemaUrl)
+        assertEquals(originalScope.attributes, observedScope.attributes.toMap())
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
@@ -26,7 +26,7 @@ public fun OpenTelemetryInstance.default(
     val sdkErrorHandler = NoopSdkErrorHandler
     return OpenTelemetryImpl(
         tracerProvider = TracerProviderImpl(clock, tracingConfig, objectCreator, sdkErrorHandler),
-        loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkErrorHandler),
+        loggerProvider = LoggerProviderImpl(clock, loggingConfig, objectCreator, sdkErrorHandler),
         clock = clock,
         objectCreator = objectCreator
     )

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -5,13 +5,21 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.model.LogRecordModel
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecordImpl
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import io.embrace.opentelemetry.kotlin.resource.Resource
 
 @Suppress("unused")
 @OptIn(ExperimentalApi::class)
 internal class LoggerImpl(
     private val clock: Clock,
-    private val key: InstrumentationScopeInfo
+    private val processor: LogRecordProcessor,
+    private val objectCreator: ObjectCreator,
+    private val key: InstrumentationScopeInfo,
+    private val resource: Resource,
 ) : Logger {
 
     override fun log(
@@ -23,6 +31,8 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        throw UnsupportedOperationException()
+        val log = LogRecordModel()
+        val ctx = context ?: objectCreator.context.root()
+        processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -33,7 +33,11 @@ internal class LoggerImpl(
         attributes: MutableAttributeContainer.() -> Unit
     ) {
         val attrs = MutableAttributeContainerImpl().apply(attributes)
-        val log = LogRecordModel(attrs)
+        val log = LogRecordModel(
+            attributeContainer = attrs,
+            resource = resource,
+            instrumentationScopeInfo = key,
+        )
         val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -31,7 +32,8 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        val log = LogRecordModel()
+        val attrs = MutableAttributeContainerImpl().apply(attributes)
+        val log = LogRecordModel(attrs)
         val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -32,6 +32,7 @@ internal class LoggerImpl(
         attributes: MutableAttributeContainer.() -> Unit
     ) {
         val attrs = MutableAttributeContainerImpl().apply(attributes)
+        val ctx = context ?: objectCreator.context.root()
         val log = LogRecordModel(
             attributeContainer = attrs,
             resource = resource,
@@ -41,8 +42,8 @@ internal class LoggerImpl(
             body = body,
             severityText = severityText,
             severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
+            spanContext = objectCreator.span.fromContext(ctx).spanContext,
         )
-        val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -13,7 +13,6 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecordImpl
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.resource.Resource
 
-@Suppress("unused")
 @OptIn(ExperimentalApi::class)
 internal class LoggerImpl(
     private val clock: Clock,
@@ -37,6 +36,11 @@ internal class LoggerImpl(
             attributeContainer = attrs,
             resource = resource,
             instrumentationScopeInfo = key,
+            timestamp = timestamp ?: clock.now(),
+            observedTimestamp = observedTimestamp ?: clock.now(),
+            body = body,
+            severityText = severityText,
+            severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
         )
         val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -3,21 +3,24 @@ package io.embrace.opentelemetry.kotlin.logging
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
+import io.embrace.opentelemetry.kotlin.logging.export.CompositeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
 
-@Suppress("UNUSED_PARAMETER")
 @OptIn(ExperimentalApi::class)
 internal class LoggerProviderImpl(
     private val clock: Clock,
     loggingConfig: LoggingConfig,
+    objectCreator: ObjectCreator,
     sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : LoggerProvider {
 
     private val apiProvider = ApiProviderImpl<Logger> { key ->
-        LoggerImpl(clock, key)
+        val processor = CompositeLogRecordProcessor(loggingConfig.processors, sdkErrorHandler)
+        LoggerImpl(clock, processor, objectCreator, key, loggingConfig.resource)
     }
 
     override fun getLogger(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -18,29 +18,54 @@ internal class LogRecordModel(
     attributeContainer: AttributeContainer,
     override val resource: Resource,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,
+    timestamp: Long,
+    observedTimestamp: Long,
+    body: String?,
+    severityText: String?,
+    severityNumber: SeverityNumber?
 ) : ReadWriteLogRecord {
 
     private val lock = ReentrantReadWriteLock()
 
-    override var timestamp: Long?
-        get() = throw UnsupportedOperationException()
-        set(value) {}
+    override var timestamp: Long? = timestamp
+        get() = readLogRecord { field }
+        set(value) {
+            writeLogRecord {
+                field = value
+            }
+        }
 
-    override var observedTimestamp: Long?
-        get() = throw UnsupportedOperationException()
-        set(value) {}
+    override var observedTimestamp: Long? = observedTimestamp
+        get() = readLogRecord { field }
+        set(value) {
+            writeLogRecord {
+                field = value
+            }
+        }
 
-    override var severityNumber: SeverityNumber?
-        get() = throw UnsupportedOperationException()
-        set(value) {}
+    override var severityNumber: SeverityNumber? = severityNumber
+        get() = readLogRecord { field }
+        set(value) {
+            writeLogRecord {
+                field = value
+            }
+        }
 
-    override var severityText: String?
-        get() = throw UnsupportedOperationException()
-        set(value) {}
+    override var severityText: String? = severityText
+        get() = readLogRecord { field }
+        set(value) {
+            writeLogRecord {
+                field = value
+            }
+        }
 
-    override var body: String?
-        get() = throw UnsupportedOperationException()
-        set(value) {}
+    override var body: String? = body
+        get() = readLogRecord { field }
+        set(value) {
+            writeLogRecord {
+                field = value
+            }
+        }
 
     override var spanContext: SpanContext
         get() = throw UnsupportedOperationException()

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -16,6 +16,8 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 @OptIn(ExperimentalApi::class)
 internal class LogRecordModel(
     attributeContainer: AttributeContainer,
+    override val resource: Resource,
+    override val instrumentationScopeInfo: InstrumentationScopeInfo,
 ) : ReadWriteLogRecord {
 
     private val lock = ReentrantReadWriteLock()
@@ -45,12 +47,6 @@ internal class LogRecordModel(
         set(value) {}
 
     override val context: Context?
-        get() = throw UnsupportedOperationException()
-
-    override val resource: Resource?
-        get() = throw UnsupportedOperationException()
-
-    override val instrumentationScopeInfo: InstrumentationScopeInfo?
         get() = throw UnsupportedOperationException()
 
     private val attrs: MutableMap<String, Any> = attributeContainer.attributes.toMutableMap()

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -1,0 +1,96 @@
+package io.embrace.opentelemetry.kotlin.logging.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+
+/**
+ * The single source of truth for log record state. This is not exposed to consumers of the API - they
+ * are presented with views such as [ReadableLogRecordImpl], depending on which API call they make.
+ */
+@Suppress("unused", "UNUSED_PARAMETER")
+@OptIn(ExperimentalApi::class)
+internal class LogRecordModel : ReadWriteLogRecord {
+
+    override var timestamp: Long?
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override var observedTimestamp: Long?
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override var severityNumber: SeverityNumber?
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override var severityText: String?
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override var body: String?
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override var spanContext: SpanContext
+        get() = throw UnsupportedOperationException()
+        set(value) {}
+
+    override val context: Context?
+        get() = throw UnsupportedOperationException()
+
+    override val attributes: Map<String, Any>
+        get() = throw UnsupportedOperationException()
+
+    override val resource: Resource?
+        get() = throw UnsupportedOperationException()
+
+    override val instrumentationScopeInfo: InstrumentationScopeInfo?
+        get() = throw UnsupportedOperationException()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setBooleanListAttribute(
+        key: String,
+        value: List<Boolean>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setStringListAttribute(
+        key: String,
+        value: List<String>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setLongListAttribute(
+        key: String,
+        value: List<Long>
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setDoubleListAttribute(
+        key: String,
+        value: List<Double>
+    ) {
+        throw UnsupportedOperationException()
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecordImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecordImpl.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.logging.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A view of [LogRecordModel] that is returned when read and write operations are permissible on a log record.
+ */
+@OptIn(ExperimentalApi::class)
+internal class ReadWriteLogRecordImpl(
+    private val impl: ReadWriteLogRecord
+) : ReadWriteLogRecord by impl

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecordImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecordImpl.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.logging.model
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A view of [LogRecordModel] that is returned when only read operations are permissible on a log record.
+ */
+@OptIn(ExperimentalApi::class)
+internal class ReadableLogRecordImpl(
+    private val impl: ReadWriteLogRecord
+) : ReadableLogRecord by impl

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -1,0 +1,64 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.tracing.TracerImpl
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class LogContextTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private lateinit var logger: LoggerImpl
+    private lateinit var tracer: TracerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeLogRecordProcessor
+    private lateinit var objectCreator: ObjectCreator
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeLogRecordProcessor()
+        objectCreator = ObjectCreatorImpl()
+        logger = LoggerImpl(
+            clock,
+            processor,
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+        tracer = TracerImpl(
+            clock,
+            FakeSpanProcessor(),
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+    }
+
+    @Test
+    fun `test default context`() {
+        logger.log()
+        val log = processor.logs.single()
+        val root = objectCreator.span.fromContext(objectCreator.context.root()).spanContext
+        assertSame(root, log.spanContext)
+    }
+
+    @Test
+    fun `test non-default context`() {
+        val span = tracer.createSpan("span")
+        val ctx = objectCreator.context.storeSpan(objectCreator.context.root(), span)
+        logger.log(context = ctx)
+
+        val log = processor.logs.single()
+        assertSame(span.spanContext, log.spanContext)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -1,0 +1,48 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class LogMetaPropertiesTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private val fakeResource = FakeResource()
+    private lateinit var logger: LoggerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeLogRecordProcessor
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeLogRecordProcessor()
+        logger = LoggerImpl(
+            clock,
+            processor,
+            FakeObjectCreator(),
+            key,
+            fakeResource,
+        )
+    }
+
+    @Test
+    fun `test log instrumentation scope`() {
+        logger.log()
+        val log = processor.logs.single()
+        assertSame(key, log.instrumentationScopeInfo)
+    }
+
+    @Test
+    fun `test log resource`() {
+        logger.log()
+        val log = processor.logs.single()
+        assertSame(fakeResource, log.resource)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -6,9 +6,12 @@ import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalApi::class)
 internal class LogSimplePropertiesTest {
@@ -35,8 +38,35 @@ internal class LogSimplePropertiesTest {
 
     @Test
     fun `test minimal log`() {
+        val now = 5L
+        clock.time = now
         logger.log()
+
         val log = processor.logs.single()
-        checkNotNull(log)
+        assertNull(log.body)
+        assertEquals(now, log.timestamp)
+        assertEquals(now, log.observedTimestamp)
+        assertEquals(SeverityNumber.UNKNOWN, log.severityNumber)
+        assertNull(log.severityText)
+    }
+
+    @Test
+    fun `test log properties`() {
+        val body = "Hello, World!"
+        val severityText = "INFO"
+        logger.log(
+            body = body,
+            timestamp = 2,
+            observedTimestamp = 3,
+            severityNumber = SeverityNumber.INFO,
+            severityText = severityText
+        )
+
+        val log = processor.logs.single()
+        assertEquals(body, log.body)
+        assertEquals(2, log.timestamp)
+        assertEquals(3, log.observedTimestamp)
+        assertEquals(SeverityNumber.INFO, log.severityNumber)
+        assertEquals(severityText, log.severityText)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -1,0 +1,42 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogSimplePropertiesTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private lateinit var logger: LoggerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeLogRecordProcessor
+    private lateinit var objectCreator: ObjectCreator
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeLogRecordProcessor()
+        objectCreator = FakeObjectCreator()
+        logger = LoggerImpl(
+            clock,
+            processor,
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+    }
+
+    @Test
+    fun `test minimal log`() {
+        logger.log()
+        val log = processor.logs.single()
+        checkNotNull(log)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
 import io.embrace.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
@@ -19,16 +20,17 @@ internal class LoggerProviderImplTest {
         LogLimitConfig(100, 100),
         ResourceImpl(emptyMap(), null)
     )
+    private val objectCreator = ObjectCreatorImpl()
 
     @Test
     fun `test minimal logger provider`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         assertNotNull(impl.getLogger(name = ""))
     }
 
     @Test
     fun `test full logger provider`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         val first = impl.getLogger(
             name = "name",
             version = "0.1.0",
@@ -41,7 +43,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider name`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         val first = impl.getLogger(name = "name")
         val second = impl.getLogger(name = "name")
         val third = impl.getLogger(name = "other")
@@ -51,7 +53,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider version`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         val first = impl.getLogger(name = "name", version = "0.1.0")
         val second = impl.getLogger(name = "name", version = "0.1.0")
         val third = impl.getLogger(name = "name", version = "0.2.0")
@@ -61,7 +63,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider schemaUrl`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         val first = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val second = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val third = impl.getLogger(name = "name", schemaUrl = "https://example.com/bar")
@@ -71,7 +73,7 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun `test dupe logger provider attributes`() {
-        val impl = LoggerProviderImpl(clock, loggingConfig)
+        val impl = LoggerProviderImpl(clock, loggingConfig, objectCreator)
         val first = impl.getLogger(name = "name") {
             setStringAttribute("key", "value")
         }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -1,0 +1,85 @@
+package io.embrace.opentelemetry.kotlin.integration.test.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.integration.test.IntegrationTestHarness
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogProcessorNaughtyExportTest {
+
+    private lateinit var harness: IntegrationTestHarness
+
+    @BeforeTest
+    fun setUp() {
+        harness = IntegrationTestHarness()
+    }
+
+    @Test
+    fun `test override properties in LogRecordProcessor onEmit`() {
+        val processor = NaughtyLogRecordProcessor()
+        prepareConfig(processor)
+        val ctx = prepareContext()
+
+        harness.logger.log(
+            body = "custom_log",
+            timestamp = 500,
+            observedTimestamp = 600,
+            severityNumber = SeverityNumber.WARN2,
+            severityText = "warn2",
+            context = ctx,
+        ) {
+            setStringAttribute("foo", "bar")
+            setBooleanAttribute("experiment_enabled", true)
+        }
+        harness.assertLogRecords(1, "log_naughty_export.json") {
+            processor.overrideAttributes()
+        }
+    }
+
+    private fun prepareConfig(processor: LogRecordProcessor) {
+        harness.config.attributes = {
+            setStringAttribute("resource.foo", "bar")
+        }
+        harness.config.schemaUrl = "https://example.com/foo"
+        harness.config.logRecordProcessors.add(processor)
+    }
+
+    private fun prepareContext(): Context {
+        val span = harness.tracer.createSpan("span")
+        val contextCreator = harness.objectCreator.context
+        val ctx = contextCreator.storeSpan(contextCreator.root(), span)
+        return ctx
+    }
+
+    private class NaughtyLogRecordProcessor : LogRecordProcessor {
+
+        private lateinit var log: ReadWriteLogRecord
+
+        override fun onEmit(
+            log: ReadWriteLogRecord,
+            context: Context
+        ) {
+            this.log = log
+        }
+
+        fun overrideAttributes() {
+            with(log) {
+                body = "override"
+                timestamp = 123
+                observedTimestamp = 456
+                severityNumber = SeverityNumber.INFO
+                severityText = "info"
+                setStringAttribute("key", "value")
+            }
+        }
+
+        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -1,0 +1,93 @@
+package io.embrace.opentelemetry.kotlin.integration.test.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.integration.test.IntegrationTestHarness
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class LogProcessorOnEmitTest {
+
+    private lateinit var harness: IntegrationTestHarness
+
+    @BeforeTest
+    fun setUp() {
+        harness = IntegrationTestHarness()
+    }
+
+    @Test
+    fun `test override properties in LogRecordProcessor onEmit`() {
+        prepareConfig()
+        val ctx = prepareContext()
+
+        harness.logger.log(
+            body = "custom_log",
+            timestamp = 500,
+            observedTimestamp = 600,
+            severityNumber = SeverityNumber.WARN2,
+            severityText = "warn2",
+            context = ctx,
+        ) {
+            setStringAttribute("foo", "bar")
+            setBooleanAttribute("experiment_enabled", true)
+        }
+        harness.assertLogRecords(1, "log_emit_override.json")
+    }
+
+    private fun prepareConfig() {
+        harness.config.attributes = {
+            setStringAttribute("resource.foo", "bar")
+        }
+        harness.config.schemaUrl = "https://example.com/foo"
+        harness.config.logRecordProcessors.add(OnEmitLogRecordProcessor())
+    }
+
+    private fun prepareContext(): Context {
+        val span = harness.tracer.createSpan("span")
+        val contextCreator = harness.objectCreator.context
+        val ctx = contextCreator.storeSpan(contextCreator.root(), span)
+        return ctx
+    }
+
+    private class OnEmitLogRecordProcessor : LogRecordProcessor {
+        override fun onEmit(
+            log: ReadWriteLogRecord,
+            context: Context
+        ) {
+            log.assertAttributes()
+            log.overrideAttributes()
+        }
+
+        private fun ReadWriteLogRecord.assertAttributes() {
+            assertEquals("custom_log", body)
+            assertEquals(500, timestamp)
+            assertEquals(600, observedTimestamp)
+            assertEquals(SeverityNumber.WARN2, severityNumber)
+            assertEquals("warn2", severityText)
+            assertEquals("bar", attributes["foo"])
+            assertEquals(true, attributes["experiment_enabled"])
+            assertEquals("test_logger", instrumentationScopeInfo.name)
+            assertEquals("bar", resource.attributes["resource.foo"])
+            assertTrue(spanContext.isValid)
+        }
+
+        private fun ReadWriteLogRecord.overrideAttributes() {
+            body = "override"
+            timestamp = 123
+            observedTimestamp = 456
+            severityNumber = SeverityNumber.INFO
+            severityText = "info"
+            setStringAttribute("key", "value")
+        }
+
+        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -1,0 +1,77 @@
+package io.embrace.opentelemetry.kotlin.integration.test.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.integration.test.IntegrationTestHarness
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LoggerExportTest {
+
+    private lateinit var harness: IntegrationTestHarness
+
+    @BeforeTest
+    fun setUp() {
+        harness = IntegrationTestHarness()
+    }
+
+    @Test
+    fun `test minimal log exported by logger`() {
+        harness.logger.log("test") {
+            setStringAttribute("foo", "bar")
+        }
+        harness.assertLogRecords(1, "log_minimal.json")
+    }
+
+    @Test
+    fun `test log with basic properties exported by logger`() {
+        harness.logger.log(
+            body = "custom_log",
+            timestamp = 500,
+            observedTimestamp = 600,
+            severityNumber = SeverityNumber.WARN2,
+            severityText = "warn2",
+        )
+        harness.assertLogRecords(1, "log_basic_props.json")
+    }
+
+    @Test
+    fun `test log with attributes exported by logger`() {
+        harness.logger.log("test") {
+            setStringAttribute("foo", "bar")
+            setBooleanAttribute("experiment_enabled", true)
+        }
+        harness.assertLogRecords(1, "log_attrs.json")
+    }
+
+    @Test
+    fun `test log with resource and instrumentation scope exported by logger`() {
+        harness.config.attributes = {
+            setStringAttribute("resource.foo", "bar")
+        }
+        harness.config.schemaUrl = "https://example.com/foo"
+        val logger = harness.loggerProvider.getLogger("test", "0.1.0", "https://example.com/bar/") {
+            setStringAttribute("instrumentation_scope.foo", "bar")
+        }
+        logger.log("test")
+        harness.assertLogRecords(1, "log_resource_scope.json")
+    }
+
+    @Test
+    fun `test log with parent span in context`() {
+        val span = harness.tracer.createSpan("span")
+        val contextCreator = harness.objectCreator.context
+        val ctx = contextCreator.storeSpan(contextCreator.root(), span)
+        harness.logger.log("test", context = ctx)
+        harness.assertLogRecords(1, "log_span_context.json")
+    }
+
+    @Test
+    fun `test log with root context`() {
+        val contextCreator = harness.objectCreator.context
+        val ctx = contextCreator.root()
+        harness.logger.log("test", context = ctx)
+        harness.assertLogRecords(1, "log_root_context.json")
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
@@ -1,8 +1,9 @@
-package io.embrace.opentelemetry.kotlin.integration.test
+package io.embrace.opentelemetry.kotlin.integration.test.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.integration.test.IntegrationTestHarness
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -17,7 +18,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
-internal class SpanProcessOnEndReadTest {
+internal class SpanProcessOnStartOverrideTest {
 
     private lateinit var harness: IntegrationTestHarness
 
@@ -27,22 +28,20 @@ internal class SpanProcessOnEndReadTest {
     }
 
     @Test
-    fun `test read properties in SpanProcessor onEnd`() {
-        harness.config.spanProcessors.add(OnEndSpanProcessor())
+    fun `test override properties in SpanProcessor onStart`() {
+        harness.config.spanProcessors.add(OnStartSpanProcessor())
         harness.tracer.createSpan("span") {
             setStringAttribute("key", "value")
             addEvent("test")
-            addLink(FakeSpanContext()) {
-                setStringAttribute("foo", "bar")
-            }
-        }.end()
+            addLink(FakeSpanContext())
+        }
         harness.assertSpans(
             expectedCount = 1,
-            goldenFileName = "span_read_on_end.json",
+            goldenFileName = "span_override_on_start.json",
         )
     }
 
-    private class OnEndSpanProcessor : SpanProcessor {
+    private class OnStartSpanProcessor : SpanProcessor {
         override fun onStart(
             span: ReadWriteSpan,
             parentContext: Context
@@ -50,10 +49,7 @@ internal class SpanProcessOnEndReadTest {
             span.handleSpan()
         }
 
-        override fun onEnd(span: ReadableSpan) {
-        }
-
-        private fun ReadableSpan.handleSpan() {
+        private fun ReadWriteSpan.handleSpan() {
             // assert properties can be read
             assertEquals("span", name)
             assertEquals(StatusData.Unset, status)
@@ -66,8 +62,23 @@ internal class SpanProcessOnEndReadTest {
             assertTrue(resource.attributes.isEmpty())
             assertEquals("test_tracer", instrumentationScopeInfo.name)
             assertEquals(mapOf("key" to "value"), attributes)
-            assertEquals("test", events.single().name)
-            assertEquals("bar", links.single().attributes["foo"])
+            assertEquals(1, events.size)
+            assertEquals(1, links.size)
+
+            // assert subset of properties can be written
+            name = "override"
+            status = StatusData.Error("override")
+            setStringAttribute("foo", "bar")
+            addEvent("test", 5) {
+                setStringAttribute("foo", "bar")
+            }
+            addLink(FakeSpanContext()) {
+                setStringAttribute("foo", "bar")
+            }
+            end(678)
+        }
+
+        override fun onEnd(span: ReadableSpan) {
         }
 
         override fun isStartRequired(): Boolean = true

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -1,6 +1,7 @@
-package io.embrace.opentelemetry.kotlin.integration.test
+package io.embrace.opentelemetry.kotlin.integration.test.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.integration.test.IntegrationTestHarness
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import kotlin.test.BeforeTest

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_attrs.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_attrs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {
+      "experiment_enabled": "true",
+      "foo": "bar"
+    },
+    "totalAttributeCount": 2
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_basic_props.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_basic_props.json
@@ -1,0 +1,27 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 500,
+    "observedTimestampEpochNanos": 600,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "WARN2",
+    "severityText": "warn2",
+    "body": "custom_log",
+    "attributes": {},
+    "totalAttributeCount": 0
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_emit_override.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_emit_override.json
@@ -1,0 +1,33 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "https://example.com/foo",
+      "attributes": {
+        "resource.foo": "bar"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 123,
+    "observedTimestampEpochNanos": 456,
+    "spanContext": {
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "INFO",
+    "severityText": "info",
+    "body": "override",
+    "attributes": {
+      "experiment_enabled": "true",
+      "foo": "bar",
+      "key": "value"
+    },
+    "totalAttributeCount": 3
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_minimal.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_minimal.json
@@ -1,0 +1,29 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {
+      "foo": "bar"
+    },
+    "totalAttributeCount": 1
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_naughty_export.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_naughty_export.json
@@ -1,0 +1,32 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "https://example.com/foo",
+      "attributes": {
+        "resource.foo": "bar"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 500,
+    "observedTimestampEpochNanos": 600,
+    "spanContext": {
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "WARN2",
+    "severityText": "warn2",
+    "body": "custom_log",
+    "attributes": {
+      "experiment_enabled": "true",
+      "foo": "bar"
+    },
+    "totalAttributeCount": 2
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_resource_scope.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_resource_scope.json
@@ -1,0 +1,31 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "https://example.com/foo",
+      "attributes": {
+        "resource.foo": "bar"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test",
+      "version": "0.1.0",
+      "schemaUrl": "https://example.com/bar/",
+      "attributes": {
+        "instrumentation_scope.foo": "bar"
+      }
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {},
+    "totalAttributeCount": 0
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_root_context.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_root_context.json
@@ -1,0 +1,27 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {},
+    "totalAttributeCount": 0
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_span_context.json
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/resources/log_span_context.json
@@ -1,0 +1,27 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
+      "spanId": "e77bcc2f537f0b02",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {},
+    "totalAttributeCount": 0
+  }
+]

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -8,6 +8,7 @@ import io.embrace.opentelemetry.kotlin.framework.serialization.conversion.toSeri
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
@@ -71,6 +72,11 @@ abstract class OtelKotlinTestRule {
      * Syntactic sugar to obtain a tracer provider from the API.
      */
     val tracerProvider: TracerProvider by lazy { kotlinApi.tracerProvider }
+
+    /**
+     * Syntactic sugar to obtain a logger provider from the API.
+     */
+    val loggerProvider: LoggerProvider by lazy { kotlinApi.loggerProvider }
 
     /**
      * Syntactic sugar to obtain a tracer from the API.

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
@@ -6,8 +6,8 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
 @OptIn(ExperimentalApi::class)
 fun ReadableLogRecord.toSerializable() = SerializableLogRecordData(
-    resource = resource?.toSerializable(),
-    instrumentationScopeInfo = instrumentationScopeInfo?.toSerializable(),
+    resource = resource.toSerializable(),
+    instrumentationScopeInfo = instrumentationScopeInfo.toSerializable(),
     timestampEpochNanos = timestamp ?: 0,
     observedTimestampEpochNanos = observedTimestamp ?: 0,
     spanContext = spanContext.toSerializable(),

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -26,7 +26,6 @@ class FakeLogger(
             FakeReadableLogRecord(
                 timestamp,
                 observedTimestamp,
-                context,
                 severityNumber,
                 severityText,
                 body

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -17,7 +16,6 @@ class FakeReadWriteLogRecord : ReadWriteLogRecord {
     override var severityText: String? = null
     override var body: String? = null
     override var spanContext: SpanContext = FakeSpanContext()
-    override val context: Context? = null
     override val attributes: Map<String, Any> = emptyMap()
     override val resource: Resource = FakeResource()
     override val instrumentationScopeInfo: InstrumentationScopeInfo =

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -19,8 +19,8 @@ class FakeReadWriteLogRecord : ReadWriteLogRecord {
     override var spanContext: SpanContext = FakeSpanContext()
     override val context: Context? = null
     override val attributes: Map<String, Any> = emptyMap()
-    override val resource: Resource? = FakeResource()
-    override val instrumentationScopeInfo: InstrumentationScopeInfo? =
+    override val resource: Resource = FakeResource()
+    override val instrumentationScopeInfo: InstrumentationScopeInfo =
         FakeInstrumentationScopeInfo()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
@@ -3,9 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.context.FakeContext
-import io.embrace.opentelemetry.kotlin.context.FakeContextKey
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -14,7 +11,6 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 class FakeReadableLogRecord(
     override val timestamp: Long? = 1000,
     override val observedTimestamp: Long? = 2000,
-    override val context: Context? = FakeContext(mapOf(FakeContextKey<String>("key") to "value")),
     override val severityNumber: SeverityNumber? = SeverityNumber.WARN,
     override val severityText: String? = "warning",
     override val body: String? = "Hello, World!",

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
@@ -20,6 +20,6 @@ class FakeReadableLogRecord(
     override val body: String? = "Hello, World!",
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
     override val spanContext: FakeSpanContext = FakeSpanContext(),
-    override val resource: Resource? = FakeResource(),
-    override val instrumentationScopeInfo: InstrumentationScopeInfo? = FakeInstrumentationScopeInfo()
+    override val resource: Resource = FakeResource(),
+    override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo()
 ) : ReadableLogRecord


### PR DESCRIPTION
## Goal

Implements the `LogRecordModel` which will form the single source of truth for logs, similar to `SpanModel` for spans. There are 2 views into it: `ReadableLogRecordImpl` and `ReadWriteLogRecordImpl`. In this changeset I've hooked up the processor to process the log record.

The properties and threading model on `LogRecordModel` remains unimplemented - I'll add this in future PRs to allow easier review & to ensure explicit unit test coverage is added for each feature.

## Testing

Added initial unit tests. Further tests (unit and integration) will be added in subsequent PRs that implement the actual models.

