### PR TITLE
API surface tweaks

### DIFF
--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryExt.kt
@@ -3,12 +3,20 @@ package io.embrace.opentelemetry.kotlin
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
+/**
+ * Returns a [Tracer] for the given [instrumentationScopeName]. This is equivalent to calling
+ * [io.embrace.opentelemetry.kotlin.tracing.TracerProvider.getTracer].
+ */
 @ExperimentalApi
 @ThreadSafe
 public fun OpenTelemetry.getTracer(instrumentationScopeName: String): Tracer {
     return tracerProvider.getTracer(name = instrumentationScopeName)
 }
 
+/**
+ * Returns a [Logger] for the given [instrumentationScopeName]. This is equivalent to calling
+ * [io.embrace.opentelemetry.kotlin.logging.LoggerProvider.getLogger].
+ */
 @ExperimentalApi
 @ThreadSafe
 public fun OpenTelemetry.getLogger(instrumentationScopeName: String): Logger {

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -126,6 +126,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProvi
 
 public abstract interface class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun resource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun resource (Ljava/util/Map;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl$DefaultImpls {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Clock.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/Clock.kt
@@ -4,7 +4,7 @@ package io.embrace.opentelemetry.kotlin
  * A clock that provides the current time in nanoseconds.
  */
 @ExperimentalApi
-public interface Clock {
+public fun interface Clock {
 
     /**
      * Returns the current time in nanoseconds.

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/InstrumentationScopeInfo.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/InstrumentationScopeInfo.kt
@@ -6,8 +6,23 @@ package io.embrace.opentelemetry.kotlin
 @ExperimentalApi
 public interface InstrumentationScopeInfo {
 
+    /**
+     * The name of the instrumentation scope.
+     */
     public val name: String
+
+    /**
+     * The version of the instrumentation scope, if set
+     */
     public val version: String?
+
+    /**
+     * The URL for the schema of the instrumentation scope, if set
+     */
     public val schemaUrl: String?
+
+    /**
+     * The attributes of the instrumentation scope, if set
+     */
     public val attributes: Map<String, Any>
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -11,6 +11,7 @@ import io.embrace.opentelemetry.kotlin.ThreadSafe
 @ExperimentalApi
 @ThreadSafe
 public interface AttributeContainer {
+
     /**
      * Returns a snapshot of the attributes as a map.
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
@@ -11,7 +11,8 @@ import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 public interface LoggerProviderConfigDsl : ResourceConfigDsl {
 
     /**
-     * Adds a [LogRecordProcessor] to the logger provider.
+     * Adds a [LogRecordProcessor] to the logger provider. Processors will be invoked
+     * in the order in which they were added.
      */
     public fun addLogRecordProcessor(processor: LogRecordProcessor)
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -3,7 +3,19 @@ package io.embrace.opentelemetry.kotlin.init
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 
+/**
+ * Defines configuration for a resource.
+ */
 @ExperimentalApi
 public interface ResourceConfigDsl {
+
+    /**
+     * Declares a resource, including an optional schema and any attributes.
+     */
     public fun resource(schemaUrl: String? = null, attributes: MutableAttributeContainer.() -> Unit)
+
+    /**
+     * Declares a resource by taking a copy of the supplied Map values.
+     */
+    public fun resource(map: Map<String, Any>)
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
@@ -11,7 +11,8 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 public interface TracerProviderConfigDsl : ResourceConfigDsl {
 
     /**
-     * The span limits configuration for this tracer provider.
+     * The span limits configuration for this tracer provider. Processors will be invoked
+     * in the order in which they were added.
      */
     public fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit)
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/EventData.kt
@@ -9,6 +9,7 @@ import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
  */
 @ExperimentalApi
 public interface EventData : AttributeContainer {
+
     /**
      * The name of the event
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/LinkData.kt
@@ -10,6 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
  */
 @ExperimentalApi
 public interface LinkData : AttributeContainer {
+
     /**
      * The span context of the link.
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanData.kt
@@ -10,6 +10,7 @@ import io.embrace.opentelemetry.kotlin.resource.Resource
  */
 @ExperimentalApi
 public interface SpanData : SpanSchema {
+
     /**
      * The timestamp at which this span ended, in nanoseconds. If it has not ended null will return.
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/SpanSchema.kt
@@ -12,6 +12,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  */
 @ExperimentalApi
 public interface SpanSchema : AttributeContainer {
+
     /**
      * The span name
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/data/StatusData.kt
@@ -12,6 +12,7 @@ public sealed class StatusData(
     public val statusCode: StatusCode,
     public val description: String?
 ) {
+
     /**
      * Default status.
      */

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan.kt
@@ -8,6 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
  */
 @ExperimentalApi
 public interface ReadableSpan : SpanData {
+
     /**
      * Return an instance of the span at the time of invocation. The implementation provided should be immutable.
      */

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -7,6 +7,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderBuilder
 import io.embrace.opentelemetry.kotlin.attributes.CompatMutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -26,6 +27,12 @@ internal class CompatLoggerProviderConfig(
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = CompatMutableAttributeContainer().apply(attributes).otelJavaAttributes()
         builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
+    }
+
+    override fun resource(map: Map<String, Any>) {
+        resource {
+            setAttributes(map)
+        }
     }
 
     override fun addLogRecordProcessor(processor: LogRecordProcessor) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -8,6 +8,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
 import io.embrace.opentelemetry.kotlin.attributes.CompatMutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.embrace.opentelemetry.kotlin.creator.ObjectCreator
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
@@ -34,6 +35,12 @@ internal class CompatTracerProviderConfig(
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = CompatMutableAttributeContainer().apply(attributes).otelJavaAttributes()
         builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
+    }
+
+    override fun resource(map: Map<String, Any>) {
+        resource {
+            setAttributes(map)
+        }
     }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {

--- a/opentelemetry-kotlin-implementation/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":opentelemetry-kotlin-api"))
+                implementation(project(":opentelemetry-kotlin-api-ext"))
                 implementation(project(":opentelemetry-kotlin-model"))
                 implementation(project(":opentelemetry-kotlin-primitives"))
             }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
+import io.embrace.opentelemetry.kotlin.attributes.setAttributes
 import io.embrace.opentelemetry.kotlin.resource.Resource
 import io.embrace.opentelemetry.kotlin.resource.ResourceImpl
 
@@ -19,6 +20,12 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
     ) {
         this.schemaUrl = schemaUrl
         resourceAttrs.attributes()
+    }
+
+    override fun resource(map: Map<String, Any>) {
+        resource {
+            setAttributes(map)
+        }
     }
 
     fun generateResource(): Resource = ResourceImpl(

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -54,4 +54,12 @@ internal class LoggerProviderConfigImplTest {
             assertEquals(attrValueCount, attributeValueLengthLimit)
         }
     }
+
+    @Test
+    fun testSimpleResourceConfig() {
+        val cfg = LoggerProviderConfigImpl().apply {
+            resource(mapOf("key" to "value"))
+        }.generateLoggingConfig()
+        assertEquals(mapOf("key" to "value"), cfg.resource.attributes)
+    }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -66,4 +66,12 @@ internal class TracerProviderConfigImplTest {
             assertEquals(attrCountPerEvent, attributeCountPerEventLimit)
         }
     }
+
+    @Test
+    fun testSimpleResourceConfig() {
+        val cfg = TracerProviderConfigImpl().apply {
+            resource(mapOf("key" to "value"))
+        }.generateTracingConfig()
+        assertEquals(mapOf("key" to "value"), cfg.resource.attributes)
+    }
 }


### PR DESCRIPTION
## Goal

Makes some tweaks to the API based on self-review of all the entire surface. This includes:

- Some missing documentation
- Making `Clock` a `fun` interface to enable SAM conversions if an end-users wishes to do so
- Adds an overload to specifying the resource that allows creating one from just a map
