### PR TITLE
Use kotlinx.datetime for implementing Clock.now()

### DIFF
--- a/opentelemetry-kotlin-implementation/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.apple.kt
+++ b/opentelemetry-kotlin-implementation/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.apple.kt
@@ -1,0 +1,10 @@
+package io.embrace.opentelemetry.kotlin.clock
+
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+internal actual fun getCurrentTimeNanos(): Long {
+    // NSDate.timeIntervalSince1970 returns seconds since epoch as a Double
+    // Convert to nanoseconds by multiplying by 1_000_000_000
+    return (NSDate().timeIntervalSince1970 * 1_000_000_000.0).toLong()
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.kt
@@ -3,7 +3,9 @@ package io.embrace.opentelemetry.kotlin.clock
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
+internal expect fun getCurrentTimeNanos(): Long
+
 @OptIn(ExperimentalApi::class)
 internal class ClockImpl : Clock {
-    override fun now(): Long = 0
+    override fun now(): Long = getCurrentTimeNanos()
 }

--- a/opentelemetry-kotlin-implementation/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.jvm.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImpl.jvm.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin.clock
+
+internal actual fun getCurrentTimeNanos(): Long {
+    return System.currentTimeMillis() * 1_000_000L
+}

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImplJvmTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/clock/ClockImplJvmTest.kt
@@ -1,0 +1,44 @@
+package io.embrace.opentelemetry.kotlin.clock
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class ClockImplJvmTest {
+
+    @Test
+    fun `getCurrentTimeNanos returns consistent nanosecond format`() {
+        val timestamp = getCurrentTimeNanos()
+
+        // Should end with 6 zeros since we convert milliseconds to nanoseconds
+        // (milliseconds * 1_000_000 always ends in 6 zeros)
+        val lastSixDigits = timestamp % 1_000_000
+        assertTrue(lastSixDigits == 0L)
+    }
+
+    @Test
+    fun `getCurrentTimeNanos should handle multiple rapid calls`() {
+        val iterations = 100
+        var previousTime = 0L
+
+        repeat(iterations) {
+            val currentTime = getCurrentTimeNanos()
+            assertTrue(currentTime >= previousTime)
+            previousTime = currentTime
+        }
+    }
+
+    @Test
+    fun `getCurrentTimeNanos returns reasonable current time`() {
+        val timestamp = getCurrentTimeNanos()
+        // Convert to seconds for comparison
+        val timestampInSeconds = timestamp / 1_000_000_000L
+
+        // Should be sometime after 2020 (timestamp > Jan 1, 2020)
+        val jan2020 = 1577836800L // Jan 1, 2020 in seconds
+        assertTrue(timestampInSeconds > jan2020)
+
+        // Should be before year 2100 (timestamp < Jan 1, 2100)
+        val jan2100 = 4102444800L // Jan 1, 2100 in seconds
+        assertTrue(timestampInSeconds < jan2100)
+    }
+}


### PR DESCRIPTION
## Considerations:
- Java: Implemented using `System.currentTimeMillis() * 1_000_000L`
- apple: Implemented using `(NSDate().timeIntervalSince1970 * 1_000_000_000.0).toLong()`