### PR TITLE
Add conversion functions for existing exporters/processors

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -31,12 +31,20 @@ public final class io/embrace/opentelemetry/kotlin/factory/ContextFactoryExtKt {
 	public static final fun current (Lio/embrace/opentelemetry/kotlin/factory/ContextFactory;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }
 
-public final class io/embrace/opentelemetry/kotlin/logging/export/OtelJavaLogRecordExporterExtKt {
+public final class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtKt {
 	public static final fun toOtelKotlinLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExtKt {
+public final class io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtKt {
+	public static final fun toOtelKotlinLogRecordProcessor (Lio/opentelemetry/sdk/logs/LogRecordProcessor;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtKt {
 	public static final fun toOtelKotlinSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
+}
+
+public final class io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtKt {
+	public static final fun toOtelKotlinSpanProcessor (Lio/opentelemetry/sdk/trace/SpanProcessor;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor;
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/ext/EventDataExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.embrace.opentelemetry.kotlin.toOperationResultCode
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaLogRecordExporterAdapter(
+internal class LogRecordExporterAdapter(
     private val impl: OtelJavaLogRecordExporter
 ) : LogRecordExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExt.kt
@@ -3,6 +3,10 @@ package io.embrace.opentelemetry.kotlin.logging.export
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 
+/**
+ * Converts an opentelemetry-java log record exporter to an opentelemetry-kotlin log record exporter.
+ * This is useful if you wish to use an existing Java exporter whilst using opentelemetry-kotlin.
+ */
 @OptIn(ExperimentalApi::class)
 public fun OtelJavaLogRecordExporter.toOtelKotlinLogRecordExporter(): LogRecordExporter =
-    OtelJavaLogRecordExporterAdapter(this)
+    LogRecordExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.embrace.opentelemetry.kotlin.toOperationResultCode
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordProcessorAdapter(
+    private val impl: OtelJavaLogRecordProcessor
+) : LogRecordProcessor {
+
+    override fun onEmit(
+        log: ReadWriteLogRecord,
+        context: Context
+    ) {
+        if (log is ReadWriteLogRecordAdapter) {
+            impl.onEmit(context.toOtelJavaContext(), log.impl)
+        }
+    }
+
+    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+
+/**
+ * Converts an opentelemetry-java log record processor to an opentelemetry-kotlin log record processor.
+ * This is useful if you wish to use an existing Java processor whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaLogRecordProcessor.toOtelKotlinLogRecordProcessor(): LogRecordProcessor =
+    LogRecordProcessorAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -17,7 +17,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanContextAdapter
 @Suppress("UNUSED_PARAMETER")
 @OptIn(ExperimentalApi::class)
 internal class ReadWriteLogRecordAdapter(
-    private val impl: OtelJavaReadWriteLogRecord
+    val impl: OtelJavaReadWriteLogRecord
 ) : ReadWriteLogRecord {
 
     override var timestamp: Long?

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtelJavaSpanExporterExt.kt
@@ -1,7 +1,0 @@
-package io.embrace.opentelemetry.kotlin.tracing.export
-
-import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
-
-@OptIn(ExperimentalApi::class)
-public fun OtelJavaSpanExporter.toOtelKotlinSpanExporter(): SpanExporter = OtelJavaSpanExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanData
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterAdapter(
+internal class SpanExporterAdapter(
     private val impl: OtelJavaSpanExporter
 ) : SpanExporter {
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExt.kt
@@ -1,0 +1,11 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+
+/**
+ * Converts an opentelemetry-java span exporter to an opentelemetry-kotlin span exporter.
+ * This is useful if you wish to use an existing Java exporter whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaSpanExporter.toOtelKotlinSpanExporter(): SpanExporter = SpanExporterAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
@@ -1,0 +1,38 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.toOperationResultCode
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpanAdapter
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
+import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpanAdapter
+
+@OptIn(ExperimentalApi::class)
+internal class SpanProcessorAdapter(
+    private val impl: OtelJavaSpanProcessor
+) : SpanProcessor {
+
+    override fun onStart(
+        span: ReadWriteSpan,
+        parentContext: Context
+    ) {
+        if (span is ReadWriteSpanAdapter) {
+            impl.onStart(parentContext.toOtelJavaContext(), span.impl)
+        }
+    }
+
+    override fun onEnd(span: ReadableSpan) {
+        if (span is ReadableSpanAdapter) {
+            impl.onEnd(span.impl)
+        }
+    }
+
+    override fun isStartRequired(): Boolean = impl.isStartRequired
+    override fun isEndRequired(): Boolean = impl.isEndRequired
+    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExt.kt
@@ -1,0 +1,12 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+
+/**
+ * Converts an opentelemetry-java span processor to an opentelemetry-kotlin span processor.
+ * This is useful if you wish to use an existing Java processor whilst using opentelemetry-kotlin.
+ */
+@OptIn(ExperimentalApi::class)
+public fun OtelJavaSpanProcessor.toOtelKotlinSpanProcessor(): SpanProcessor =
+    SpanProcessorAdapter(this)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
 internal class ReadWriteSpanAdapter(
-    private val impl: OtelJavaReadWriteSpan,
+    val impl: OtelJavaReadWriteSpan,
     private val readableSpan: ReadableSpanAdapter = ReadableSpanAdapter(impl)
 ) : ReadWriteSpan, ReadableSpan by readableSpan {
 
@@ -42,14 +42,21 @@ internal class ReadWriteSpanAdapter(
 
     override fun isRecording(): Boolean = impl.isRecording
 
-    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addLink(
+        spanContext: SpanContext,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
         val container = CompatMutableAttributeContainer()
         attributes(container)
         val ctx = (spanContext as SpanContextAdapter).impl
         impl.addLink(ctx, container.otelJavaAttributes())
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addEvent(
+        name: String,
+        timestamp: Long?,
+        attributes: MutableAttributeContainer.() -> Unit
+    ) {
         val container = CompatMutableAttributeContainer()
         attributes(container)
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
@@ -19,7 +19,7 @@ import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinStatusData
 
 @OptIn(ExperimentalApi::class)
 internal class ReadableSpanAdapter(
-    private val impl: OtelJavaReadableSpan
+    val impl: OtelJavaReadableSpan
 ) : ReadableSpan {
     override val parent: SpanContext
     override val spanContext: SpanContext

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaLogRecordProcessor.kt
@@ -1,0 +1,30 @@
+package io.embrace.opentelemetry.kotlin.fakes.otel.java
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
+
+internal class FakeOtelJavaLogRecordProcessor : OtelJavaLogRecordProcessor {
+
+    var flushCount = 0
+    var shutdownCount = 0
+    val exports: MutableList<OtelJavaReadWriteLogRecord> = mutableListOf()
+
+    override fun onEmit(
+        context: OtelJavaContext,
+        logRecord: OtelJavaReadWriteLogRecord
+    ) {
+        exports += logRecord
+    }
+
+    override fun forceFlush(): OtelJavaCompletableResultCode? {
+        flushCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        shutdownCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanProcessor.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/fakes/otel/java/FakeOtelJavaSpanProcessor.kt
@@ -1,0 +1,39 @@
+package io.embrace.opentelemetry.kotlin.fakes.otel.java
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+
+internal class FakeOtelJavaSpanProcessor : OtelJavaSpanProcessor {
+
+    var flushCount = 0
+    var shutdownCount = 0
+    val startCalls: MutableList<OtelJavaReadWriteSpan> = mutableListOf()
+    val endCalls: MutableList<OtelJavaReadableSpan> = mutableListOf()
+
+    override fun onStart(
+        parentContext: OtelJavaContext,
+        span: OtelJavaReadWriteSpan
+    ) {
+        startCalls += span
+    }
+
+    override fun onEnd(span: OtelJavaReadableSpan) {
+        endCalls += span
+    }
+
+    override fun isStartRequired(): Boolean = true
+    override fun isEndRequired(): Boolean = true
+
+    override fun forceFlush(): OtelJavaCompletableResultCode? {
+        flushCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        shutdownCount += 1
+        return OtelJavaCompletableResultCode.ofSuccess()
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
@@ -10,15 +10,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaLogRecordExporterAdapterTest {
+internal class LogRecordExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaLogRecordExporter
-    private lateinit var wrapper: OtelJavaLogRecordExporterAdapter
+    private lateinit var wrapper: LogRecordExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaLogRecordExporter()
-        wrapper = OtelJavaLogRecordExporterAdapter(impl)
+        wrapper = LogRecordExporterAdapter(impl)
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterExtTest.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordExporterExtTest {
+
+    @Test
+    fun toOtelKotlinLogRecordExporter() {
+        val impl = FakeOtelJavaLogRecordExporter()
+        val adapter = impl.toOtelKotlinLogRecordExporter()
+        val timestamp = 500L
+        adapter.export(mutableListOf(FakeReadWriteLogRecord(timestamp = timestamp)))
+
+        val export = impl.exports.single()
+        assertEquals(timestamp, export.timestampEpochNanos)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
@@ -1,0 +1,44 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordProcessorExtTest {
+
+    @Test
+    fun testOnEmit() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        val harness = OtelKotlinHarness()
+        harness.config.logRecordProcessors.add(adapter)
+
+        val logger = harness.javaApi.logsBridge.get("logger")
+        val msg = "hello world"
+        logger.logRecordBuilder()
+            .setBody(msg)
+            .emit()
+
+        val export = impl.exports.single()
+        assertEquals(msg, export.bodyValue?.asString())
+    }
+
+    @Test
+    fun testFlush() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        adapter.forceFlush()
+        assertEquals(1, impl.flushCount)
+    }
+
+    @Test
+    fun testShutdown() {
+        val impl = FakeOtelJavaLogRecordProcessor()
+        val adapter = impl.toOtelKotlinLogRecordProcessor()
+        adapter.shutdown()
+        assertEquals(1, impl.shutdownCount)
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
@@ -12,15 +12,15 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterAdapterTest {
+internal class SpanExporterAdapterTest {
 
     private lateinit var impl: FakeOtelJavaSpanExporter
-    private lateinit var wrapper: OtelJavaSpanExporterAdapter
+    private lateinit var wrapper: SpanExporterAdapter
 
     @Before
     fun setUp() {
         impl = FakeOtelJavaSpanExporter()
-        wrapper = OtelJavaSpanExporterAdapter(impl)
+        wrapper = SpanExporterAdapter(impl)
     }
 
     @Test

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterExtTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class OtelJavaSpanExporterExtTest {
+internal class SpanExporterExtTest {
 
     @Test
     fun toOtelKotlinSpanExporter() {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
@@ -1,0 +1,52 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.framework.OtelKotlinHarness
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class SpanProcessorExtTest {
+
+    @Test
+    fun toOtelKotlinSpanProcessor() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        val harness = OtelKotlinHarness()
+        harness.config.spanProcessors.add(adapter)
+
+        val tracer = harness.javaApi.tracerProvider.get("tracer")
+        val spanName = "my_span"
+        tracer.spanBuilder(spanName).startSpan().end()
+
+        assertSame(spanName, impl.startCalls.single().name)
+        assertSame(spanName, impl.endCalls.single().name)
+    }
+
+    @Test
+    fun testIsRequired() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        assertTrue(adapter.isStartRequired())
+        assertTrue(adapter.isEndRequired())
+    }
+
+    @Test
+    fun testFlush() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        adapter.forceFlush()
+        assertEquals(1, impl.flushCount)
+    }
+
+    @Test
+    fun testShutdown() {
+        val impl = FakeOtelJavaSpanProcessor()
+        val adapter = impl.toOtelKotlinSpanProcessor()
+        adapter.shutdown()
+        assertEquals(1, impl.shutdownCount)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -9,17 +9,18 @@ import io.embrace.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-class FakeReadWriteLogRecord : ReadWriteLogRecord {
-    override var timestamp: Long? = null
-    override var observedTimestamp: Long? = null
-    override var severityNumber: SeverityNumber? = SeverityNumber.UNKNOWN
-    override var severityText: String? = null
-    override var body: String? = null
-    override var spanContext: SpanContext = FakeSpanContext()
-    override val attributes: Map<String, Any> = emptyMap()
-    override val resource: Resource = FakeResource()
+class FakeReadWriteLogRecord(
+    override var timestamp: Long? = null,
+    override var observedTimestamp: Long? = null,
+    override var severityNumber: SeverityNumber? = SeverityNumber.UNKNOWN,
+    override var severityText: String? = null,
+    override var body: String? = null,
+    override var spanContext: SpanContext = FakeSpanContext(),
+    override val attributes: Map<String, Any> = emptyMap(),
+    override val resource: Resource = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo =
-        FakeInstrumentationScopeInfo()
+        FakeInstrumentationScopeInfo(),
+) : ReadWriteLogRecord {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
     }


### PR DESCRIPTION
## Goal

Implements conversion functions on our public API that convert an opentelemetry-java exporter/processor to the Kotlin API. This will be essential for using the SDK until we implement our own OTLP exporters.

