### PR TITLE
Implement log model meta attributes

### DIFF
--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -56,12 +56,12 @@ public interface ReadableLogRecord {
     public val spanContext: SpanContext
 
     /**
-     * The resource associated with the log record, if any.
+     * The resource associated with the log record
      */
-    public val resource: Resource?
+    public val resource: Resource
 
     /**
-     * The instrumentation scope information associated with the log record, if any.
+     * The instrumentation scope information associated with the log record
      */
-    public val instrumentationScopeInfo: InstrumentationScopeInfo?
+    public val instrumentationScopeInfo: InstrumentationScopeInfo
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
@@ -4,9 +4,7 @@ package io.embrace.opentelemetry.kotlin.logging.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaBody
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.attributes.attrsFromMap
 import io.embrace.opentelemetry.kotlin.attributes.resourceFromMap
@@ -23,11 +21,11 @@ internal fun ReadableLogRecord.toLogRecordData(): OtelJavaLogRecordData {
         observedTimestampNanos = observedTimestamp ?: 0,
         spanContextImpl = spanContext.toOtelJavaSpanContext(),
         severityTextImpl = severityText,
-        severityImpl = severityNumber?.toOtelJavaSeverityNumber() ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
+        severityImpl = severityNumber?.toOtelJavaSeverityNumber()
+            ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
         bodyImpl = body?.let(OtelJavaBody::string) ?: OtelJavaBody.empty(),
         attributesImpl = attrsFromMap(attributes),
-        resourceImpl = resource?.let(::resourceFromMap) ?: OtelJavaResource.empty(),
-        scopeImpl = instrumentationScopeInfo?.toOtelJavaInstrumentationScopeInfo()
-            ?: OtelJavaInstrumentationScopeInfo.empty()
+        resourceImpl = resourceFromMap(resource),
+        scopeImpl = instrumentationScopeInfo.toOtelJavaInstrumentationScopeInfo()
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterAdapterTest.kt
@@ -45,14 +45,14 @@ internal class OtelJavaLogRecordExporterAdapterTest {
         assertEquals(original.severityNumber?.severityNumber, observed.severity.severityNumber)
         assertEquals(original.body, observed.bodyValue?.asString())
         assertEquals(original.attributes, observed.attributes.toMap())
-        assertEquals(original.resource?.attributes, observed.resource.attributes.toMap())
+        assertEquals(original.resource.attributes, observed.resource.attributes.toMap())
         assertEquals(original.spanContext.spanId, observed.spanContext.spanId)
 
         val originalScope = original.instrumentationScopeInfo
         val observedScope = observed.instrumentationScopeInfo
-        assertEquals(originalScope?.name, observedScope.name)
-        assertEquals(originalScope?.version, observedScope.version)
-        assertEquals(originalScope?.schemaUrl, observedScope.schemaUrl)
-        assertEquals(originalScope?.attributes, observedScope.attributes.toMap())
+        assertEquals(originalScope.name, observedScope.name)
+        assertEquals(originalScope.version, observedScope.version)
+        assertEquals(originalScope.schemaUrl, observedScope.schemaUrl)
+        assertEquals(originalScope.attributes, observedScope.attributes.toMap())
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -33,7 +33,11 @@ internal class LoggerImpl(
         attributes: MutableAttributeContainer.() -> Unit
     ) {
         val attrs = MutableAttributeContainerImpl().apply(attributes)
-        val log = LogRecordModel(attrs)
+        val log = LogRecordModel(
+            attributeContainer = attrs,
+            resource = resource,
+            instrumentationScopeInfo = key,
+        )
         val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -16,6 +16,8 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 @OptIn(ExperimentalApi::class)
 internal class LogRecordModel(
     attributeContainer: AttributeContainer,
+    override val resource: Resource,
+    override val instrumentationScopeInfo: InstrumentationScopeInfo,
 ) : ReadWriteLogRecord {
 
     private val lock = ReentrantReadWriteLock()
@@ -45,12 +47,6 @@ internal class LogRecordModel(
         set(value) {}
 
     override val context: Context?
-        get() = throw UnsupportedOperationException()
-
-    override val resource: Resource?
-        get() = throw UnsupportedOperationException()
-
-    override val instrumentationScopeInfo: InstrumentationScopeInfo?
         get() = throw UnsupportedOperationException()
 
     private val attrs: MutableMap<String, Any> = attributeContainer.attributes.toMutableMap()

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -1,0 +1,48 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class LogMetaPropertiesTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private val fakeResource = FakeResource()
+    private lateinit var logger: LoggerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeLogRecordProcessor
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeLogRecordProcessor()
+        logger = LoggerImpl(
+            clock,
+            processor,
+            FakeObjectCreator(),
+            key,
+            fakeResource,
+        )
+    }
+
+    @Test
+    fun `test log instrumentation scope`() {
+        logger.log()
+        val log = processor.logs.single()
+        assertSame(key, log.instrumentationScopeInfo)
+    }
+
+    @Test
+    fun `test log resource`() {
+        logger.log()
+        val log = processor.logs.single()
+        assertSame(fakeResource, log.resource)
+    }
+}

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
@@ -6,8 +6,8 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
 @OptIn(ExperimentalApi::class)
 fun ReadableLogRecord.toSerializable() = SerializableLogRecordData(
-    resource = resource?.toSerializable(),
-    instrumentationScopeInfo = instrumentationScopeInfo?.toSerializable(),
+    resource = resource.toSerializable(),
+    instrumentationScopeInfo = instrumentationScopeInfo.toSerializable(),
     timestampEpochNanos = timestamp ?: 0,
     observedTimestampEpochNanos = observedTimestamp ?: 0,
     spanContext = spanContext.toSerializable(),

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -19,8 +19,8 @@ class FakeReadWriteLogRecord : ReadWriteLogRecord {
     override var spanContext: SpanContext = FakeSpanContext()
     override val context: Context? = null
     override val attributes: Map<String, Any> = emptyMap()
-    override val resource: Resource? = FakeResource()
-    override val instrumentationScopeInfo: InstrumentationScopeInfo? =
+    override val resource: Resource = FakeResource()
+    override val instrumentationScopeInfo: InstrumentationScopeInfo =
         FakeInstrumentationScopeInfo()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
@@ -20,6 +20,6 @@ class FakeReadableLogRecord(
     override val body: String? = "Hello, World!",
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
     override val spanContext: FakeSpanContext = FakeSpanContext(),
-    override val resource: Resource? = FakeResource(),
-    override val instrumentationScopeInfo: InstrumentationScopeInfo? = FakeInstrumentationScopeInfo()
+    override val resource: Resource = FakeResource(),
+    override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo()
 ) : ReadableLogRecord


### PR DESCRIPTION
## Goal

Implements the `resource` and `instrumentationScopeInfo` properties on `LogModel`. I made these properties non-null as there isn't any feasible chance the logger won't set them.

## Testing

Added unit tests.

