### PR TITLE
Make OpenTelemetry interface supply factories

### DIFF
--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -42,7 +42,7 @@ fun runTracingExamples(api: OpenTelemetry) {
     val simpleSpan = tracer.createSpan("simple_span")
 
     // create a more complex span
-    val complexSpan = createComplexSpan(tracer, simpleSpan, api.sdkFactory.contextFactory.root())
+    val complexSpan = createComplexSpan(tracer, simpleSpan, api.contextFactory.root())
 
     // alter the span after its creation
 

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -12,10 +12,9 @@ public abstract interface class io/embrace/opentelemetry/kotlin/InstrumentationS
 	public abstract fun getVersion ()Ljava/lang/String;
 }
 
-public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry {
+public abstract interface class io/embrace/opentelemetry/kotlin/OpenTelemetry : io/embrace/opentelemetry/kotlin/factory/SdkFactory {
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun getLoggerProvider ()Lio/embrace/opentelemetry/kotlin/logging/LoggerProvider;
-	public abstract fun getSdkFactory ()Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;
 	public abstract fun getTracerProvider ()Lio/embrace/opentelemetry/kotlin/tracing/TracerProvider;
 }
 

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetry.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
  * The main entry point for the OpenTelemetry API.
  */
 @ExperimentalApi
-public interface OpenTelemetry {
+public interface OpenTelemetry : SdkFactory {
 
     /**
      * The [TracerProvider] for creating [Tracer] instances.
@@ -26,9 +26,4 @@ public interface OpenTelemetry {
      * The [Clock] that will be used for obtaining timestamps by this instance.
      */
     public val clock: Clock
-
-    /**
-     * Used for creating new objects that can be passed to the SDK.
-     */
-    public val sdkFactory: SdkFactory
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -85,7 +85,7 @@ internal class LogExportTest {
         harness.config.logRecordProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.kotlinApi.sdkFactory.contextFactory.current()
+        val currentContext = harness.kotlinApi.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -115,7 +115,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test span context parent`() {
-        val root = harness.sdkFactory.contextFactory.root()
+        val root = harness.kotlinApi.contextFactory.root()
 
         val a = harness.tracer.createSpan("a", parentContext = root)
         val ctxa = a.storeInContext(root)
@@ -125,7 +125,7 @@ internal class SpanExportTest {
 
         val c = harness.tracer.createSpan("c", parentContext = ctxb)
 
-        assertSpanContextsMatch(harness.sdkFactory.spanContextFactory.invalid, a.parent)
+        assertSpanContextsMatch(harness.kotlinApi.spanContextFactory.invalid, a.parent)
         assertNotNull(a.spanContext)
         assertSpanContextsMatch(a.spanContext, b.parent)
         assertSpanContextsMatch(b.spanContext, c.parent)
@@ -159,7 +159,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test invalid span context`() {
-        val invalidContext = harness.sdkFactory.spanContextFactory.invalid
+        val invalidContext = harness.kotlinApi.spanContextFactory.invalid
 
         // Test invalid context properties
         assertFalse(invalidContext.isValid)
@@ -169,7 +169,7 @@ internal class SpanExportTest {
         // Test span creation with invalid parent
         val span = harness.tracer.createSpan(
             "test_span",
-            parentContext = harness.sdkFactory.contextFactory.root()
+            parentContext = harness.kotlinApi.contextFactory.root()
         )
 
         // Child span should be created with a valid context
@@ -283,7 +283,7 @@ internal class SpanExportTest {
     fun `test trace and span id validation without sanitization`() {
         val span1 = harness.tracer.createSpan("validation_span_1")
         val span2 = harness.tracer.createSpan("validation_span_2")
-        val ctx = span1.storeInContext(harness.sdkFactory.contextFactory.root())
+        val ctx = span1.storeInContext(harness.kotlinApi.contextFactory.root())
         val span3 = harness.tracer.createSpan("validation_span_3", ctx)
 
         span1.end()
@@ -390,7 +390,7 @@ internal class SpanExportTest {
         harness.config.spanProcessors.add(contextCapturingProcessor)
 
         // Create a context key and add a test value
-        val currentContext = harness.sdkFactory.contextFactory.current()
+        val currentContext = harness.kotlinApi.contextFactory.current()
         val contextKey = currentContext.createKey<String>("best_team")
         val testContextValue = "independiente"
         val testContext = currentContext.set(contextKey, testContextValue)

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -52,7 +52,7 @@ internal class LogProcessorNaughtyExportTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -51,7 +51,7 @@ internal class LogProcessorOnEmitTest {
 
     private fun prepareContext(): Context {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx
     }

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -67,7 +67,7 @@ internal class LoggerExportTest {
     @Test
     fun `test log with parent span in context`() {
         val span = harness.tracer.createSpan("span")
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_span_context.json")
@@ -75,7 +75,7 @@ internal class LoggerExportTest {
 
     @Test
     fun `test log with root context`() {
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.root()
         harness.logger.log("test", context = ctx)
         harness.assertLogRecords(1, "log_root_context.json")

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -145,7 +145,7 @@ internal class TracerExportTest {
         val parentName = "parent"
         val childName = "child"
         val parentSpan = harness.tracer.createSpan(parentName)
-        val contextFactory = harness.sdkFactory.contextFactory
+        val contextFactory = harness.kotlinApi.contextFactory
         val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
         val childSpan = harness.tracer.createSpan(childName, parentContext = parentCtx)
         parentSpan.end()

--- a/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/opentelemetry-kotlin-integration-test/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -3,7 +3,6 @@ package io.embrace.opentelemetry.kotlin.framework
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
-import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
@@ -87,11 +86,6 @@ abstract class OtelKotlinTestRule {
      * Syntactic sugar to obtain a logger from the API.
      */
     val logger: Logger by lazy { kotlinApi.loggerProvider.getLogger("test_logger") }
-
-    /**
-     * Syntactic sugar to obtain an object factory from the API.
-     */
-    val sdkFactory: SdkFactory by lazy { kotlinApi.sdkFactory }
 
     /**
      * Asserts that log records were exported correctly. A custom assertion can be provided as a lambda,

--- a/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -9,5 +9,5 @@ class OpenTelemetryImpl(
     override val tracerProvider: TracerProvider,
     override val loggerProvider: LoggerProvider,
     override val clock: Clock,
-    override val sdkFactory: SdkFactory
-) : OpenTelemetry
+    private val sdkFactory: SdkFactory
+) : OpenTelemetry, SdkFactory by sdkFactory

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetry.kt
@@ -8,9 +8,8 @@ import io.embrace.opentelemetry.kotlin.tracing.NoopTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @ExperimentalApi
-internal object NoopOpenTelemetry : OpenTelemetry {
+internal object NoopOpenTelemetry : OpenTelemetry, SdkFactory by NoopSdkFactory {
     override val tracerProvider: TracerProvider = NoopTracerProvider
     override val loggerProvider: LoggerProvider = NoopLoggerProvider
     override val clock: Clock = NoopClock
-    override val sdkFactory: SdkFactory = NoopSdkFactory
 }

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -95,7 +95,7 @@ internal class NoopTests {
     @Test
     fun testNoopContext() {
         val otel = OpenTelemetryInstance.noop()
-        val ctx = otel.sdkFactory.contextFactory.root()
+        val ctx = otel.contextFactory.root()
 
         val key = ctx.createKey<String>("key")
         assertTrue(key is NoopContextKey)
@@ -109,16 +109,15 @@ internal class NoopTests {
     @Test
     fun testNoopSpanContext() {
         val otel = OpenTelemetryInstance.noop()
-        val factory = otel.sdkFactory
-        val invalid = factory.spanContextFactory.invalid
+        val invalid = otel.spanContextFactory.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
 
-        val other = factory.spanContextFactory.create(
-            factory.tracingIdFactory.generateTraceId(),
-            factory.tracingIdFactory.generateSpanId(),
-            factory.traceFlagsFactory.default,
-            factory.traceStateFactory.default
+        val other = otel.spanContextFactory.create(
+            otel.tracingIdFactory.generateTraceId(),
+            otel.tracingIdFactory.generateSpanId(),
+            otel.traceFlagsFactory.default,
+            otel.traceStateFactory.default
         )
         assertSame(invalid, other)
     }
@@ -126,16 +125,15 @@ internal class NoopTests {
     @Test
     fun testNoopSpan() {
         val otel = OpenTelemetryInstance.noop()
-        val factory = otel.sdkFactory
 
-        val first = factory.spanFactory.invalid
+        val first = otel.spanFactory.invalid
         assertTrue(first is NoopSpan)
         assertFalse(first.isRecording())
 
-        val second = factory.spanFactory.fromSpanContext(factory.spanContextFactory.invalid)
+        val second = otel.spanFactory.fromSpanContext(otel.spanContextFactory.invalid)
         assertTrue(second is NoopSpan)
 
-        val third = factory.spanFactory.fromContext(factory.contextFactory.root())
+        val third = otel.spanFactory.fromContext(otel.contextFactory.root())
         assertTrue(third is NoopSpan)
     }
 

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeOpenTelemetry.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeOpenTelemetry.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin
 
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
+import io.embrace.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.embrace.opentelemetry.kotlin.logging.LoggerProvider
@@ -8,10 +9,10 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeTracerProvider
 import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 
 @OptIn(ExperimentalApi::class)
-class FakeOpenTelemetry : OpenTelemetry {
+class FakeOpenTelemetry(
+    private val sdkFactory: SdkFactory = FakeSdkFactory()
+) : OpenTelemetry, SdkFactory by sdkFactory {
     override val tracerProvider: TracerProvider = FakeTracerProvider()
     override val loggerProvider: LoggerProvider = FakeLoggerProvider()
     override val clock: Clock = FakeClock()
-    override val sdkFactory: SdkFactory
-        get() = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
## Goal

Builds on #352 by making `OpenTelemetry` supply the factories for creating objects such as `SpanContext/TraceState`.

