### PR TITLE
Rename SDK factory properties

### DIFF
--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -42,7 +42,7 @@ fun runTracingExamples(api: OpenTelemetry) {
     val simpleSpan = tracer.createSpan("simple_span")
 
     // create a more complex span
-    val complexSpan = createComplexSpan(tracer, simpleSpan, api.sdkFactory.context.root())
+    val complexSpan = createComplexSpan(tracer, simpleSpan, api.sdkFactory.contextFactory.root())
 
     // alter the span after its creation
 

--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -42,7 +42,7 @@ fun runTracingExamples(api: OpenTelemetry) {
     val simpleSpan = tracer.createSpan("simple_span")
 
     // create a more complex span
-    val complexSpan = createComplexSpan(tracer, simpleSpan, api.sdkFactory.contextFactory.root())
+    val complexSpan = createComplexSpan(tracer, simpleSpan, api.contextFactory.root())
 
     // alter the span after its creation
 

--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -6,9 +6,8 @@ import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.default
+import io.embrace.opentelemetry.kotlin.createOpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
@@ -18,7 +17,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  * Example of how to instantiate a Kotlin API wrapper around the OTel Java SDK.
  */
 fun instantiateOtelApi(): OpenTelemetry {
-    return OpenTelemetryInstance.default(
+    return createOpenTelemetryInstance(
         tracerProvider = {
             addSpanProcessor(ExampleSpanProcessor())
         },

--- a/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/AppTracerProvider.kt
+++ b/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/AppTracerProvider.kt
@@ -2,8 +2,7 @@ package io.embrace.opentelemetry.kotlin.telescope.telemetry
 
 import android.content.res.Resources
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -36,7 +35,7 @@ class AppTracerProvider(
             .setTracerProvider(sdkTracerProvider)
             .build()
 
-        val kotlinApi = OpenTelemetryInstance.decorateJavaApi(javaSdk)
+        val kotlinApi = javaSdk.toOtelKotlinApi()
 
         return kotlinApi.tracerProvider.getTracer("AppTracer")
     }

--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -13,6 +13,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
+	public static final fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun addLink$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun recordException (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun recordException$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -26,3 +26,12 @@ public fun Span.recordException(
         attributes(this)
     }
 }
+
+/**
+ * Adds a link to the span that associates it with another [Span].
+ */
+@OptIn(ExperimentalApi::class)
+@ThreadSafe
+public fun Span.addLink(span: Span, attributes: MutableAttributeContainer.() -> Unit = {}) {
+    addLink(span.spanContext, attributes)
+}

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class SpanExtTest {
@@ -54,5 +55,29 @@ internal class SpanExtTest {
         assertEquals(1, simpleAttrs.size)
         assertNull(simpleAttrs["exception.type"])
         assertNotNull(simpleAttrs["exception.stacktrace"])
+    }
+
+    @Test
+    fun testAddLinkSimple() {
+        val a = FakeSpan()
+        val b = FakeSpan()
+
+        a.addLink(b)
+        val link = a.links.single()
+        assertEquals(b.spanContext, link.spanContext)
+        assertTrue(link.attributes.isEmpty())
+    }
+
+    @Test
+    fun testAddLinkWithAttrs() {
+        val a = FakeSpan()
+        val b = FakeSpan()
+
+        a.addLink(b) {
+            setStringAttribute("extra", "value")
+        }
+        val link = a.links.single()
+        assertEquals(b.spanContext, link.spanContext)
+        assertEquals(mapOf("extra" to "value"), link.attributes)
     }
 }

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -18,10 +18,6 @@ public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry : 
 	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstance {
-	public static final field INSTANCE Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;
-}
-
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/ThreadSafe : java/lang/annotation/Annotation {
 }
 

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -12,10 +12,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/InstrumentationS
 	public abstract fun getVersion ()Ljava/lang/String;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
+public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry : io/embrace/opentelemetry/kotlin/factory/SdkFactory {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
-	public abstract fun getSdkFactory ()Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;
 	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -73,12 +73,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/factory/ContextF
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/factory/SdkFactory {
-	public abstract fun getContext ()Lio/embrace/opentelemetry/kotlin/factory/ContextFactory;
-	public abstract fun getSpan ()Lio/embrace/opentelemetry/kotlin/factory/SpanFactory;
-	public abstract fun getSpanContext ()Lio/embrace/opentelemetry/kotlin/factory/SpanContextFactory;
-	public abstract fun getTraceFlags ()Lio/embrace/opentelemetry/kotlin/factory/TraceFlagsFactory;
-	public abstract fun getTraceState ()Lio/embrace/opentelemetry/kotlin/factory/TraceStateFactory;
-	public abstract fun getTracingIds ()Lio/embrace/opentelemetry/kotlin/factory/TracingIdFactory;
+	public abstract fun getContextFactory ()Lio/embrace/opentelemetry/kotlin/factory/ContextFactory;
+	public abstract fun getSpanContextFactory ()Lio/embrace/opentelemetry/kotlin/factory/SpanContextFactory;
+	public abstract fun getSpanFactory ()Lio/embrace/opentelemetry/kotlin/factory/SpanFactory;
+	public abstract fun getTraceFlagsFactory ()Lio/embrace/opentelemetry/kotlin/factory/TraceFlagsFactory;
+	public abstract fun getTraceStateFactory ()Lio/embrace/opentelemetry/kotlin/factory/TraceStateFactory;
+	public abstract fun getTracingIdFactory ()Lio/embrace/opentelemetry/kotlin/factory/TracingIdFactory;
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/factory/SpanContextFactory {

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
  * The main entry point for the OpenTelemetry API.
  */
 @ExperimentalApi
-public interface OpenTelemetry {
+public interface OpenTelemetry : SdkFactory {
 
     /**
      * The [TracerProvider] for creating [Tracer] instances.
@@ -26,9 +26,4 @@ public interface OpenTelemetry {
      * The [Clock] that will be used for obtaining timestamps by this instance.
      */
     public val clock: Clock
-
-    /**
-     * Used for creating new objects that can be passed to the SDK.
-     */
-    public val sdkFactory: SdkFactory
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstance.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstance.kt
@@ -1,7 +1,0 @@
-package io.embrace.opentelemetry.kotlin
-
-/**
- * Entrypoint for creating instances of [OpenTelemetry].
- */
-@ExperimentalApi
-public object OpenTelemetryInstance

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/SdkFactory.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/SdkFactory.kt
@@ -11,30 +11,30 @@ public interface SdkFactory {
     /**
      * Factory that constructs SpanContext objects.
      */
-    public val spanContext: SpanContextFactory
+    public val spanContextFactory: SpanContextFactory
 
     /**
      * Factory that constructs TraceFlags objects.
      */
-    public val traceFlags: TraceFlagsFactory
+    public val traceFlagsFactory: TraceFlagsFactory
 
     /**
      * Factory that constructs TraceState objects.
      */
-    public val traceState: TraceStateFactory
+    public val traceStateFactory: TraceStateFactory
 
     /**
      * Factory that constructs Context objects.
      */
-    public val context: ContextFactory
+    public val contextFactory: ContextFactory
 
     /**
      * Factory that constructs Span objects.
      */
-    public val span: SpanFactory
+    public val spanFactory: SpanFactory
 
     /**
      * Factory that constructs tracing IDs.
      */
-    public val tracingIds: TracingIdFactory
+    public val tracingIdFactory: TracingIdFactory
 }

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,13 +1,14 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {
+	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+}
+
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompatKt {
 	public static final fun createOpenTelemetryKotlin (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 	public static synthetic fun createOpenTelemetryKotlin$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static final fun decorateJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun decorateJavaApi$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static final fun decorateKotlinApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryJavaExtKt {
-	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExtKt {
+	public static final fun toOtelKotlinApi (Lio/opentelemetry/api/OpenTelemetry;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/context/ContextExtKt {

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,10 +1,10 @@
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {
-	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypointKt {
+	public static final fun createCompatOpenTelemetryInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createCompatOpenTelemetryInstance$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompatKt {
-	public static final fun createOpenTelemetryKotlin (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun createOpenTelemetryKotlin$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {
+	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExtKt {
@@ -31,12 +31,20 @@ public final class io/embrace/opentelemetry/kotlin/factory/ContextFactoryExtKt {
 	public static final fun current (Lio/embrace/opentelemetry/kotlin/factory/ContextFactory;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }
 
-public final class io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterExtKt {
+public final class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtKt {
 	public static final fun toOtelKotlinLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExtKt {
+public final class io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtKt {
+	public static final fun toOtelKotlinLogRecordProcessor (Lio/opentelemetry/sdk/logs/LogRecordProcessor;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtKt {
 	public static final fun toOtelKotlinSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtKt {
+	public static final fun toOtelKotlinSpanProcessor (Lio/opentelemetry/sdk/trace/SpanProcessor;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/ext/EventDataExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -18,13 +18,29 @@ import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
  * [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
-public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
+public fun createCompatOpenTelemetryInstance(
+    tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
+    loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
+    clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
+): OpenTelemetry {
+    return createCompatOpenTelemetryInstanceImpl(
+        tracerProvider,
+        loggerProvider,
+        clock,
+    )
+}
+
+/**
+ * Internal implementation of [createCompatOpenTelemetryInstance]. This is not publicly visible as
+ * we don't want to allow users to supply a custom [SdkFactory].
+ */
+@ExperimentalApi
+internal fun createCompatOpenTelemetryInstanceImpl(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
     sdkFactory: SdkFactory = createCompatSdkFactory(),
 ): OpenTelemetry {
-    sdkFactory.tracingIdFactory
     val tracerCfg = CompatTracerProviderConfig(clock, sdkFactory).apply(tracerProvider)
     val loggerCfg = CompatLoggerProviderConfig(clock).apply(loggerProvider)
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -9,7 +9,7 @@ import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
  * to the opentelemetry-java API.
  *
  * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
- * or [decorateJavaApi] instead.
+ * or [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
 public fun OpenTelemetry.toOtelJavaApi(): OtelJavaOpenTelemetry {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
  * Constructs an [OtelJavaOpenTelemetry] instance that makes the Kotlin implementation conform
  * to the opentelemetry-java API.
  *
- * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
+ * End-users should generally not use this function and should call [createCompatOpenTelemetryInstance]
  * or [toOtelKotlinApi] instead.
  */
 @ExperimentalApi

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
@@ -1,7 +1,5 @@
 package io.embrace.opentelemetry.kotlin
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.factory.createCompatSdkFactory
@@ -9,34 +7,6 @@ import io.embrace.opentelemetry.kotlin.init.CompatLoggerProviderConfig
 import io.embrace.opentelemetry.kotlin.init.CompatTracerProviderConfig
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
-import io.embrace.opentelemetry.kotlin.logging.OtelJavaLoggerProviderAdapter
-import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
-import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
-
-/**
- * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API.
- * Callers must pass a reference to an OpenTelemetry Java SDK instance. Under the hood calls to the
- * Kotlin API will be delegated to the Java SDK implementation.
- *
- * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
- * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
- * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
- * generally be encouraged to migrate to [createOpenTelemetryKotlin] as a long-term goal.
- */
-@ExperimentalApi
-public fun OpenTelemetryInstance.decorateJavaApi(
-    impl: OtelJavaOpenTelemetry,
-    sdkFactory: SdkFactory = createCompatSdkFactory(),
-): OpenTelemetry {
-    val clock = ClockAdapter(OtelJavaClock.getDefault())
-    return OpenTelemetryImpl(
-        tracerProvider = TracerProviderAdapter(impl.tracerProvider, clock),
-        loggerProvider = LoggerProviderAdapter(impl.logsBridge),
-        clock = clock,
-        sdkFactory = sdkFactory
-    )
-}
 
 /**
  * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API. The SDK is
@@ -45,7 +15,7 @@ public fun OpenTelemetryInstance.decorateJavaApi(
  *
  * It's not possible to obtain a reference to the Java API using this function. If this is a
  * requirement because you have existing instrumentation, it's recommended to call
- * [decorateJavaApi] instead.
+ * [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
 public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
@@ -63,20 +33,5 @@ public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
         loggerProvider = loggerCfg.build(),
         clock = clock,
         sdkFactory = sdkFactory,
-    )
-}
-
-/**
- * Constructs an [OtelJavaOpenTelemetry] instance that makes the Kotlin implementation conform
- * to the opentelemetry-java API.
- *
- * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
- * or [decorateJavaApi] instead.
- */
-@ExperimentalApi
-public fun OpenTelemetryInstance.decorateKotlinApi(impl: OpenTelemetry): OtelJavaOpenTelemetry {
-    return OtelJavaOpenTelemetrySdk(
-        tracerProvider = OtelJavaTracerProviderAdapter(impl.tracerProvider),
-        loggerProvider = OtelJavaLoggerProviderAdapter(impl.loggerProvider)
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
@@ -54,7 +54,7 @@ public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
     sdkFactory: SdkFactory = createCompatSdkFactory(),
 ): OpenTelemetry {
-    sdkFactory.tracingIds
+    sdkFactory.tracingIdFactory
     val tracerCfg = CompatTracerProviderConfig(clock, sdkFactory).apply(tracerProvider)
     val loggerCfg = CompatLoggerProviderConfig(clock).apply(loggerProvider)
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -1,0 +1,31 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
+import io.embrace.opentelemetry.kotlin.factory.SdkFactory
+import io.embrace.opentelemetry.kotlin.factory.createCompatSdkFactory
+import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
+import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
+
+/**
+ * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API.
+ * Callers must pass a reference to an OpenTelemetry Java SDK instance. Under the hood calls to the
+ * Kotlin API will be delegated to the Java SDK implementation.
+ *
+ * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
+ * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
+ * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
+ * generally be encouraged to migrate to [createOpenTelemetryKotlin] as a long-term goal.
+ */
+@ExperimentalApi
+public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
+    val sdkFactory: SdkFactory = createCompatSdkFactory()
+    val clock = ClockAdapter(OtelJavaClock.getDefault())
+    return OpenTelemetryImpl(
+        tracerProvider = TracerProviderAdapter(tracerProvider, clock),
+        loggerProvider = LoggerProviderAdapter(logsBridge),
+        clock = clock,
+        sdkFactory = sdkFactory
+    )
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -16,7 +16,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
  * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
  * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
  * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
- * generally be encouraged to migrate to [createOpenTelemetryKotlin] as a long-term goal.
+ * generally be encouraged to migrate to [createCompatOpenTelemetryInstance] as a long-term goal.
  */
 @ExperimentalApi
 public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/factory/CompatSdkFactory.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/factory/CompatSdkFactory.kt
@@ -4,11 +4,11 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class CompatSdkFactory(
-    override val tracingIds: TracingIdFactory = CompatTracingIdFactory()
+    override val tracingIdFactory: TracingIdFactory = CompatTracingIdFactory()
 ) : SdkFactory {
-    override val spanContext: SpanContextFactory by lazy { CompatSpanContextFactory() }
-    override val traceFlags: TraceFlagsFactory by lazy { CompatTraceFlagsFactory() }
-    override val traceState: TraceStateFactory by lazy { CompatTraceStateFactory() }
-    override val context: ContextFactory by lazy { CompatContextFactory() }
-    override val span: SpanFactory by lazy { CompatSpanFactory(spanContext) }
+    override val spanContextFactory: SpanContextFactory by lazy { CompatSpanContextFactory() }
+    override val traceFlagsFactory: TraceFlagsFactory by lazy { CompatTraceFlagsFactory() }
+    override val traceStateFactory: TraceStateFactory by lazy { CompatTraceStateFactory() }
+    override val contextFactory: ContextFactory by lazy { CompatContextFactory() }
+    override val spanFactory: SpanFactory by lazy { CompatSpanFactory(spanContextFactory) }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -26,7 +26,7 @@ internal class CompatTracerProviderConfig(
     init {
         builder.setClock(OtelJavaClockWrapper(clock))
 
-        val idGenerator = sdkFactory.tracingIds
+        val idGenerator = sdkFactory.tracingIdFactory
         if (idGenerator is OtelJavaIdGenerator) {
             builder.setIdGenerator(idGenerator)
         }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.embrace.opentelemetry.kotlin.toOperationResultCode
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaLogRecordExporterAdapter(
+internal class LogRecordExporterAdapter(
     private val impl: OtelJavaLogRecordExporter
 ) : LogRecordExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExt.kt
@@ -3,6 +3,10 @@ package io.embrace.opentelemetry.kotlin.logging.export
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 
+/**
+ * Converts an opentelemetry-java log record exporter to an opentelemetry-kotlin log record exporter.
+ * This is useful if you wish to use an existing Java exporter whilst using opentelemetry-kotlin.
+ */
 @OptIn(ExperimentalApi::class)
 public fun OtelJavaLogRecordExporter.toOtelKotlinLogRecordExporter(): LogRecordExporter =
-    OtelJavaLogRecordExporterAdapter(this)
+    LogRecordExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.toOperationResultCode
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordProcessorAdapter(
+    private val impl: OtelJavaLogRecordProcessor
+) : LogRecordProcessor {
+
+    override fun onEmit(
+        log: ReadWriteLogRecord,
+        context: Context
+    ) {
+        if (log is ReadWriteLogRecordAdapter) {
+            impl.onEmit(context.toOtelJavaContext(), log.impl)
+        }
+    }
+
+    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+
+/**
+ * Converts an opentelemetry-java log record processor to an opentelemetry-kotlin log record processor.
+ * This is useful if you wish to use an existing Java processor whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaLogRecordProcessor.toOtelKotlinLogRecordProcessor(): LogRecordProcessor =
+    LogRecordProcessorAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -17,7 +17,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextAdapter
 @Suppress("UNUSED_PARAMETER")
 @OptIn(ExperimentalApi::class)
 internal class ReadWriteLogRecordAdapter(
-    private val impl: OtelJavaReadWriteLogRecord
+    val impl: OtelJavaReadWriteLogRecord
 ) : ReadWriteLogRecord {
 
     override var timestamp: Long?

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExt.kt
@@ -1,7 +1,0 @@
-package io.embrace.opentelemetry.kotlin.tracing.export
-
-import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
-
-@OptIn(ExperimentalApi::class)
-public fun OtelJavaSpanExporter.toOtelKotlinSpanExporter(): SpanExporter = OtelJavaSpanExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanData
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterAdapter(
+internal class SpanExporterAdapter(
     private val impl: OtelJavaSpanExporter
 ) : SpanExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExt.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+
+/**
+ * Converts an opentelemetry-java span exporter to an opentelemetry-kotlin span exporter.
+ * This is useful if you wish to use an existing Java exporter whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaSpanExporter.toOtelKotlinSpanExporter(): SpanExporter = SpanExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
@@ -1,0 +1,38 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.toOperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpanAdapter
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpanAdapter
+
+@OptIn(ExperimentalApi::class)
+internal class SpanProcessorAdapter(
+    private val impl: OtelJavaSpanProcessor
+) : SpanProcessor {
+
+    override fun onStart(
+        span: ReadWriteSpan,
+        parentContext: Context
+    ) {
+        if (span is ReadWriteSpanAdapter) {
+            impl.onStart(parentContext.toOtelJavaContext(), span.impl)
+        }
+    }
+
+    override fun onEnd(span: ReadableSpan) {
+        if (span is ReadableSpanAdapter) {
+            impl.onEnd(span.impl)
+        }
+    }
+
+    override fun isStartRequired(): Boolean = impl.isStartRequired
+    override fun isEndRequired(): Boolean = impl.isEndRequired
+    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+
+/**
+ * Converts an opentelemetry-java span processor to an opentelemetry-kotlin span processor.
+ * This is useful if you wish to use an existing Java processor whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaSpanProcessor.toOtelKotlinSpanProcessor(): SpanProcessor =
+    SpanProcessorAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
 internal class ReadWriteSpanAdapter(
-    private val impl: OtelJavaReadWriteSpan,
+    val impl: OtelJavaReadWriteSpan,
     private val readableSpan: ReadableSpanAdapter = ReadableSpanAdapter(impl)
 ) : ReadWriteSpan, ReadableSpan by readableSpan {
 
@@ -42,14 +42,21 @@ internal class ReadWriteSpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addLink(
+        spanContext: SpanContext,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
         val container = CompatMutableAttributeContainer()
         attributes(container)
         val ctx = (spanContext as SpanContextAdapter).impl
         impl.addLink(ctx, container.otelJavaAttributes())
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addEvent(
+        name: String,
+        timestamp: Long?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
         val container = CompatMutableAttributeContainer()
         attributes(container)
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
@@ -19,7 +19,7 @@ import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinStatusData
 
 @OptIn(ExperimentalApi::class)
 internal class ReadableSpanAdapter(
-    private val impl: OtelJavaReadableSpan
+    val impl: OtelJavaReadableSpan
 ) : ReadableSpan {
     override val parent: SpanContext
     override val spanContext: SpanContext

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
@@ -8,7 +8,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve tracer provider`() {
-        val sdk = OpenTelemetryInstance.createOpenTelemetryKotlin()
+        val sdk = createCompatOpenTelemetryInstance()
         val provider = sdk.tracerProvider
         val a = provider.getTracer("test")
         val b = provider.getTracer("test")
@@ -23,7 +23,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve logger provider`() {
-        val sdk = OpenTelemetryInstance.createOpenTelemetryKotlin()
+        val sdk = createCompatOpenTelemetryInstance()
         val provider = sdk.loggerProvider
         val a = provider.getLogger("test")
         val b = provider.getLogger("test")

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/OtelJavaContextAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/context/OtelJavaContextAdapterTest.kt
@@ -15,7 +15,7 @@ internal class OtelJavaContextAdapterTest {
     fun `test context`() {
         val factory = createCompatSdkFactory()
         val repository = OtelJavaContextKeyRepository()
-        val ctx = OtelJavaContextAdapter(factory.context.root(), repository)
+        val ctx = OtelJavaContextAdapter(factory.contextFactory.root(), repository)
         val key1 = OtelJavaContextKey.named<String>("foo")
         val key2 = OtelJavaContextKey.named<String>("foo")
         val key3 = OtelJavaContextKey.named<String>("bar")

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
@@ -13,11 +13,11 @@ internal class ContextFactoryImplTest {
 
     @Test
     fun `test root`() {
-        assertSame(OtelJavaContext.root(), factory.context.root().toOtelJavaContext())
+        assertSame(OtelJavaContext.root(), factory.contextFactory.root().toOtelJavaContext())
     }
 
     @Test
     fun `test current`() {
-        assertSame(OtelJavaContext.current(), factory.context.current().toOtelJavaContext())
+        assertSame(OtelJavaContext.current(), factory.contextFactory.current().toOtelJavaContext())
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanContextFactoryTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanContextFactoryTest.kt
@@ -11,7 +11,7 @@ internal class SpanContextFactoryTest {
 
     @Test
     fun `test invalid`() {
-        assertSame(factory.spanContext.invalid, factory.spanContext.invalid)
+        assertSame(factory.spanContextFactory.invalid, factory.spanContextFactory.invalid)
     }
 
     @Test
@@ -19,9 +19,9 @@ internal class SpanContextFactoryTest {
         val generator = CompatTracingIdFactory()
         val traceId = generator.generateTraceId()
         val spanId = generator.generateSpanId()
-        val traceFlags = factory.traceFlags.default
-        val traceState = factory.traceState.default
-        val spanContext = factory.spanContext.create(
+        val traceFlags = factory.traceFlagsFactory.default
+        val traceState = factory.traceStateFactory.default
+        val spanContext = factory.spanContextFactory.create(
             traceId,
             spanId,
             traceFlags,

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -13,26 +13,26 @@ internal class SpanFactoryImplTest {
 
     @Test
     fun `test invalid`() {
-        assertSame(factory.spanContext.invalid, factory.spanContext.invalid)
+        assertSame(factory.spanContextFactory.invalid, factory.spanContextFactory.invalid)
     }
 
     @Test
     fun `test from context`() {
-        val ctx = factory.context.root()
-        val span = factory.span.fromContext(ctx)
+        val ctx = factory.contextFactory.root()
+        val span = factory.spanFactory.fromContext(ctx)
         assertFalse(span.spanContext.isValid)
     }
 
     @Test
     fun `test from span context`() {
         val generator = CompatTracingIdFactory()
-        val spanContext = factory.spanContext.create(
+        val spanContext = factory.spanContextFactory.create(
             traceId = generator.generateTraceId(),
             spanId = generator.generateSpanId(),
-            traceState = factory.traceState.default,
-            traceFlags = factory.traceFlags.default,
+            traceState = factory.traceStateFactory.default,
+            traceFlags = factory.traceFlagsFactory.default,
         )
-        val span = factory.span.fromSpanContext(spanContext)
+        val span = factory.spanFactory.fromSpanContext(spanContext)
         assertTrue(span.spanContext.isValid)
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalApi::class)
 internal class TraceFlagsFactoryTest {
 
-    private val factory = createCompatSdkFactory().traceFlags
+    private val factory = createCompatSdkFactory().traceFlagsFactory
 
     @Test
     fun `default property`() {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TraceStateFactoryTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TraceStateFactoryTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalApi::class)
 internal class TraceStateFactoryTest {
 
-    private val factory = createCompatSdkFactory().traceState
+    private val factory = createCompatSdkFactory().traceStateFactory
 
     @Test
     fun `test valid`() {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TracingIdFactoryTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/factory/TracingIdFactoryTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalApi::class)
 internal class TracingIdFactoryTest {
 
-    private val factory = createCompatSdkFactory().tracingIds
+    private val factory = createCompatSdkFactory().tracingIdFactory
 
     @Test
     fun `test invalid`() {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordProcessor.kt
@@ -1,0 +1,30 @@
+package io.embrace.opentelemetry.kotlin.fakes.otel.java
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
+
+internal class FakeOtelJavaLogRecordProcessor : OtelJavaLogRecordProcessor {
+
+    var flushCount = 0
+    var shutdownCount = 0
+    val exports: MutableList<OtelJavaReadWriteLogRecord> = mutableListOf()
+
+    override fun onEmit(
+        context: OtelJavaContext,
+        logRecord: OtelJavaReadWriteLogRecord
+    ) {
+        exports += logRecord
+    }
+
+    override fun forceFlush(): OtelJavaCompletableResultCode? {
+        flushCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        shutdownCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanProcessor.kt
@@ -1,0 +1,39 @@
+package io.embrace.opentelemetry.kotlin.fakes.otel.java
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+
+internal class FakeOtelJavaSpanProcessor : OtelJavaSpanProcessor {
+
+    var flushCount = 0
+    var shutdownCount = 0
+    val startCalls: MutableList<OtelJavaReadWriteSpan> = mutableListOf()
+    val endCalls: MutableList<OtelJavaReadableSpan> = mutableListOf()
+
+    override fun onStart(
+        parentContext: OtelJavaContext,
+        span: OtelJavaReadWriteSpan
+    ) {
+        startCalls += span
+    }
+
+    override fun onEnd(span: OtelJavaReadableSpan) {
+        endCalls += span
+    }
+
+    override fun isStartRequired(): Boolean = true
+    override fun isEndRequired(): Boolean = true
+
+    override fun forceFlush(): OtelJavaCompletableResultCode? {
+        flushCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        shutdownCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -2,9 +2,8 @@ package io.embrace.opentelemetry.kotlin.framework
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
-import io.embrace.opentelemetry.kotlin.createOpenTelemetryKotlin
+import io.embrace.opentelemetry.kotlin.createCompatOpenTelemetryInstanceImpl
 import io.embrace.opentelemetry.kotlin.factory.CompatSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.CompatTracingIdFactory
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactory
@@ -15,10 +14,10 @@ import kotlin.random.Random
 internal class OtelKotlinHarness : OtelKotlinTestRule() {
 
     override val kotlinApi: OpenTelemetry by lazy {
-        OpenTelemetryInstance.createOpenTelemetryKotlin(
-            clock = clock,
+        createCompatOpenTelemetryInstanceImpl(
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
+            clock = clock,
             sdkFactory = CompatSdkFactory(tracingIdFactory = FakeTracingIdFactory())
         )
     }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -5,10 +5,10 @@ import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.createOpenTelemetryKotlin
-import io.embrace.opentelemetry.kotlin.decorateKotlinApi
 import io.embrace.opentelemetry.kotlin.factory.CompatSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.CompatTracingIdFactory
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactory
+import io.embrace.opentelemetry.kotlin.toOtelJavaApi
 import kotlin.random.Random
 
 @OptIn(ExperimentalApi::class)
@@ -24,7 +24,7 @@ internal class OtelKotlinHarness : OtelKotlinTestRule() {
     }
 
     val javaApi by lazy {
-        OpenTelemetryInstance.decorateKotlinApi(kotlinApi)
+        kotlinApi.toOtelJavaApi()
     }
 }
 

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -19,7 +19,7 @@ internal class OtelKotlinHarness : OtelKotlinTestRule() {
             clock = clock,
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
-            sdkFactory = CompatSdkFactory(tracingIds = FakeTracingIdFactory())
+            sdkFactory = CompatSdkFactory(tracingIdFactory = FakeTracingIdFactory())
         )
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -85,7 +85,7 @@ internal class LogExportTest {
         harness.config.logRecordProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.kotlinApi.sdkFactory.contextFactory.current()
+        val currentContext = harness.kotlinApi.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -85,7 +85,7 @@ internal class LogExportTest {
         harness.config.logRecordProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.kotlinApi.sdkFactory.context.current()
+        val currentContext = harness.kotlinApi.sdkFactory.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
@@ -10,15 +10,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaLogRecordExporterAdapterTest {
+internal class LogRecordExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaLogRecordExporter
-    private lateinit var wrapper: OtelJavaLogRecordExporterAdapter
+    private lateinit var wrapper: LogRecordExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaLogRecordExporter()
-        wrapper = OtelJavaLogRecordExporterAdapter(impl)
+        wrapper = LogRecordExporterAdapter(impl)
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtTest.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordExporterExtTest {
+
+    @Test
+    fun toOtelKotlinLogRecordExporter() {
+        val impl = FakeOtelJavaLogRecordExporter()
+        val adapter = impl.toOtelKotlinLogRecordExporter()
+        val timestamp = 500L
+        adapter.export(mutableListOf(FakeReadWriteLogRecord(timestamp = timestamp)))
+
+        val export = impl.exports.single()
+        assertEquals(timestamp, export.timestampEpochNanos)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
@@ -1,0 +1,44 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordProcessorExtTest {
+
+    @Test
+    fun testOnEmit() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        val harness = OtelKotlinHarness()
+        harness.config.logRecordProcessors.add(adapter)
+
+        val logger = harness.javaApi.logsBridge.get("logger")
+        val msg = "hello world"
+        logger.logRecordBuilder()
+            .setBody(msg)
+            .emit()
+
+        val export = impl.exports.single()
+        assertEquals(msg, export.bodyValue?.asString())
+    }
+
+    @Test
+    fun testFlush() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        adapter.forceFlush()
+        assertEquals(1, impl.flushCount)
+    }
+
+    @Test
+    fun testShutdown() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        adapter.shutdown()
+        assertEquals(1, impl.shutdownCount)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -115,7 +115,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test span context parent`() {
-        val root = harness.sdkFactory.contextFactory.root()
+        val root = harness.kotlinApi.contextFactory.root()
 
         val a = harness.tracer.createSpan("a", parentContext = root)
         val ctxa = a.storeInContext(root)
@@ -125,7 +125,7 @@ internal class SpanExportTest {
 
         val c = harness.tracer.createSpan("c", parentContext = ctxb)
 
-        assertSpanContextsMatch(harness.sdkFactory.spanContextFactory.invalid, a.parent)
+        assertSpanContextsMatch(harness.kotlinApi.spanContextFactory.invalid, a.parent)
         assertNotNull(a.spanContext)
         assertSpanContextsMatch(a.spanContext, b.parent)
         assertSpanContextsMatch(b.spanContext, c.parent)
@@ -159,7 +159,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test invalid span context`() {
-        val invalidContext = harness.sdkFactory.spanContextFactory.invalid
+        val invalidContext = harness.kotlinApi.spanContextFactory.invalid
 
         // Test invalid context properties
         assertFalse(invalidContext.isValid)
@@ -169,7 +169,7 @@ internal class SpanExportTest {
         // Test span creation with invalid parent
         val span = harness.tracer.createSpan(
             "test_span",
-            parentContext = harness.sdkFactory.contextFactory.root()
+            parentContext = harness.kotlinApi.contextFactory.root()
         )
 
         // Child span should be created with a valid context
@@ -283,7 +283,7 @@ internal class SpanExportTest {
     fun `test trace and span id validation without sanitization`() {
         val span1 = harness.tracer.createSpan("validation_span_1")
         val span2 = harness.tracer.createSpan("validation_span_2")
-        val ctx = span1.storeInContext(harness.sdkFactory.contextFactory.root())
+        val ctx = span1.storeInContext(harness.kotlinApi.contextFactory.root())
         val span3 = harness.tracer.createSpan("validation_span_3", ctx)
 
         span1.end()
@@ -390,7 +390,7 @@ internal class SpanExportTest {
         harness.config.spanProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.sdkFactory.contextFactory.current()
+        val currentContext = harness.kotlinApi.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -115,7 +115,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test span context parent`() {
-        val root = harness.sdkFactory.context.root()
+        val root = harness.sdkFactory.contextFactory.root()
 
         val a = harness.tracer.createSpan("a", parentContext = root)
         val ctxa = a.storeInContext(root)
@@ -125,7 +125,7 @@ internal class SpanExportTest {
 
         val c = harness.tracer.createSpan("c", parentContext = ctxb)
 
-        assertSpanContextsMatch(harness.sdkFactory.spanContext.invalid, a.parent)
+        assertSpanContextsMatch(harness.sdkFactory.spanContextFactory.invalid, a.parent)
         assertNotNull(a.spanContext)
         assertSpanContextsMatch(a.spanContext, b.parent)
         assertSpanContextsMatch(b.spanContext, c.parent)
@@ -159,7 +159,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test invalid span context`() {
-        val invalidContext = harness.sdkFactory.spanContext.invalid
+        val invalidContext = harness.sdkFactory.spanContextFactory.invalid
 
         // Test invalid context properties
         assertFalse(invalidContext.isValid)
@@ -169,7 +169,7 @@ internal class SpanExportTest {
         // Test span creation with invalid parent
         val span = harness.tracer.createSpan(
             "test_span",
-            parentContext = harness.sdkFactory.context.root()
+            parentContext = harness.sdkFactory.contextFactory.root()
         )
 
         // Child span should be created with a valid context
@@ -283,7 +283,7 @@ internal class SpanExportTest {
     fun `test trace and span id validation without sanitization`() {
         val span1 = harness.tracer.createSpan("validation_span_1")
         val span2 = harness.tracer.createSpan("validation_span_2")
-        val ctx = span1.storeInContext(harness.sdkFactory.context.root())
+        val ctx = span1.storeInContext(harness.sdkFactory.contextFactory.root())
         val span3 = harness.tracer.createSpan("validation_span_3", ctx)
 
         span1.end()
@@ -390,7 +390,7 @@ internal class SpanExportTest {
         harness.config.spanProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.sdkFactory.context.current()
+        val currentContext = harness.sdkFactory.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -23,37 +23,37 @@ internal class SpanExtTest {
     private val factory = createCompatSdkFactory()
     private val generator = OtelJavaIdGenerator.random()
 
-    private val validSpanContext = factory.spanContext.create(
+    private val validSpanContext = factory.spanContextFactory.create(
         traceId = generator.generateTraceId(),
         spanId = generator.generateSpanId(),
-        traceState = factory.traceState.default,
-        traceFlags = factory.traceFlags.default,
+        traceState = factory.traceStateFactory.default,
+        traceFlags = factory.traceFlagsFactory.default,
     )
 
     @Test
     fun `test invalid span`() {
-        val invalid = factory.span.invalid
-        assertSpanContextsMatch(factory.spanContext.invalid, invalid.spanContext)
-        assertSpanContextsMatch(factory.spanContext.invalid, invalid.parent)
+        val invalid = factory.spanFactory.invalid
+        assertSpanContextsMatch(factory.spanContextFactory.invalid, invalid.spanContext)
+        assertSpanContextsMatch(factory.spanContextFactory.invalid, invalid.parent)
     }
 
     @Test
     fun `test from span context valid`() {
-        val span = factory.span.fromSpanContext(validSpanContext)
+        val span = factory.spanFactory.fromSpanContext(validSpanContext)
         assertSpanContextsMatch(validSpanContext, span.spanContext)
-        assertSpanContextsMatch(factory.spanContext.invalid, span.parent)
+        assertSpanContextsMatch(factory.spanContextFactory.invalid, span.parent)
     }
 
     @Test
     fun `test from span context invalid`() {
-        val span = factory.span.fromSpanContext(factory.spanContext.invalid)
-        assertEquals(factory.span.invalid, span)
+        val span = factory.spanFactory.fromSpanContext(factory.spanContextFactory.invalid)
+        assertEquals(factory.spanFactory.invalid, span)
     }
 
     @Test
     fun `test from context invalid`() {
-        val span = factory.span.fromContext(factory.context.root())
-        assertSpanContextsMatch(factory.spanContext.invalid, span.spanContext)
+        val span = factory.spanFactory.fromContext(factory.contextFactory.root())
+        assertSpanContextsMatch(factory.spanContextFactory.invalid, span.spanContext)
     }
 
     @Test
@@ -71,12 +71,12 @@ internal class SpanExtTest {
             SpanKind.INTERNAL,
             0
         )
-        val root = factory.context.root()
+        val root = factory.contextFactory.root()
         val ctx = span.storeInContext(root)
-        val observed = factory.span.fromContext(root).spanContext
-        assertSpanContextsMatch(factory.spanContext.invalid, observed)
+        val observed = factory.spanFactory.fromContext(root).spanContext
+        assertSpanContextsMatch(factory.spanContextFactory.invalid, observed)
 
-        val retrievedSpan = factory.span.fromContext(ctx)
+        val retrievedSpan = factory.spanFactory.fromContext(ctx)
         assertSpanContextsMatch(SpanContextAdapter(spanContext), retrievedSpan.spanContext)
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
@@ -12,15 +12,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterAdapterTest {
+internal class SpanExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaSpanExporter
-    private lateinit var wrapper: OtelJavaSpanExporterAdapter
+    private lateinit var wrapper: SpanExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaSpanExporter()
-        wrapper = OtelJavaSpanExporterAdapter(impl)
+        wrapper = SpanExporterAdapter(impl)
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterExtTest {
+internal class SpanExporterExtTest {
 
     @Test
     fun toOtelKotlinSpanExporter() {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
@@ -1,0 +1,52 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class SpanProcessorExtTest {
+
+    @Test
+    fun toOtelKotlinSpanProcessor() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        val harness = OtelKotlinHarness()
+        harness.config.spanProcessors.add(adapter)
+
+        val tracer = harness.javaApi.tracerProvider.get("tracer")
+        val spanName = "my_span"
+        tracer.spanBuilder(spanName).startSpan().end()
+
+        assertSame(spanName, impl.startCalls.single().name)
+        assertSame(spanName, impl.endCalls.single().name)
+    }
+
+    @Test
+    fun testIsRequired() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        assertTrue(adapter.isStartRequired())
+        assertTrue(adapter.isEndRequired())
+    }
+
+    @Test
+    fun testFlush() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        adapter.forceFlush()
+        assertEquals(1, impl.flushCount)
+    }
+
+    @Test
+    fun testShutdown() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        adapter.shutdown()
+        assertEquals(1, impl.shutdownCount)
+    }
+}

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -1,6 +1,6 @@
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceImplKt {
-	public static final fun default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun default$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypointKt {
+	public static final fun createOpenTelemetryInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createOpenTelemetryInstance$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/factory/SdkFactoryExtKt {

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -15,7 +15,24 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProviderImpl
  * Constructs an [OpenTelemetry] instance that uses the opentelemetry-kotlin implementation.
  */
 @ExperimentalApi
-public fun OpenTelemetryInstance.default(
+public fun createOpenTelemetryInstance(
+    tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
+    loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
+    clock: Clock = ClockImpl(),
+): OpenTelemetry {
+    return createOpenTelemetryInstanceImpl(
+        tracerProvider,
+        loggerProvider,
+        clock,
+    )
+}
+
+/**
+ * Internal implementation of [createOpenTelemetryInstance]. This is not publicly visible as
+ * we don't want to allow users to supply a custom [SdkFactory].
+ */
+@ExperimentalApi
+internal fun createOpenTelemetryInstanceImpl(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockImpl(),

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/SdkFactoryImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/SdkFactoryImpl.kt
@@ -4,19 +4,19 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal class SdkFactoryImpl(
-    override val tracingIds: TracingIdFactory = TracingIdFactoryImpl()
+    override val tracingIdFactory: TracingIdFactory = TracingIdFactoryImpl()
 ) : SdkFactory {
 
-    override val spanContext: SpanContextFactory = SpanContextFactoryImpl()
+    override val spanContextFactory: SpanContextFactory = SpanContextFactoryImpl()
 
-    override val traceFlags: TraceFlagsFactory
+    override val traceFlagsFactory: TraceFlagsFactory
         get() = TraceFlagsFactoryImpl()
 
-    override val traceState: TraceStateFactory
+    override val traceStateFactory: TraceStateFactory
         get() = TraceStateFactoryImpl()
 
     private val contextFactoryImpl = ContextFactoryImpl()
-    override val context: ContextFactory = contextFactoryImpl
+    override val contextFactory: ContextFactory = contextFactoryImpl
 
-    override val span: SpanFactory = SpanFactoryImpl(spanContext, contextFactoryImpl.spanKey)
+    override val spanFactory: SpanFactory = SpanFactoryImpl(spanContextFactory, contextFactoryImpl.spanKey)
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -34,7 +34,7 @@ internal class LoggerImpl(
         attributes: MutableAttributeContainer.() -> Unit
     ) {
         val attrs = MutableAttributeContainerImpl(logLimitConfig.attributeCountLimit).apply(attributes)
-        val ctx = context ?: sdkFactory.context.root()
+        val ctx = context ?: sdkFactory.contextFactory.root()
         val log = LogRecordModel(
             attributeContainer = attrs,
             resource = resource,
@@ -44,7 +44,7 @@ internal class LoggerImpl(
             body = body,
             severityText = severityText,
             severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
-            spanContext = sdkFactory.span.fromContext(ctx).spanContext,
+            spanContext = sdkFactory.spanFactory.fromContext(ctx).spanContext,
             logLimitConfig = logLimitConfig
         )
         processor.onEmit(ReadWriteLogRecordImpl(log), ctx)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -36,7 +36,7 @@ internal class TracerImpl(
         val spanRelationships = SpanRelationshipsImpl(clock, spanLimitConfig)
         action(spanRelationships)
 
-        val ctx = parentContext ?: sdkFactory.context.root()
+        val ctx = parentContext ?: sdkFactory.contextFactory.root()
         val parentSpanContext = retrieveParentSpanContext(ctx)
         val spanContext = calculateSpanContext(parentSpanContext, sdkFactory)
 
@@ -58,7 +58,7 @@ internal class TracerImpl(
     }
 
     private fun retrieveParentSpanContext(parent: Context): SpanContext {
-        val parentSpan = sdkFactory.span.fromContext(parent)
+        val parentSpan = sdkFactory.spanFactory.fromContext(parent)
         return parentSpan.spanContext
     }
 
@@ -66,7 +66,7 @@ internal class TracerImpl(
         parent: SpanContext,
         sdkFactory: SdkFactory
     ): SpanContext {
-        val factory = sdkFactory.tracingIds
+        val factory = sdkFactory.tracingIdFactory
 
         val traceId = if (parent.isValid) {
             parent.traceId
@@ -78,10 +78,10 @@ internal class TracerImpl(
         return SpanContextImpl(
             traceId = traceId,
             spanId = spanId,
-            traceFlags = sdkFactory.traceFlags.default,
+            traceFlags = sdkFactory.traceFlagsFactory.default,
             isValid = true,
             isRemote = false,
-            traceState = sdkFactory.traceState.default,
+            traceState = sdkFactory.traceStateFactory.default,
         )
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/SpanStorageTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/SpanStorageTest.kt
@@ -20,8 +20,8 @@ internal class SpanStorageTest {
     @BeforeTest
     fun setUp() {
         sdkFactory = createSdkFactory()
-        spanFactory = sdkFactory.span
-        contextFactory = sdkFactory.context
+        spanFactory = sdkFactory.spanFactory
+        contextFactory = sdkFactory.contextFactory
     }
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFalse
 internal class SpanFactoryImplTest {
 
     private val sdkFactory = createSdkFactory()
-    private val factory = sdkFactory.span
+    private val factory = sdkFactory.spanFactory
 
     @Test
     fun testInvalidSpan() {

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -52,14 +52,14 @@ internal class LogContextTest {
     fun testDefaultContext() {
         logger.log()
         val log = processor.logs.single()
-        val root = sdkFactory.span.fromContext(sdkFactory.context.root()).spanContext
+        val root = sdkFactory.spanFactory.fromContext(sdkFactory.contextFactory.root()).spanContext
         assertSame(root, log.spanContext)
     }
 
     @Test
     fun testOverrideContext() {
         val span = tracer.createSpan("span")
-        val ctx = sdkFactory.context.storeSpan(sdkFactory.context.root(), span)
+        val ctx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), span)
         logger.log(context = ctx)
 
         val log = processor.logs.single()

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -49,9 +49,9 @@ internal class TracerSpanContextTest {
 
     @Test
     fun testExplicitParentContextOfInvalidSpan() {
-        val invalidSpan = sdkFactory.span.invalid
+        val invalidSpan = sdkFactory.spanFactory.invalid
         assertFalse(invalidSpan.spanContext.isValid)
-        val parentCtx = sdkFactory.context.storeSpan(sdkFactory.context.root(), invalidSpan)
+        val parentCtx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), invalidSpan)
         val span = tracer.createSpan("test", parentContext = parentCtx)
 
         assertFalse(span.parent.isValid)
@@ -62,7 +62,7 @@ internal class TracerSpanContextTest {
     @Test
     fun testExplicitParentContextOfValidSpan() {
         val parentSpan = tracer.createSpan("parent")
-        val parentCtx = sdkFactory.context.storeSpan(sdkFactory.context.root(), parentSpan)
+        val parentCtx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), parentSpan)
         val span = tracer.createSpan("test", parentContext = parentCtx)
 
         assertTrue(span.parent.isValid)
@@ -75,8 +75,8 @@ internal class TracerSpanContextTest {
     private fun assertValidSpanContext(spanContext: SpanContext) {
         assertTrue(spanContext.isValid)
         assertFalse(spanContext.isRemote)
-        assertNotEquals(sdkFactory.tracingIds.invalidTraceId, spanContext.traceId)
-        assertNotEquals(sdkFactory.tracingIds.invalidSpanId, spanContext.spanId)
+        assertNotEquals(sdkFactory.tracingIdFactory.invalidTraceId, spanContext.traceId)
+        assertNotEquals(sdkFactory.tracingIdFactory.invalidSpanId, spanContext.spanId)
         assertEquals(emptyMap(), spanContext.traceState.asMap())
         assertEquals("01", spanContext.traceFlags.hex)
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -20,7 +20,7 @@ internal class IntegrationTestHarness : OtelKotlinTestRule() {
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
             clock = clock,
-            sdkFactory = SdkFactoryImpl(tracingIds = TracingIdFactoryImpl(Random(0)))
+            sdkFactory = SdkFactoryImpl(tracingIdFactory = TracingIdFactoryImpl(Random(0)))
         )
     }
 }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -2,8 +2,7 @@ package io.embrace.opentelemetry.kotlin.integration.test
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
-import io.embrace.opentelemetry.kotlin.default
+import io.embrace.opentelemetry.kotlin.createOpenTelemetryInstanceImpl
 import io.embrace.opentelemetry.kotlin.factory.SdkFactoryImpl
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactoryImpl
 import io.embrace.opentelemetry.kotlin.framework.OtelKotlinTestRule
@@ -16,7 +15,7 @@ import kotlin.random.Random
 @OptIn(ExperimentalApi::class)
 internal class IntegrationTestHarness : OtelKotlinTestRule() {
     override val kotlinApi: OpenTelemetry by lazy {
-        OpenTelemetryInstance.default(
+        createOpenTelemetryInstanceImpl(
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
             clock = clock,

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -52,7 +52,7 @@ internal class LogProcessorNaughtyExportTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -52,7 +52,7 @@ internal class LogProcessorNaughtyExportTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.context
+        val contextFactory = harness.sdkFactory.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -51,7 +51,7 @@ internal class LogProcessorOnEmitTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.context
+        val contextFactory = harness.sdkFactory.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -51,7 +51,7 @@ internal class LogProcessorOnEmitTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -67,7 +67,7 @@ internal class LoggerExportTest {
     @Test
     fun `test log with parent span in context`() {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_span_context.json")
@@ -75,7 +75,7 @@ internal class LoggerExportTest {
 
     @Test
     fun `test log with root context`() {
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.root()
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_root_context.json")

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -67,7 +67,7 @@ internal class LoggerExportTest {
     @Test
     fun `test log with parent span in context`() {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.context
+        val contextFactory = harness.sdkFactory.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_span_context.json")
@@ -75,7 +75,7 @@ internal class LoggerExportTest {
 
     @Test
     fun `test log with root context`() {
-        val contextFactory = harness.sdkFactory.context
+        val contextFactory = harness.sdkFactory.contextFactory
         val ctx = contextFactory.root()
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_root_context.json")

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -145,7 +145,7 @@ internal class TracerExportTest {
         val parentName = "parent"
         val childName = "child"
         val parentSpan = harness.tracer.createSpan(parentName)
-        val contextFactory = harness.sdkFactory.context
+        val contextFactory = harness.sdkFactory.contextFactory
         val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
         val childSpan = harness.tracer.createSpan(childName, parentContext = parentCtx)
         parentSpan.end()

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -145,7 +145,7 @@ internal class TracerExportTest {
         val parentName = "parent"
         val childName = "child"
         val parentSpan = harness.tracer.createSpan(parentName)
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
         val childSpan = harness.tracer.createSpan(childName, parentContext = parentCtx)
         parentSpan.end()

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.framework
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
-import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
@@ -87,11 +86,6 @@ abstract class OtelKotlinTestRule {
      * Syntactic sugar to obtain a logger from the API.
      */
     val logger: Logger by lazy { kotlinApi.loggerProvider.getLogger("test_logger") }
-
-    /**
-     * Syntactic sugar to obtain an object factory from the API.
-     */
-    val sdkFactory: SdkFactory by lazy { kotlinApi.sdkFactory }
 
     /**
      * Asserts that log records were exported correctly. A custom assertion can be provided as a lambda,

--- a/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -9,5 +9,5 @@ class OpenTelemetryImpl(
     override val tracerProvider: TracerProvider,
     override val loggerProvider: LoggerProvider,
     override val clock: Clock,
-    override val sdkFactory: SdkFactory
-) : OpenTelemetry
+    private val sdkFactory: SdkFactory
+) : OpenTelemetry, SdkFactory by sdkFactory

--- a/opentelemetry-kotlin-noop/api/opentelemetry-kotlin-noop.api
+++ b/opentelemetry-kotlin-noop/api/opentelemetry-kotlin-noop.api
@@ -1,4 +1,4 @@
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceNoopKt {
-	public static final fun noop (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypointKt {
+	public static final fun noopOpenTelemetry ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
@@ -8,9 +8,8 @@ import io.embrace.opentelemetry.kotlin.tracing.NoopTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @ExperimentalApi
-internal object NoopOpenTelemetry : OpenTelemetry {
+internal object NoopOpenTelemetry : OpenTelemetry, SdkFactory by NoopSdkFactory {
     override val tracerProvider: TracerProvider = NoopTracerProvider
     override val loggerProvider: LoggerProvider = NoopLoggerProvider
     override val clock: Clock = NoopClock
-    override val sdkFactory: SdkFactory = NoopSdkFactory
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypoint.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypoint.kt
@@ -1,0 +1,7 @@
+package io.embrace.opentelemetry.kotlin
+
+/**
+ * Returns a no-op instance of [OpenTelemetry] instance.
+ */
+@OptIn(ExperimentalApi::class)
+public fun noopOpenTelemetry(): OpenTelemetry = NoopOpenTelemetry

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceNoop.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceNoop.kt
@@ -1,7 +1,0 @@
-package io.embrace.opentelemetry.kotlin
-
-/**
- * Returns a no-op [OpenTelemetry] instance.
- */
-@ExperimentalApi
-public fun OpenTelemetryInstance.noop(): OpenTelemetry = NoopOpenTelemetry

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/NoopSdkFactory.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/NoopSdkFactory.kt
@@ -4,10 +4,10 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 internal object NoopSdkFactory : SdkFactory {
-    override val spanContext: SpanContextFactory = NoopSpanContextFactory
-    override val traceFlags: TraceFlagsFactory = NoopTraceFlagsFactory
-    override val traceState: TraceStateFactory = NoopTraceStateFactory
-    override val context: ContextFactory = NoopContextFactory
-    override val span: SpanFactory = NoopSpanFactory
-    override val tracingIds: TracingIdFactory = NoopTracingIdFactory
+    override val spanContextFactory: SpanContextFactory = NoopSpanContextFactory
+    override val traceFlagsFactory: TraceFlagsFactory = NoopTraceFlagsFactory
+    override val traceStateFactory: TraceStateFactory = NoopTraceStateFactory
+    override val contextFactory: ContextFactory = NoopContextFactory
+    override val spanFactory: SpanFactory = NoopSpanFactory
+    override val tracingIdFactory: TracingIdFactory = NoopTracingIdFactory
 }

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -95,7 +95,7 @@ internal class NoopTests {
     @Test
     fun testNoopContext() {
         val otel = OpenTelemetryInstance.noop()
-        val ctx = otel.sdkFactory.contextFactory.root()
+        val ctx = otel.contextFactory.root()
 
         val key = ctx.createKey<String>("key")
         assertTrue(key is NoopContextKey)
@@ -109,16 +109,15 @@ internal class NoopTests {
     @Test
     fun testNoopSpanContext() {
         val otel = OpenTelemetryInstance.noop()
-        val factory = otel.sdkFactory
-        val invalid = factory.spanContextFactory.invalid
+        val invalid = otel.spanContextFactory.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
 
-        val other = factory.spanContextFactory.create(
-            factory.tracingIdFactory.generateTraceId(),
-            factory.tracingIdFactory.generateSpanId(),
-            factory.traceFlagsFactory.default,
-            factory.traceStateFactory.default
+        val other = otel.spanContextFactory.create(
+            otel.tracingIdFactory.generateTraceId(),
+            otel.tracingIdFactory.generateSpanId(),
+            otel.traceFlagsFactory.default,
+            otel.traceStateFactory.default
         )
         assertSame(invalid, other)
     }
@@ -126,16 +125,15 @@ internal class NoopTests {
     @Test
     fun testNoopSpan() {
         val otel = OpenTelemetryInstance.noop()
-        val factory = otel.sdkFactory
 
-        val first = factory.spanFactory.invalid
+        val first = otel.spanFactory.invalid
         assertTrue(first is NoopSpan)
         assertFalse(first.isRecording())
 
-        val second = factory.spanFactory.fromSpanContext(factory.spanContextFactory.invalid)
+        val second = otel.spanFactory.fromSpanContext(otel.spanContextFactory.invalid)
         assertTrue(second is NoopSpan)
 
-        val third = factory.spanFactory.fromContext(factory.contextFactory.root())
+        val third = otel.spanFactory.fromContext(otel.contextFactory.root())
         assertTrue(third is NoopSpan)
     }
 

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -95,7 +95,7 @@ internal class NoopTests {
     @Test
     fun testNoopContext() {
         val otel = OpenTelemetryInstance.noop()
-        val ctx = otel.sdkFactory.context.root()
+        val ctx = otel.sdkFactory.contextFactory.root()
 
         val key = ctx.createKey<String>("key")
         assertTrue(key is NoopContextKey)
@@ -110,15 +110,15 @@ internal class NoopTests {
     fun testNoopSpanContext() {
         val otel = OpenTelemetryInstance.noop()
         val factory = otel.sdkFactory
-        val invalid = factory.spanContext.invalid
+        val invalid = factory.spanContextFactory.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
 
-        val other = factory.spanContext.create(
-            factory.tracingIds.generateTraceId(),
-            factory.tracingIds.generateSpanId(),
-            factory.traceFlags.default,
-            factory.traceState.default
+        val other = factory.spanContextFactory.create(
+            factory.tracingIdFactory.generateTraceId(),
+            factory.tracingIdFactory.generateSpanId(),
+            factory.traceFlagsFactory.default,
+            factory.traceStateFactory.default
         )
         assertSame(invalid, other)
     }
@@ -128,14 +128,14 @@ internal class NoopTests {
         val otel = OpenTelemetryInstance.noop()
         val factory = otel.sdkFactory
 
-        val first = factory.span.invalid
+        val first = factory.spanFactory.invalid
         assertTrue(first is NoopSpan)
         assertFalse(first.isRecording())
 
-        val second = factory.span.fromSpanContext(factory.spanContext.invalid)
+        val second = factory.spanFactory.fromSpanContext(factory.spanContextFactory.invalid)
         assertTrue(second is NoopSpan)
 
-        val third = factory.span.fromContext(factory.context.root())
+        val third = factory.spanFactory.fromContext(factory.contextFactory.root())
         assertTrue(third is NoopSpan)
     }
 

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -17,7 +17,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopTracing() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
         val tracerProvider = otel.tracerProvider
         val tracer = tracerProvider.getTracer("test-tracer")
 
@@ -57,7 +57,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopLogging() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
         val loggerProvider = otel.loggerProvider
         val logger = loggerProvider.getLogger("test-logger")
 
@@ -84,7 +84,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopClockDefault() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
         val clock = otel.clock
 
         // Noop clock always returns 0
@@ -94,7 +94,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopContext() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
         val ctx = otel.contextFactory.root()
 
         val key = ctx.createKey<String>("key")
@@ -108,7 +108,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopSpanContext() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
         val invalid = otel.spanContextFactory.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
@@ -124,7 +124,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopSpan() {
-        val otel = OpenTelemetryInstance.noop()
+        val otel = noopOpenTelemetry()
 
         val first = otel.spanFactory.invalid
         assertTrue(first is NoopSpan)

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeOpenTelemetry.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeOpenTelemetry.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin
 
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
@@ -8,10 +9,10 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @OptIn(ExperimentalApi::class)
-class FakeOpenTelemetry : OpenTelemetry {
+class FakeOpenTelemetry(
+    private val sdkFactory: SdkFactory = FakeSdkFactory()
+) : OpenTelemetry, SdkFactory by sdkFactory {
     override val tracerProvider: TracerProvider = FakeTracerProvider()
     override val loggerProvider: LoggerProvider = FakeLoggerProvider()
     override val clock: Clock = FakeClock()
-    override val sdkFactory: SdkFactory
-        get() = throw UnsupportedOperationException()
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/FakeMutableAttributeContainer.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/FakeMutableAttributeContainer.kt
@@ -1,0 +1,56 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+class FakeMutableAttributeContainer(
+    private val map: MutableMap<String, Any> = mutableMapOf()
+) : MutableAttributeContainer {
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        map[key] = value
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        map[key] = value
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        map[key] = value
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        map[key] = value
+    }
+
+    override fun setBooleanListAttribute(
+        key: String,
+        value: List<Boolean>
+    ) {
+        map[key] = value
+    }
+
+    override fun setStringListAttribute(
+        key: String,
+        value: List<String>
+    ) {
+        map[key] = value
+    }
+
+    override fun setLongListAttribute(
+        key: String,
+        value: List<Long>
+    ) {
+        map[key] = value
+    }
+
+    override fun setDoubleListAttribute(
+        key: String,
+        value: List<Double>
+    ) {
+        map[key] = value
+    }
+
+    override val attributes: Map<String, Any>
+        get() = map.toMap()
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/FakeSdkFactory.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/FakeSdkFactory.kt
@@ -4,10 +4,10 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
 class FakeSdkFactory : SdkFactory {
-    override val spanContext: SpanContextFactory = FakeSpanContextFactory()
-    override val traceFlags: TraceFlagsFactory = FakeTraceFlagsFactory()
-    override val traceState: TraceStateFactory = FakeTraceStateFactory()
-    override val context: ContextFactory = FakeContextFactory()
-    override val span: SpanFactory = FakeSpanFactory()
-    override val tracingIds: TracingIdFactory = FakeTracingIdFactory()
+    override val spanContextFactory: SpanContextFactory = FakeSpanContextFactory()
+    override val traceFlagsFactory: TraceFlagsFactory = FakeTraceFlagsFactory()
+    override val traceStateFactory: TraceStateFactory = FakeTraceStateFactory()
+    override val contextFactory: ContextFactory = FakeContextFactory()
+    override val spanFactory: SpanFactory = FakeSpanFactory()
+    override val tracingIdFactory: TracingIdFactory = FakeTracingIdFactory()
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -9,17 +9,18 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-class FakeReadWriteLogRecord : ReadWriteLogRecord {
-    override var timestamp: Long? = null
-    override var observedTimestamp: Long? = null
-    override var severityNumber: SeverityNumber? = SeverityNumber.UNKNOWN
-    override var severityText: String? = null
-    override var body: String? = null
-    override var spanContext: SpanContext = FakeSpanContext()
-    override val attributes: Map<String, Any> = emptyMap()
-    override val resource: Resource = FakeResource()
+class FakeReadWriteLogRecord(
+    override var timestamp: Long? = null,
+    override var observedTimestamp: Long? = null,
+    override var severityNumber: SeverityNumber? = SeverityNumber.UNKNOWN,
+    override var severityText: String? = null,
+    override var body: String? = null,
+    override var spanContext: SpanContext = FakeSpanContext(),
+    override val attributes: Map<String, Any> = emptyMap(),
+    override val resource: Resource = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo =
-        FakeInstrumentationScopeInfo()
+        FakeInstrumentationScopeInfo(),
+) : ReadWriteLogRecord {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
     }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.FakeMutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeLinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
@@ -48,7 +50,8 @@ class FakeSpan(
         spanContext: SpanContext,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        TODO("Not yet implemented")
+        val attrs = FakeMutableAttributeContainer().apply(attributes).attributes
+        links.add(FakeLinkData(spanContext, attrs))
     }
 
     override fun addEvent(

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
@@ -4,19 +4,17 @@ package io.embrace.opentelemetry.kotlin.testing.junit4
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
-import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.rules.ExternalResource
 
 /**
- * A JUnit4 rule which sets up an [OpenTelemetrySdk] for testing, resetting state before each test.
+ * A JUnit4 rule which sets up an [OpenTelemetry] instance for testing, resetting state before each test.
  *
  * ```kotlin
  * class CoolTest {
@@ -40,7 +38,7 @@ import org.junit.rules.ExternalResource
  * }
  * ```
  */
-public class OpenTelemetryRule : ExternalResource() {
+class OpenTelemetryRule : ExternalResource() {
 
     private val spanExporter = InMemorySpanExporter()
 
@@ -52,13 +50,13 @@ public class OpenTelemetryRule : ExternalResource() {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.decorateJavaApi(sdk)
+    val openTelemetry: OpenTelemetry = sdk.toOtelKotlinApi()
 
-    public val spans: List<OtelJavaSpanData>
+    val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans
 
-    public fun getTracer(name: String): Tracer {
-        return openTelemetry.getTracer(name)
+    fun getTracer(name: String): Tracer {
+        return openTelemetry.tracerProvider.getTracer(name)
     }
 
     override fun before() {

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
@@ -4,20 +4,18 @@ package io.embrace.opentelemetry.kotlin.testing.junit5
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
-import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
 /**
- * A JUnit5 extension which sets up an [OpenTelemetrySdk] for testing, resetting state before each test.
+ * A JUnit5 extension which sets up an [OpenTelemetry] instance for testing, resetting state before each test.
  *
  * ```kotlin
  * @ExtendWith(OpenTelemetryExtension::class)
@@ -40,7 +38,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * }
  * ```
  */
-public class OpenTelemetryExtension : BeforeEachCallback {
+class OpenTelemetryExtension : BeforeEachCallback {
 
     private val spanExporter = InMemorySpanExporter()
 
@@ -52,13 +50,13 @@ public class OpenTelemetryExtension : BeforeEachCallback {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.decorateJavaApi(sdk)
+    val openTelemetry: OpenTelemetry = sdk.toOtelKotlinApi()
 
-    public val spans: List<OtelJavaSpanData>
+    val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans
 
-    public fun getTracer(name: String): Tracer {
-        return openTelemetry.getTracer(name)
+    fun getTracer(name: String): Tracer {
+        return openTelemetry.tracerProvider.getTracer(name)
     }
 
     override fun beforeEach(context: ExtensionContext?) {


### PR DESCRIPTION
## Goal

Builds on #351 by renaming properties on the `SdkFactory` interface.

