### PR TITLE
Rename compat implementations to avoid clashes

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
@@ -5,10 +5,10 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.creator.createCompatObjectCreator
+import io.embrace.opentelemetry.kotlin.init.CompatLoggerProviderConfig
+import io.embrace.opentelemetry.kotlin.init.CompatTracerProviderConfig
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigImpl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigImpl
 import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.logging.OtelJavaLoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
@@ -55,8 +55,8 @@ public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
     objectCreator: ObjectCreator = createCompatObjectCreator(),
 ): OpenTelemetry {
     objectCreator.idCreator
-    val tracerCfg = TracerProviderConfigImpl(clock, objectCreator).apply(tracerProvider)
-    val loggerCfg = LoggerProviderConfigImpl(clock).apply(loggerProvider)
+    val tracerCfg = CompatTracerProviderConfig(clock, objectCreator).apply(tracerProvider)
+    val loggerCfg = CompatLoggerProviderConfig(clock).apply(loggerProvider)
 
     return OpenTelemetryImpl(
         tracerProvider = tracerCfg.build(),

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatContextCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatContextCreator.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.ext.storeInContext
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 
 @OptIn(ExperimentalApi::class)
-internal class ContextCreatorImpl : ContextCreator {
+internal class CompatContextCreator : ContextCreator {
 
     override fun root(): Context = OtelJavaContext.root().toOtelKotlinContext()
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatObjectCreator.kt
@@ -4,11 +4,11 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class CompatObjectCreator(
-    override val idCreator: TracingIdCreator = TracingIdCreatorImpl()
+    override val idCreator: TracingIdCreator = CompatTracingIdCreator()
 ) : ObjectCreator {
-    override val spanContext: SpanContextCreator by lazy { SpanContextCreatorImpl() }
-    override val traceFlags: TraceFlagsCreator by lazy { TraceFlagsCreatorImpl() }
-    override val traceState: TraceStateCreator by lazy { TraceStateCreatorImpl() }
-    override val context: ContextCreator by lazy { ContextCreatorImpl() }
-    override val span: SpanCreator by lazy { SpanCreatorImpl(spanContext) }
+    override val spanContext: SpanContextCreator by lazy { CompatSpanContextCreator() }
+    override val traceFlags: TraceFlagsCreator by lazy { CompatTraceFlagsCreator() }
+    override val traceState: TraceStateCreator by lazy { CompatTraceStateCreator() }
+    override val context: ContextCreator by lazy { CompatContextCreator() }
+    override val span: SpanCreator by lazy { CompatSpanCreator(spanContext) }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatSpanContextCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatSpanContextCreator.kt
@@ -13,7 +13,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceStateAdapter
 
 @OptIn(ExperimentalApi::class)
-internal class SpanContextCreatorImpl : SpanContextCreator {
+internal class CompatSpanContextCreator : SpanContextCreator {
 
     override val invalid: SpanContext by lazy {
         val impl: OtelJavaSpanContext = OtelJavaSpanContext.getInvalid()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatSpanCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatSpanCreator.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DiscouragedImport")
+
 package io.embrace.opentelemetry.kotlin.creator
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
@@ -12,7 +14,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextAdapter
 import io.opentelemetry.api.trace.otelJavaSpanContextKey
 
 @OptIn(ExperimentalApi::class)
-internal class SpanCreatorImpl(spanContextCreator: SpanContextCreator) : SpanCreator {
+internal class CompatSpanCreator(spanContextCreator: SpanContextCreator) : SpanCreator {
 
     private val invalidSpanContext by lazy { spanContextCreator.invalid }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTraceFlagsCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTraceFlagsCreator.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlagsAdapter
 
 @OptIn(ExperimentalApi::class)
-internal class TraceFlagsCreatorImpl : TraceFlagsCreator {
+internal class CompatTraceFlagsCreator : TraceFlagsCreator {
     override val default: TraceFlags by lazy { TraceFlagsAdapter(OtelJavaTraceFlags.getDefault()) }
 
     override fun create(sampled: Boolean, random: Boolean): TraceFlags {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTraceStateCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTraceStateCreator.kt
@@ -6,6 +6,6 @@ import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceStateAdapter
 
 @OptIn(ExperimentalApi::class)
-internal class TraceStateCreatorImpl : TraceStateCreator {
+internal class CompatTraceStateCreator : TraceStateCreator {
     override val default: TraceState by lazy { TraceStateAdapter(OtelJavaTraceState.getDefault()) }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTracingIdCreator.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/creator/CompatTracingIdCreator.kt
@@ -6,7 +6,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
 
 @OptIn(ExperimentalApi::class)
-internal class TracingIdCreatorImpl(
+internal class CompatTracingIdCreator(
     private val generator: OtelJavaIdGenerator = OtelJavaIdGenerator.random()
 ) : TracingIdCreator {
     override fun generateSpanId(): String = generator.generateSpanId()

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLogLimitsConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLogLimitsConfig.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogLimits
 
 @ExperimentalApi
-internal class LogLimitsConfigImpl : LogLimitsConfigDsl {
+internal class CompatLogLimitsConfig : LogLimitsConfigDsl {
 
     private val builder = OtelJavaLogLimits.builder()
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -13,7 +13,7 @@ import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.export.OtelJavaLogRecordProcessorAdapter
 
 @ExperimentalApi
-internal class LoggerProviderConfigImpl(
+internal class CompatLoggerProviderConfig(
     clock: Clock
 ) : LoggerProviderConfigDsl {
 
@@ -33,7 +33,7 @@ internal class LoggerProviderConfigImpl(
     }
 
     override fun logLimits(action: LogLimitsConfigDsl.() -> Unit) {
-        builder.setLogLimits { LogLimitsConfigImpl().apply(action).build() }
+        builder.setLogLimits { CompatLogLimitsConfig().apply(action).build() }
     }
 
     fun build(): LoggerProvider = LoggerProviderAdapter(builder.build())

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatSpanLimitsConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatSpanLimitsConfig.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 
 @ExperimentalApi
-internal class SpanLimitsConfigImpl : SpanLimitsConfigDsl {
+internal class CompatSpanLimitsConfig : SpanLimitsConfigDsl {
 
     private val builder = OtelJavaSpanLimits.builder()
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -15,7 +15,7 @@ import io.embrace.opentelemetry.kotlin.tracing.export.OtelJavaSpanProcessorAdapt
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 @ExperimentalApi
-internal class TracerProviderConfigImpl(
+internal class CompatTracerProviderConfig(
     private val clock: Clock,
     objectCreator: ObjectCreator,
 ) : TracerProviderConfigDsl {
@@ -37,7 +37,7 @@ internal class TracerProviderConfigImpl(
     }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {
-        builder.setSpanLimits(SpanLimitsConfigImpl().apply(action).build())
+        builder.setSpanLimits(CompatSpanLimitsConfig().apply(action).build())
     }
 
     override fun addSpanProcessor(processor: SpanProcessor) {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanContextCreatorImplTest.kt
@@ -16,7 +16,7 @@ internal class SpanContextCreatorImplTest {
 
     @Test
     fun `test valid`() {
-        val generator = TracingIdCreatorImpl()
+        val generator = CompatTracingIdCreator()
         val traceId = generator.generateTraceId()
         val spanId = generator.generateSpanId()
         val traceFlags = creator.traceFlags.default

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
@@ -25,7 +25,7 @@ internal class SpanCreatorImplTest {
 
     @Test
     fun `test from span context`() {
-        val generator = TracingIdCreatorImpl()
+        val generator = CompatTracingIdCreator()
         val spanContext = creator.spanContext.create(
             traceId = generator.generateTraceId(),
             spanId = generator.generateSpanId(),

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -6,8 +6,8 @@ import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.createOpenTelemetryKotlin
 import io.embrace.opentelemetry.kotlin.creator.CompatObjectCreator
+import io.embrace.opentelemetry.kotlin.creator.CompatTracingIdCreator
 import io.embrace.opentelemetry.kotlin.creator.TracingIdCreator
-import io.embrace.opentelemetry.kotlin.creator.TracingIdCreatorImpl
 import io.embrace.opentelemetry.kotlin.decorateKotlinApi
 import kotlin.random.Random
 
@@ -30,7 +30,7 @@ internal class OtelKotlinHarness : OtelKotlinTestRule() {
 
 @OptIn(ExperimentalApi::class)
 private class FakeTracingIdCreator(
-    private val impl: TracingIdCreator = TracingIdCreatorImpl(),
+    private val impl: TracingIdCreator = CompatTracingIdCreator(),
 ) : TracingIdCreator by impl, OtelJavaIdGenerator {
 
     private val random: Random = Random(0)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImplTest.kt
@@ -9,7 +9,7 @@ internal class LogLimitsConfigImplTest {
 
     @Test
     fun `test default`() {
-        LogLimitsConfigImpl().apply {
+        CompatLogLimitsConfig().apply {
             assertEquals(0, attributeCountLimit)
             assertEquals(0, attributeValueLengthLimit)
         }
@@ -17,7 +17,7 @@ internal class LogLimitsConfigImplTest {
 
     @Test
     fun `test span limits`() {
-        val cfg = LogLimitsConfigImpl()
+        val cfg = CompatLogLimitsConfig()
         cfg.apply {
             attributeCountLimit = 11
             attributeValueLengthLimit = 111

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImplTest.kt
@@ -9,7 +9,7 @@ internal class SpanLimitsConfigImplTest {
 
     @Test
     fun `test default`() {
-        SpanLimitsConfigImpl().apply {
+        CompatSpanLimitsConfig().apply {
             assertEquals(0, eventCountLimit)
             assertEquals(0, attributeCountLimit)
             assertEquals(0, linkCountLimit)
@@ -20,7 +20,7 @@ internal class SpanLimitsConfigImplTest {
 
     @Test
     fun `test span limits`() {
-        val cfg = SpanLimitsConfigImpl()
+        val cfg = CompatSpanLimitsConfig()
         cfg.apply {
             eventCountLimit = 1
             attributeCountLimit = 2

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -47,7 +47,7 @@ internal class TracerSpanContextTest {
     }
 
     @Test
-    fun `test span with explicit parent context, invalid span`() {
+    fun `test span with explicit parent context - invalid span`() {
         val invalidSpan = objectCreator.span.invalid
         assertFalse(invalidSpan.spanContext.isValid)
         val parentCtx = objectCreator.context.storeSpan(objectCreator.context.root(), invalidSpan)
@@ -59,7 +59,7 @@ internal class TracerSpanContextTest {
     }
 
     @Test
-    fun `test span with explicit parent context, valid span`() {
+    fun `test span with explicit parent context - valid span`() {
         val parentSpan = tracer.createSpan("parent")
         val parentCtx = objectCreator.context.storeSpan(objectCreator.context.root(), parentSpan)
         val span = tracer.createSpan("test", parentContext = parentCtx)


### PR DESCRIPTION
The package and class names for some impls in compat and the sdk modules are the same, so having them in the same classpath is problematic. We should probably use package names to differentiate these, but this will be fine for now.

