### PR TITLE
Enforce count-based span, log, and attributes limits

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -8,7 +8,7 @@ complexity:
     active: false
   LongParameterList:
     constructorThreshold: 30
-    functionThreshold: 11
+    functionThreshold: 31
     ignoreDataClasses: true
   TooManyFunctions:
     thresholdInFiles: 31

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
@@ -6,54 +6,78 @@ import io.embrace.opentelemetry.kotlin.threadSafeMap
 
 @OptIn(ExperimentalApi::class)
 @ThreadSafe
-internal class MutableAttributeContainerImpl : MutableAttributeContainer {
+internal class MutableAttributeContainerImpl(
+    private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
+) : MutableAttributeContainer {
 
     private val attrs: MutableMap<String, Any> = threadSafeMap()
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setStringAttribute(key: String, value: String) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setBooleanListAttribute(
         key: String,
         value: List<Boolean>
     ) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setStringListAttribute(
         key: String,
         value: List<String>
     ) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setLongListAttribute(
         key: String,
         value: List<Long>
     ) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override fun setDoubleListAttribute(
         key: String,
         value: List<Double>
     ) {
-        attrs[key] = value
+        if (canAddAttribute(key)) {
+            attrs[key] = value
+        }
     }
 
     override val attributes: Map<String, Any>
         get() = attrs.toMap()
+
+    private fun canAddAttribute(key: String): Boolean = attrs.size < attributeLimit || attrs.contains(key)
+
+    private companion object {
+        const val DEFAULT_ATTRIBUTE_LIMIT = 128
+    }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.threadSafeMap
 @OptIn(ExperimentalApi::class)
 @ThreadSafe
 internal class MutableAttributeContainerImpl(
-    private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
+    private val attributeLimit: Int
 ) : MutableAttributeContainer {
 
     private val attrs: MutableMap<String, Any> = threadSafeMap()
@@ -76,8 +76,6 @@ internal class MutableAttributeContainerImpl(
         get() = attrs.toMap()
 
     private fun canAddAttribute(key: String): Boolean = attrs.size < attributeLimit || attrs.contains(key)
-
-    private companion object {
-        const val DEFAULT_ATTRIBUTE_LIMIT = 128
-    }
 }
+
+internal const val DEFAULT_ATTRIBUTE_LIMIT: Int = 128

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
@@ -1,9 +1,10 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 
 @OptIn(ExperimentalApi::class)
 internal class LogLimitsConfigImpl : LogLimitsConfigDsl {
-    override var attributeCountLimit: Int = 128
+    override var attributeCountLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
     override var attributeValueLengthLimit: Int = Int.MAX_VALUE
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.resource.Resource
@@ -9,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
 @OptIn(ExperimentalApi::class)
 internal class ResourceConfigImpl : ResourceConfigDsl {
 
-    private val resourceAttrs = MutableAttributeContainerImpl()
+    private val resourceAttrs = MutableAttributeContainerImpl(DEFAULT_ATTRIBUTE_LIMIT)
     private var schemaUrl: String? = null
 
     override fun resource(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
@@ -1,12 +1,15 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.embrace.opentelemetry.kotlin.init.config.DEFAULT_EVENT_LIMIT
+import io.embrace.opentelemetry.kotlin.init.config.DEFAULT_LINK_LIMIT
 
 @OptIn(ExperimentalApi::class)
 internal class SpanLimitsConfigImpl : SpanLimitsConfigDsl {
-    override var attributeCountLimit: Int = 128
-    override var linkCountLimit: Int = 128
-    override var eventCountLimit: Int = 128
-    override var attributeCountPerEventLimit: Int = 128
-    override var attributeCountPerLinkLimit: Int = 128
+    override var attributeCountLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
+    override var linkCountLimit: Int = DEFAULT_LINK_LIMIT
+    override var eventCountLimit: Int = DEFAULT_EVENT_LIMIT
+    override var attributeCountPerEventLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
+    override var attributeCountPerLinkLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/config/SpanLimitConfig.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/config/SpanLimitConfig.kt
@@ -33,3 +33,6 @@ internal class SpanLimitConfig(
      */
     val attributeCountPerLinkLimit: Int,
 )
+
+internal const val DEFAULT_LINK_LIMIT: Int = 128
+internal const val DEFAULT_EVENT_LIMIT: Int = 128

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -20,7 +20,7 @@ internal class LoggerProviderImpl(
 
     private val apiProvider = ApiProviderImpl<Logger> { key ->
         val processor = CompositeLogRecordProcessor(loggingConfig.processors, sdkErrorHandler)
-        LoggerImpl(clock, processor, objectCreator, key, loggingConfig.resource)
+        LoggerImpl(clock, processor, objectCreator, key, loggingConfig.resource, loggingConfig.logLimits)
     }
 
     override fun getLogger(

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.embrace.opentelemetry.kotlin.ThreadSafe
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.sync
@@ -38,7 +39,7 @@ internal class ApiProviderImpl<T>(
         schemaUrl: String?,
         attributes: MutableAttributeContainer.() -> Unit
     ): InstrumentationScopeInfo {
-        val attrs = MutableAttributeContainerImpl().apply {
+        val attrs = MutableAttributeContainerImpl(DEFAULT_ATTRIBUTE_LIMIT).apply {
             attributes()
         }.attributes
         return InstrumentationScopeInfoImpl(name, version, schemaUrl, attrs)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
+import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.CreatedSpan
@@ -22,6 +23,7 @@ internal class TracerImpl(
     private val objectCreator: ObjectCreator,
     private val scope: InstrumentationScopeInfo,
     private val resource: Resource,
+    private val spanLimitConfig: SpanLimitConfig,
 ) : Tracer {
 
     override fun createSpan(
@@ -31,7 +33,7 @@ internal class TracerImpl(
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit
     ): Span {
-        val spanRelationships = SpanRelationshipsImpl(clock)
+        val spanRelationships = SpanRelationshipsImpl(clock, spanLimitConfig)
         action(spanRelationships)
 
         val ctx = parentContext ?: objectCreator.context.root()
@@ -48,7 +50,8 @@ internal class TracerImpl(
             instrumentationScopeInfo = scope,
             resource = resource,
             parent = parentSpanContext,
-            spanContext = spanContext
+            spanContext = spanContext,
+            spanLimitConfig = spanLimitConfig
         )
         processor.onStart(ReadWriteSpanImpl(spanModel), ctx)
         return CreatedSpan(spanModel)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -25,7 +25,8 @@ internal class TracerProviderImpl(
             processor = processor,
             objectCreator = objectCreator,
             scope = key,
-            resource = tracingConfig.resource
+            resource = tracingConfig.resource,
+            spanLimitConfig = tracingConfig.spanLimits
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
@@ -7,7 +7,16 @@ internal class MutableAttributeContainerImplTest {
 
     @Test
     fun `test attributes`() {
-        val attrs = MutableAttributeContainerImpl().apply {
+        val attrs = MutableAttributeContainerImpl(8).apply {
+            setStringAttribute("string", "old-value")
+            setBooleanAttribute("boolean", false)
+            setDoubleAttribute("double", 1.6)
+            setLongAttribute("long", 1234L)
+            setStringListAttribute("stringList", listOf("a", "b", "d"))
+            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 4.5))
+            setLongListAttribute("longList", listOf(4L, 5L, 7L))
+            setBooleanListAttribute("booleanList", listOf(true, false, false))
+
             setStringAttribute("string", "value")
             setBooleanAttribute("boolean", true)
             setDoubleAttribute("double", 5.2)
@@ -29,5 +38,23 @@ internal class MutableAttributeContainerImplTest {
             "booleanList" to listOf(true, false, true),
         )
         assertEquals(expected, attrs)
+    }
+
+    fun `attributes cannot exceed limit`() {
+        val limit = 2
+        val attrs = MutableAttributeContainerImpl(limit).apply {
+            setStringAttribute("attr-1", "value")
+            setStringAttribute("attr-2", "value")
+            setStringAttribute("string", "value")
+            setBooleanAttribute("boolean", true)
+            setDoubleAttribute("double", 5.2)
+            setLongAttribute("long", 123L)
+            setStringListAttribute("stringList", listOf("a", "b", "c"))
+            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 3.5))
+            setLongListAttribute("longList", listOf(4L, 5L, 6L))
+            setBooleanListAttribute("booleanList", listOf(true, false, true))
+        }.attributes
+
+        assertEquals(limit, attrs.size)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImplTest.kt
@@ -1,60 +1,60 @@
 package io.embrace.opentelemetry.kotlin.attributes
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalApi::class)
 internal class MutableAttributeContainerImplTest {
+
+    private val attributeLimit = 8
+    private val expected = mapOf(
+        "string" to "value",
+        "double" to 3.14,
+        "boolean" to true,
+        "long" to 90000000000000,
+        "string_list" to listOf("string"),
+        "double_list" to listOf(3.14),
+        "boolean_list" to listOf(true),
+        "long_list" to listOf(90000000000000)
+    )
 
     @Test
     fun `test attributes`() {
-        val attrs = MutableAttributeContainerImpl(8).apply {
-            setStringAttribute("string", "old-value")
-            setBooleanAttribute("boolean", false)
-            setDoubleAttribute("double", 1.6)
-            setLongAttribute("long", 1234L)
-            setStringListAttribute("stringList", listOf("a", "b", "d"))
-            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 4.5))
-            setLongListAttribute("longList", listOf(4L, 5L, 7L))
-            setBooleanListAttribute("booleanList", listOf(true, false, false))
-
-            setStringAttribute("string", "value")
-            setBooleanAttribute("boolean", true)
-            setDoubleAttribute("double", 5.2)
-            setLongAttribute("long", 123L)
-            setStringListAttribute("stringList", listOf("a", "b", "c"))
-            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 3.5))
-            setLongListAttribute("longList", listOf(4L, 5L, 6L))
-            setBooleanListAttribute("booleanList", listOf(true, false, true))
+        val attrs = MutableAttributeContainerImpl(attributeLimit).apply {
+            addTestAttributes()
         }.attributes
-
-        val expected = mapOf(
-            "string" to "value",
-            "boolean" to true,
-            "double" to 5.2,
-            "long" to 123L,
-            "stringList" to listOf("a", "b", "c"),
-            "doubleList" to listOf(1.5, 2.5, 3.5),
-            "longList" to listOf(4L, 5L, 6L),
-            "booleanList" to listOf(true, false, true),
-        )
         assertEquals(expected, attrs)
     }
 
-    fun `attributes cannot exceed limit`() {
-        val limit = 2
-        val attrs = MutableAttributeContainerImpl(limit).apply {
-            setStringAttribute("attr-1", "value")
-            setStringAttribute("attr-2", "value")
-            setStringAttribute("string", "value")
-            setBooleanAttribute("boolean", true)
-            setDoubleAttribute("double", 5.2)
-            setLongAttribute("long", 123L)
-            setStringListAttribute("stringList", listOf("a", "b", "c"))
-            setDoubleListAttribute("doubleList", listOf(1.5, 2.5, 3.5))
-            setLongListAttribute("longList", listOf(4L, 5L, 6L))
-            setBooleanListAttribute("booleanList", listOf(true, false, true))
+    fun `attributes updatable when container at limit but cannot exceed limit`() {
+        val attrs = MutableAttributeContainerImpl(attributeLimit).apply {
+            addTestAttributesAlternateValues()
+            addTestAttributes("xyz")
+            addTestAttributes()
         }.attributes
+        assertEquals(expected, attrs)
+    }
 
-        assertEquals(limit, attrs.size)
+    private fun MutableAttributeContainer.addTestAttributes(keyToken: String = "") {
+        setStringAttribute("string$keyToken", "value")
+        setDoubleAttribute("double$keyToken", 3.14)
+        setBooleanAttribute("boolean$keyToken", true)
+        setLongAttribute("long$keyToken", 90000000000000)
+        setStringListAttribute("string_list$keyToken", listOf("string"))
+        setDoubleListAttribute("double_list$keyToken", listOf(3.14))
+        setBooleanListAttribute("boolean_list$keyToken", listOf(true))
+        setLongListAttribute("long_list$keyToken", listOf(90000000000000))
+    }
+
+    private fun MutableAttributeContainer.addTestAttributesAlternateValues() {
+        setStringAttribute("string", "override")
+        setDoubleAttribute("double", 5.4)
+        setBooleanAttribute("boolean", false)
+        setLongAttribute("long", 80000000000000)
+        setStringListAttribute("string_list", listOf("override"))
+        setDoubleListAttribute("double_list", listOf(5.4))
+        setBooleanListAttribute("boolean_list", listOf(false))
+        setLongListAttribute("long_list", listOf(80000000000000))
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -9,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.TracerImpl
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.fakeSpanLimitsConfig
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -41,6 +42,7 @@ internal class LogContextTest {
             objectCreator,
             key,
             FakeResource(),
+            fakeSpanLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -9,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.TracerImpl
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
 import io.embrace.opentelemetry.kotlin.tracing.fakeSpanLimitsConfig
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -35,6 +36,7 @@ internal class LogContextTest {
             objectCreator,
             key,
             FakeResource(),
+            fakeLogLimitsConfig
         )
         tracer = TracerImpl(
             clock,

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -6,6 +6,7 @@ import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -29,6 +30,7 @@ internal class LogMetaPropertiesTest {
             FakeObjectCreator(),
             key,
             fakeResource,
+            fakeLogLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -8,6 +8,7 @@ import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import io.embrace.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,6 +34,7 @@ internal class LogSimplePropertiesTest {
             objectCreator,
             key,
             FakeResource(),
+            fakeLogLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/Fixtures.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/Fixtures.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.tracing
+
+import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
+
+internal val fakeSpanLimitsConfig = SpanLimitConfig(
+    attributeCountLimit = 100,
+    linkCountLimit = 100,
+    eventCountLimit = 100,
+    attributeCountPerEventLimit = 100,
+    attributeCountPerLinkLimit = 100
+)

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/Fixtures.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/Fixtures.kt
@@ -1,5 +1,6 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
+import io.embrace.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 
 internal val fakeSpanLimitsConfig = SpanLimitConfig(
@@ -8,4 +9,9 @@ internal val fakeSpanLimitsConfig = SpanLimitConfig(
     eventCountLimit = 100,
     attributeCountPerEventLimit = 100,
     attributeCountPerLinkLimit = 100
+)
+
+internal val fakeLogLimitsConfig = LogLimitConfig(
+    attributeCountLimit = 100,
+    attributeValueLengthLimit = 100,
 )

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -81,14 +81,14 @@ internal class SpanAttributesTest {
         span.addTestAttributes()
         assertEquals(expected, span.attributes)
         span.end()
-        span.overrideTestAttributes()
+        span.addTestAttributesAlternateValues()
         assertEquals(expected, span.attributes)
     }
 
     @Test
-    fun `span attribute only added in creation if limit not exceeded`() {
+    fun `span attribute updatable but new attributes only added in creation if limit not exceeded`() {
         val span = tracer.createSpan("test", action = {
-            overrideTestAttributes()
+            addTestAttributesAlternateValues()
             addTestAttributes("xyz")
             addTestAttributes()
         }).apply {
@@ -99,9 +99,9 @@ internal class SpanAttributesTest {
     }
 
     @Test
-    fun `span attribute only added if limit not exceeded`() {
+    fun `span attribute updatable but new attributes only added if limit not exceeded`() {
         val span = tracer.createSpan("test").apply {
-            overrideTestAttributes()
+            addTestAttributesAlternateValues()
             addTestAttributes("xyz")
             addTestAttributes()
             end()
@@ -121,7 +121,7 @@ internal class SpanAttributesTest {
         setLongListAttribute("long_list$keyToken", listOf(90000000000000))
     }
 
-    private fun MutableAttributeContainer.overrideTestAttributes() {
+    private fun MutableAttributeContainer.addTestAttributesAlternateValues() {
         setStringAttribute("string", "override")
         setDoubleAttribute("double", 5.4)
         setBooleanAttribute("boolean", false)

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -36,7 +36,8 @@ internal class SpanDataTest {
             processor,
             FakeObjectCreator(),
             key,
-            fakeResource
+            fakeResource,
+            fakeSpanLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEndTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEndTest.kt
@@ -33,6 +33,7 @@ internal class SpanEndTest {
             objectCreator,
             key,
             FakeResource(),
+            fakeSpanLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
+import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.embrace.opentelemetry.kotlin.resource.FakeResource
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -15,6 +16,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalApi::class)
 internal class SpanLinkTest {
 
+    private val linkLimit = 3
     private val fakeSpanContext = FakeSpanContext()
     private val otherFakeSpanContext = FakeSpanContext()
     private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
@@ -22,17 +24,26 @@ internal class SpanLinkTest {
     private lateinit var tracer: TracerImpl
     private lateinit var clock: FakeClock
     private lateinit var processor: FakeSpanProcessor
+    private lateinit var spanLimitConfig: SpanLimitConfig
 
     @BeforeTest
     fun setUp() {
         clock = FakeClock()
         processor = FakeSpanProcessor()
+        spanLimitConfig = SpanLimitConfig(
+            attributeCountLimit = fakeSpanLimitsConfig.attributeCountLimit,
+            linkCountLimit = linkLimit,
+            eventCountLimit = fakeSpanLimitsConfig.eventCountLimit,
+            attributeCountPerEventLimit = fakeSpanLimitsConfig.attributeCountPerEventLimit,
+            attributeCountPerLinkLimit = fakeSpanLimitsConfig.attributeCountPerLinkLimit
+        )
         tracer = TracerImpl(
             clock,
             processor,
             FakeObjectCreator(),
             key,
-            FakeResource()
+            FakeResource(),
+            spanLimitConfig
         )
     }
 
@@ -86,6 +97,31 @@ internal class SpanLinkTest {
         val links = retrieveLinks(2)
         assertLinkData(links[0], fakeSpanContext, emptyMap())
         assertLinkData(links[1], otherFakeSpanContext, mapOf("foo" to "bar"))
+    }
+
+    @Test
+    fun `span link only added in creation if limit not exceeded`() {
+        tracer.createSpan("test", action = {
+            repeat(linkLimit + 1) {
+                addLink(fakeSpanContext)
+            }
+        }).apply {
+            end()
+        }
+
+        retrieveLinks(3)
+    }
+
+    @Test
+    fun `span link only added if limit not exceeded`() {
+        tracer.createSpan("test").apply {
+            repeat(linkLimit + 1) {
+                addLink(fakeSpanContext)
+            }
+            end()
+        }
+
+        retrieveLinks(3)
     }
 
     private fun retrieveLinks(expected: Int): List<LinkData> {

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
@@ -29,6 +29,7 @@ internal class SpanMetaPropertiesTest {
             FakeObjectCreator(),
             key,
             fakeResource,
+            fakeSpanLimitsConfig,
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -27,7 +27,8 @@ internal class SpanSimplePropertiesTest {
             FakeSpanProcessor(),
             FakeObjectCreator(),
             key,
-            FakeResource()
+            FakeResource(),
+            fakeSpanLimitsConfig
         )
     }
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.creator.FakeObjectCreator
-import io.embrace.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
 import kotlin.test.BeforeTest
@@ -17,7 +16,7 @@ internal class TracerProviderImplTest {
 
     private val tracingConfig = TracingConfig(
         emptyList(),
-        SpanLimitConfig(100, 100, 100, 100, 100),
+        fakeSpanLimitsConfig,
         ResourceImpl(emptyMap(), null)
     )
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -35,6 +35,7 @@ internal class TracerSpanContextTest {
             objectCreator,
             key,
             FakeResource(),
+            fakeSpanLimitsConfig,
         )
     }
 


### PR DESCRIPTION
## Goal

Plumb down the limits for span events, links, and attributes to ensure that implementations all adhere to the stated limits.

## Testing

Added unit tests for all implementations and integration tests for log and span exporters
