### PR TITLE
Expose ObjectCreator implementation for the SDK module

### DIFF
--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -3,3 +3,7 @@ public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImplKt {
 	public static synthetic fun default$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/creator/ObjectCreator;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
+public final class io/embrace/opentelemetry/kotlin/creator/ObjectCreatorExtKt {
+	public static final fun createObjectCreator ()Lio/embrace/opentelemetry/kotlin/creator/ObjectCreator;
+}
+

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin
 
 import io.embrace.opentelemetry.kotlin.clock.ClockImpl
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
-import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.creator.createObjectCreator
 import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigImpl
@@ -19,7 +19,7 @@ public fun OpenTelemetryInstance.default(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockImpl(),
-    objectCreator: ObjectCreator = ObjectCreatorImpl()
+    objectCreator: ObjectCreator = createObjectCreator()
 ): OpenTelemetry {
     val tracingConfig = TracerProviderConfigImpl().apply(tracerProvider).generateTracingConfig()
     val loggingConfig = LoggerProviderConfigImpl().apply(loggerProvider).generateLoggingConfig()

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorExt.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/creator/ObjectCreatorExt.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin.creator
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+public fun createObjectCreator(): ObjectCreator = ObjectCreatorImpl()

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/SpanStorageTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/SpanStorageTest.kt
@@ -3,8 +3,8 @@ package io.embrace.opentelemetry.kotlin.context
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.creator.ContextCreator
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
-import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
 import io.embrace.opentelemetry.kotlin.creator.SpanCreator
+import io.embrace.opentelemetry.kotlin.creator.createObjectCreator
 import io.embrace.opentelemetry.kotlin.tracing.FakeSpan
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -19,7 +19,7 @@ internal class SpanStorageTest {
 
     @BeforeTest
     fun setUp() {
-        objectCreator = ObjectCreatorImpl()
+        objectCreator = createObjectCreator()
         spanCreator = objectCreator.span
         contextCreator = objectCreator.context
     }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/creator/SpanCreatorImplTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFalse
 @OptIn(ExperimentalApi::class)
 internal class SpanCreatorImplTest {
 
-    private val objectCreatorImpl = ObjectCreatorImpl()
+    private val objectCreatorImpl = createObjectCreator()
     private val creator = objectCreatorImpl.span
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
-import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.creator.createObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.TracerImpl
@@ -27,7 +27,7 @@ internal class LogContextTest {
     fun setUp() {
         clock = FakeClock()
         processor = FakeLogRecordProcessor()
-        objectCreator = ObjectCreatorImpl()
+        objectCreator = createObjectCreator()
         logger = LoggerImpl(
             clock,
             processor,

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
-import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.creator.createObjectCreator
 import io.embrace.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
@@ -20,7 +20,7 @@ internal class LoggerProviderImplTest {
         LogLimitConfig(100, 100),
         ResourceImpl(emptyMap(), null)
     )
-    private val objectCreator = ObjectCreatorImpl()
+    private val objectCreator = createObjectCreator()
 
     @Test
     fun `test minimal logger provider`() {

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -4,7 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
-import io.embrace.opentelemetry.kotlin.creator.ObjectCreatorImpl
+import io.embrace.opentelemetry.kotlin.creator.createObjectCreator
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
@@ -28,7 +28,7 @@ internal class TracerSpanContextTest {
     fun setUp() {
         clock = FakeClock()
         processor = FakeSpanProcessor()
-        objectCreator = ObjectCreatorImpl()
+        objectCreator = createObjectCreator()
         tracer = TracerImpl(
             clock,
             processor,


### PR DESCRIPTION
## Goal

Similar to how the default ObjectCreator is exposed for the compat module, do the same for the SDK module

