### PR TITLE
[POC] Sketch out API for attaching/detaching context

### DIFF
--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -7,6 +7,7 @@ import io.embrace.opentelemetry.example.ExampleSpanProcessor
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.ContextStorageMode
 import io.embrace.opentelemetry.kotlin.createOpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.tracing.Tracer

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/Context.kt
@@ -38,4 +38,19 @@ public interface Context {
      */
     @ThreadSafe
     public fun <T> get(key: ContextKey<T>): T?
+
+    /**
+     * Attaches then detaches the context after executing an action.
+     */
+    public fun <T> use(storageMode: ContextStorageMode = ContextStorageMode.ThreadLocal, action: () -> T)
+
+    /**
+     * Attaches the context as current to the given storage method.
+     */
+    public fun attach(storageMode: ContextStorageMode = ContextStorageMode.THREAD_LOCAL): Context
+
+    /**
+     * Detaches the context as current from the given storage method.
+     */
+    public fun detach(): Context
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextStorageMode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextStorageMode.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.context
+
+/**
+ * The approach used for storing the current context.
+ */
+public enum class ContextStorageMode {
+
+    /**
+     * The current context will be stored in the local thread.
+     */
+    THREAD_LOCAL,
+
+    /**
+     * The current context will be stored in a coroutine context.
+     */
+    COROUTINE_CONTEXT,
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactory.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactory.kt
@@ -2,6 +2,7 @@ package io.embrace.opentelemetry.kotlin.factory
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.ContextStorageMode
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 
 /**
@@ -14,6 +15,12 @@ public interface ContextFactory {
      * Retrieves the root Context.
      */
     public fun root(): Context
+
+    /**
+     * Retrieves the current Context from the given storage method. If no Context has been set
+     * for this storage method, the root Context is returned.
+     */
+    public fun current(storageMode: ContextStorageMode = ContextStorageMode.THREAD_LOCAL): Context
 
     /**
      * Stores a span and returns a new [Context], using a pre-defined key.


### PR DESCRIPTION
## Goal

Sketches out a proposed API for attaching/detaching `Context` instances, by introducing a concept of `current()`.

Fundamentally, this is just a convenient way of storing `Context` objects in a known location, so that context can be retrieved implicitly by calling `current()`. I've attempted to follow the [OTel spec](https://opentelemetry.io/docs/specs/otel/context/) by providing the means to attach/detach the context, as well as providing syntactic sugar with `use()` that performs an action then automatically detaches the context.

The main difference to the opentelemetry-java approach is that `ContextStorageMode` is exposed. This allows a library user to determine _where_ they want to store the implicit context. If they are instrumenting a backend service with lots of JVM threads, it makes sense to use a `ThreadLocal`. If they are using coroutines, it makes sense to use a `CoroutineContext`.

### Additional thoughts

1. I could lean towards making `ContextStorageMode` an interface that handles the storage, and force end-users to pass the interface in for each call. That would allow future extensibility as there will almost certainly be some sort of framework/paradigm we've not considered.
2. I think we want an easier way to create context keys than needing a `Context` object. Perhaps we can just allow string values as an API extension, or even the normal API?

### Example usage

```kotlin
    val root = api.contextFactory.root()
    val ctx = root.set(root.createKey("key"), "value")

    ctx.use {
        val current = api.contextFactory.current()
        assertEquals(ctx, api.contextFactory.current())
    }
    assertEquals(root, api.contextFactory.current())
```
