### PR TITLE
Setup extra compat module

### DIFF
--- a/opentelemetry-kotlin-implementation-java-compat/api/opentelemetry-kotlin-implementation-java-compat.api
+++ b/opentelemetry-kotlin-implementation-java-compat/api/opentelemetry-kotlin-implementation-java-compat.api
@@ -1,0 +1,4 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryJavaExtKt {
+	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+}
+

--- a/opentelemetry-kotlin-implementation-java-compat/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation-java-compat/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("io.embrace.otel.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                api(project(":opentelemetry-kotlin"))
+                implementation(project(":opentelemetry-kotlin-model"))
+                implementation(project(":opentelemetry-java-typealiases"))
+                implementation(project.dependencies.platform(libs.opentelemetry.bom))
+                implementation(libs.opentelemetry.api)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-implementation-java-compat/gradle.properties
+++ b/opentelemetry-kotlin-implementation-java-compat/gradle.properties
@@ -1,0 +1,1 @@
+io.embrace.javaSdkCompatModule=true

--- a/opentelemetry-kotlin-implementation-java-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryJavaExt.kt
+++ b/opentelemetry-kotlin-implementation-java-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryJavaExt.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+
+/**
+ * Constructs an [OtelJavaOpenTelemetry] instance that makes the Kotlin implementation conform
+ * to the opentelemetry-java API.
+ *
+ * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
+ * or [decorateJavaApi] instead.
+ */
+@ExperimentalApi
+public fun OpenTelemetry.toOtelJavaApi(): OtelJavaOpenTelemetry {
+    return OtelJavaOpenTelemetrySdk(this)
+}

--- a/opentelemetry-kotlin-implementation-java-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
+++ b/opentelemetry-kotlin-implementation-java-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
@@ -1,0 +1,25 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
+
+@Suppress("unused")
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaOpenTelemetrySdk(
+    private val impl: OpenTelemetry
+) : OtelJavaOpenTelemetry {
+
+    override fun getTracerProvider(): OtelJavaTracerProvider {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getLogsBridge(): OtelJavaLoggerProvider {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getPropagators(): OtelJavaContextPropagators {
+        throw UnsupportedOperationException()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(
     ":opentelemetry-kotlin-api-ext",
     ":opentelemetry-kotlin-noop",
     ":opentelemetry-kotlin-implementation",
+    ":opentelemetry-kotlin-implementation-java-compat",
     ":opentelemetry-kotlin-model",
     ":opentelemetry-kotlin-compat",
     ":opentelemetry-kotlin-primitives",


### PR DESCRIPTION
## Goal

Creates an extra module that will be used for Kotlin -> Java compatibility between the implementation layer and the OTel Java API.
