### PR TITLE
Reduce number of functions on OpenTelemetryInstance

### DIFF
--- a/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/AppTracerProvider.kt
+++ b/examples/telescope-app/app/src/main/java/io/embrace/opentelemetry/kotlin/telescope/telemetry/AppTracerProvider.kt
@@ -2,8 +2,7 @@ package io.embrace.opentelemetry.kotlin.telescope.telemetry
 
 import android.content.res.Resources
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -36,7 +35,7 @@ class AppTracerProvider(
             .setTracerProvider(sdkTracerProvider)
             .build()
 
-        val kotlinApi = OpenTelemetryInstance.decorateJavaApi(javaSdk)
+        val kotlinApi = javaSdk.toOtelKotlinApi()
 
         return kotlinApi.tracerProvider.getTracer("AppTracer")
     }

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,13 +1,14 @@
+public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {
+	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+}
+
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompatKt {
 	public static final fun createOpenTelemetryKotlin (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 	public static synthetic fun createOpenTelemetryKotlin$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static final fun decorateJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun decorateJavaApi$default (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/opentelemetry/api/OpenTelemetry;Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static final fun decorateKotlinApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetryInstance;Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
 }
 
-public final class io/embrace/opentelemetry/kotlin/OpenTelemetryJavaExtKt {
-	public static final fun toOtelJavaApi (Lio/embrace/opentelemetry/kotlin/OpenTelemetry;)Lio/opentelemetry/api/OpenTelemetry;
+public final class io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExtKt {
+	public static final fun toOtelKotlinApi (Lio/opentelemetry/api/OpenTelemetry;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/context/ContextExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -9,7 +9,7 @@ import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
  * to the opentelemetry-java API.
  *
  * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
- * or [decorateJavaApi] instead.
+ * or [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
 public fun OpenTelemetry.toOtelJavaApi(): OtelJavaOpenTelemetry {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryInstanceCompat.kt
@@ -1,7 +1,5 @@
 package io.embrace.opentelemetry.kotlin
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.factory.createCompatSdkFactory
@@ -9,34 +7,6 @@ import io.embrace.opentelemetry.kotlin.init.CompatLoggerProviderConfig
 import io.embrace.opentelemetry.kotlin.init.CompatTracerProviderConfig
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
-import io.embrace.opentelemetry.kotlin.logging.OtelJavaLoggerProviderAdapter
-import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
-import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
-
-/**
- * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API.
- * Callers must pass a reference to an OpenTelemetry Java SDK instance. Under the hood calls to the
- * Kotlin API will be delegated to the Java SDK implementation.
- *
- * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
- * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
- * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
- * generally be encouraged to migrate to [createOpenTelemetryKotlin] as a long-term goal.
- */
-@ExperimentalApi
-public fun OpenTelemetryInstance.decorateJavaApi(
-    impl: OtelJavaOpenTelemetry,
-    sdkFactory: SdkFactory = createCompatSdkFactory(),
-): OpenTelemetry {
-    val clock = ClockAdapter(OtelJavaClock.getDefault())
-    return OpenTelemetryImpl(
-        tracerProvider = TracerProviderAdapter(impl.tracerProvider, clock),
-        loggerProvider = LoggerProviderAdapter(impl.logsBridge),
-        clock = clock,
-        sdkFactory = sdkFactory
-    )
-}
 
 /**
  * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API. The SDK is
@@ -45,7 +15,7 @@ public fun OpenTelemetryInstance.decorateJavaApi(
  *
  * It's not possible to obtain a reference to the Java API using this function. If this is a
  * requirement because you have existing instrumentation, it's recommended to call
- * [decorateJavaApi] instead.
+ * [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
 public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
@@ -63,20 +33,5 @@ public fun OpenTelemetryInstance.createOpenTelemetryKotlin(
         loggerProvider = loggerCfg.build(),
         clock = clock,
         sdkFactory = sdkFactory,
-    )
-}
-
-/**
- * Constructs an [OtelJavaOpenTelemetry] instance that makes the Kotlin implementation conform
- * to the opentelemetry-java API.
- *
- * End-users should generally not use this function and should call [createOpenTelemetryKotlin]
- * or [decorateJavaApi] instead.
- */
-@ExperimentalApi
-public fun OpenTelemetryInstance.decorateKotlinApi(impl: OpenTelemetry): OtelJavaOpenTelemetry {
-    return OtelJavaOpenTelemetrySdk(
-        tracerProvider = OtelJavaTracerProviderAdapter(impl.tracerProvider),
-        loggerProvider = OtelJavaLoggerProviderAdapter(impl.loggerProvider)
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -1,0 +1,31 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
+import io.embrace.opentelemetry.kotlin.factory.SdkFactory
+import io.embrace.opentelemetry.kotlin.factory.createCompatSdkFactory
+import io.embrace.opentelemetry.kotlin.logging.LoggerProviderAdapter
+import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
+
+/**
+ * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API.
+ * Callers must pass a reference to an OpenTelemetry Java SDK instance. Under the hood calls to the
+ * Kotlin API will be delegated to the Java SDK implementation.
+ *
+ * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
+ * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
+ * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
+ * generally be encouraged to migrate to [createOpenTelemetryKotlin] as a long-term goal.
+ */
+@ExperimentalApi
+public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
+    val sdkFactory: SdkFactory = createCompatSdkFactory()
+    val clock = ClockAdapter(OtelJavaClock.getDefault())
+    return OpenTelemetryImpl(
+        tracerProvider = TracerProviderAdapter(tracerProvider, clock),
+        loggerProvider = LoggerProviderAdapter(logsBridge),
+        clock = clock,
+        sdkFactory = sdkFactory
+    )
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -5,10 +5,10 @@ import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.embrace.opentelemetry.kotlin.createOpenTelemetryKotlin
-import io.embrace.opentelemetry.kotlin.decorateKotlinApi
 import io.embrace.opentelemetry.kotlin.factory.CompatSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.CompatTracingIdFactory
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactory
+import io.embrace.opentelemetry.kotlin.toOtelJavaApi
 import kotlin.random.Random
 
 @OptIn(ExperimentalApi::class)
@@ -24,7 +24,7 @@ internal class OtelKotlinHarness : OtelKotlinTestRule() {
     }
 
     val javaApi by lazy {
-        OpenTelemetryInstance.decorateKotlinApi(kotlinApi)
+        kotlinApi.toOtelJavaApi()
     }
 }
 

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit4/OpenTelemetryRule.kt
@@ -4,19 +4,17 @@ package io.embrace.opentelemetry.kotlin.testing.junit4
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
-import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.rules.ExternalResource
 
 /**
- * A JUnit4 rule which sets up an [OpenTelemetrySdk] for testing, resetting state before each test.
+ * A JUnit4 rule which sets up an [OpenTelemetry] instance for testing, resetting state before each test.
  *
  * ```kotlin
  * class CoolTest {
@@ -40,7 +38,7 @@ import org.junit.rules.ExternalResource
  * }
  * ```
  */
-public class OpenTelemetryRule : ExternalResource() {
+class OpenTelemetryRule : ExternalResource() {
 
     private val spanExporter = InMemorySpanExporter()
 
@@ -52,13 +50,13 @@ public class OpenTelemetryRule : ExternalResource() {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.decorateJavaApi(sdk)
+    val openTelemetry: OpenTelemetry = sdk.toOtelKotlinApi()
 
-    public val spans: List<OtelJavaSpanData>
+    val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans
 
-    public fun getTracer(name: String): Tracer {
-        return openTelemetry.getTracer(name)
+    fun getTracer(name: String): Tracer {
+        return openTelemetry.tracerProvider.getTracer(name)
     }
 
     override fun before() {

--- a/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
+++ b/opentelemetry-kotlin-testing/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/testing/junit5/OpenTelemetryExtension.kt
@@ -4,20 +4,18 @@ package io.embrace.opentelemetry.kotlin.testing.junit5
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.embrace.opentelemetry.kotlin.decorateJavaApi
-import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanExporter
 import io.embrace.opentelemetry.kotlin.testing.common.InMemorySpanProcessor
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
 /**
- * A JUnit5 extension which sets up an [OpenTelemetrySdk] for testing, resetting state before each test.
+ * A JUnit5 extension which sets up an [OpenTelemetry] instance for testing, resetting state before each test.
  *
  * ```kotlin
  * @ExtendWith(OpenTelemetryExtension::class)
@@ -40,7 +38,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * }
  * ```
  */
-public class OpenTelemetryExtension : BeforeEachCallback {
+class OpenTelemetryExtension : BeforeEachCallback {
 
     private val spanExporter = InMemorySpanExporter()
 
@@ -52,13 +50,13 @@ public class OpenTelemetryExtension : BeforeEachCallback {
         .setTracerProvider(tracerProvider)
         .build()
 
-    public val openTelemetry: OpenTelemetry = OpenTelemetryInstance.decorateJavaApi(sdk)
+    val openTelemetry: OpenTelemetry = sdk.toOtelKotlinApi()
 
-    public val spans: List<OtelJavaSpanData>
+    val spans: List<OtelJavaSpanData>
         get() = spanExporter.exportedSpans
 
-    public fun getTracer(name: String): Tracer {
-        return openTelemetry.getTracer(name)
+    fun getTracer(name: String): Tracer {
+        return openTelemetry.tracerProvider.getTracer(name)
     }
 
     override fun beforeEach(context: ExtensionContext?) {


### PR DESCRIPTION
## Goal

Reduces the number of functions on `OpenTelemetryInstance` by replacing APIs that are simply converting between the Java/Kotlin `OpenTelemetry` interface in the compat module with extension functions instead.

