### PR TITLE
Add API for creating link from span

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -13,6 +13,8 @@ public final class io/embrace/opentelemetry/kotlin/tracing/SpanContextExtKt {
 }
 
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
+	public static final fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun addLink$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun recordException (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun recordException$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -26,3 +26,12 @@ public fun Span.recordException(
         attributes(this)
     }
 }
+
+/**
+ * Adds a link to the span that associates it with another [Span].
+ */
+@OptIn(ExperimentalApi::class)
+@ThreadSafe
+public fun Span.addLink(span: Span, attributes: MutableAttributeContainer.() -> Unit = {}) {
+    addLink(span.spanContext, attributes)
+}

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class SpanExtTest {
@@ -54,5 +55,29 @@ internal class SpanExtTest {
         assertEquals(1, simpleAttrs.size)
         assertNull(simpleAttrs["exception.type"])
         assertNotNull(simpleAttrs["exception.stacktrace"])
+    }
+
+    @Test
+    fun testAddLinkSimple() {
+        val a = FakeSpan()
+        val b = FakeSpan()
+
+        a.addLink(b)
+        val link = a.links.single()
+        assertEquals(b.spanContext, link.spanContext)
+        assertTrue(link.attributes.isEmpty())
+    }
+
+    @Test
+    fun testAddLinkWithAttrs() {
+        val a = FakeSpan()
+        val b = FakeSpan()
+
+        a.addLink(b) {
+            setStringAttribute("extra", "value")
+        }
+        val link = a.links.single()
+        assertEquals(b.spanContext, link.spanContext)
+        assertEquals(mapOf("extra" to "value"), link.attributes)
     }
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/FakeMutableAttributeContainer.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/FakeMutableAttributeContainer.kt
@@ -1,0 +1,56 @@
+package io.embrace.opentelemetry.kotlin.attributes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+class FakeMutableAttributeContainer(
+    private val map: MutableMap<String, Any> = mutableMapOf()
+) : MutableAttributeContainer {
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        map[key] = value
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        map[key] = value
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        map[key] = value
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        map[key] = value
+    }
+
+    override fun setBooleanListAttribute(
+        key: String,
+        value: List<Boolean>
+    ) {
+        map[key] = value
+    }
+
+    override fun setStringListAttribute(
+        key: String,
+        value: List<String>
+    ) {
+        map[key] = value
+    }
+
+    override fun setLongListAttribute(
+        key: String,
+        value: List<Long>
+    ) {
+        map[key] = value
+    }
+
+    override fun setDoubleListAttribute(
+        key: String,
+        value: List<Double>
+    ) {
+        map[key] = value
+    }
+
+    override val attributes: Map<String, Any>
+        get() = map.toMap()
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -1,8 +1,10 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.FakeMutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.data.EventData
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeLinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.LinkData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
@@ -48,7 +50,8 @@ class FakeSpan(
         spanContext: SpanContext,
         attributes: MutableAttributeContainer.() -> Unit
     ) {
-        TODO("Not yet implemented")
+        val attrs = FakeMutableAttributeContainer().apply(attributes).attributes
+        links.add(FakeLinkData(spanContext, attrs))
     }
 
     override fun addEvent(


### PR DESCRIPTION
## Goal

Adds an API to the `api-ext` module that allows creating a link directly from a span object, rather than just from a `SpanContext`.

