### PR TITLE
Implement context for log model

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -192,7 +192,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getBody ()Ljava/lang/String;
-	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/context/Context;
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -2,7 +2,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
@@ -23,11 +22,6 @@ public interface ReadableLogRecord {
      * The timestamp in nanoseconds at which the event was entered into the OpenTelemetry API.
      */
     public val observedTimestamp: Long?
-
-    /**
-     * The context in which the log was emitted.
-     */
-    public val context: Context?
 
     /**
      * The severity of the log.

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -5,7 +5,6 @@ import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.attributes.toMap
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.logging.toOtelKotlinSeverityNumber
@@ -83,9 +82,6 @@ internal class ReadWriteLogRecordAdapter(
     override var spanContext: SpanContext
         get() = SpanContextAdapter(impl.spanContext)
         set(value) {}
-
-    override val context: Context?
-        get() = null
 
     override val resource: Resource
         get() = ResourceAdapter(impl.toLogRecordData().resource)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapterTest.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
-import io.embrace.opentelemetry.kotlin.context.ContextKeyAdapter
 import org.junit.Test
 import java.time.Instant
 import kotlin.test.assertEquals
@@ -29,8 +28,6 @@ internal class OtelJavaLogRecordBuilderAdapterTest {
 
         val log = impl.logs.single()
         assertEquals(body, log.body)
-        val ctxValue = log.context?.get<String>(ContextKeyAdapter(key))
-        assertEquals("value", ctxValue)
 
         val expected = now.toEpochMilli() * 1000000
         assertEquals(expected, log.timestamp)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -32,6 +32,7 @@ internal class LoggerImpl(
         attributes: MutableAttributeContainer.() -> Unit
     ) {
         val attrs = MutableAttributeContainerImpl().apply(attributes)
+        val ctx = context ?: objectCreator.context.root()
         val log = LogRecordModel(
             attributeContainer = attrs,
             resource = resource,
@@ -41,8 +42,8 @@ internal class LoggerImpl(
             body = body,
             severityText = severityText,
             severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
+            spanContext = objectCreator.span.fromContext(ctx).spanContext,
         )
-        val ctx = context ?: objectCreator.context.root()
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -1,0 +1,64 @@
+package io.embrace.opentelemetry.kotlin.logging
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.tracing.TracerImpl
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class LogContextTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private lateinit var logger: LoggerImpl
+    private lateinit var tracer: TracerImpl
+    private lateinit var clock: FakeClock
+    private lateinit var processor: FakeLogRecordProcessor
+    private lateinit var objectCreator: ObjectCreator
+
+    @BeforeTest
+    fun setUp() {
+        clock = FakeClock()
+        processor = FakeLogRecordProcessor()
+        objectCreator = ObjectCreatorImpl()
+        logger = LoggerImpl(
+            clock,
+            processor,
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+        tracer = TracerImpl(
+            clock,
+            FakeSpanProcessor(),
+            objectCreator,
+            key,
+            FakeResource(),
+        )
+    }
+
+    @Test
+    fun `test default context`() {
+        logger.log()
+        val log = processor.logs.single()
+        val root = objectCreator.span.fromContext(objectCreator.context.root()).spanContext
+        assertSame(root, log.spanContext)
+    }
+
+    @Test
+    fun `test non-default context`() {
+        val span = tracer.createSpan("span")
+        val ctx = objectCreator.context.storeSpan(objectCreator.context.root(), span)
+        logger.log(context = ctx)
+
+        val log = processor.logs.single()
+        assertSame(span.spanContext, log.spanContext)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -26,7 +26,6 @@ class FakeLogger(
             FakeReadableLogRecord(
                 timestamp,
                 observedTimestamp,
-                context,
                 severityNumber,
                 severityText,
                 body

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -17,7 +16,6 @@ class FakeReadWriteLogRecord : ReadWriteLogRecord {
     override var severityText: String? = null
     override var body: String? = null
     override var spanContext: SpanContext = FakeSpanContext()
-    override val context: Context? = null
     override val attributes: Map<String, Any> = emptyMap()
     override val resource: Resource = FakeResource()
     override val instrumentationScopeInfo: InstrumentationScopeInfo =

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
@@ -3,9 +3,6 @@ package io.embrace.opentelemetry.kotlin.logging.model
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.context.FakeContext
-import io.embrace.opentelemetry.kotlin.context.FakeContextKey
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -14,7 +11,6 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 class FakeReadableLogRecord(
     override val timestamp: Long? = 1000,
     override val observedTimestamp: Long? = 2000,
-    override val context: Context? = FakeContext(mapOf(FakeContextKey<String>("key") to "value")),
     override val severityNumber: SeverityNumber? = SeverityNumber.WARN,
     override val severityText: String? = "warning",
     override val body: String? = "Hello, World!",


### PR DESCRIPTION
## Goal

Implements Context propagation for the `LogModel` class. Reading the spec again, only the `SpanContext` needs to be part of the log record so I updated the inheritance hierarchy appropriately.

## Testing

Added unit tests.

