### PR TITLE
Support attributes on LogRecordModel

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -31,7 +32,8 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        val log = LogRecordModel()
+        val attrs = MutableAttributeContainerImpl().apply(attributes)
+        val log = LogRecordModel(attrs)
         val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }


### PR DESCRIPTION
## Goal

Supports population of attributes on the `LogRecordModel`.

## Testing

Added unit tests.

