### PR TITLE
Rename api entrypoints

### DIFF
--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.example.ExampleSpanProcessor
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.createOpenTelemetryInstance
+import io.embrace.opentelemetry.kotlin.createOpenTelemetry
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
@@ -17,7 +17,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  * Example of how to instantiate a Kotlin API wrapper around the OTel Java SDK.
  */
 fun instantiateOtelApi(): OpenTelemetry {
-    return createOpenTelemetryInstance(
+    return createOpenTelemetry(
         tracerProvider = {
             addSpanProcessor(ExampleSpanProcessor())
         },

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,6 +1,6 @@
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypointKt {
-	public static final fun createCompatOpenTelemetryInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun createCompatOpenTelemetryInstance$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun createCompatOpenTelemetry (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createCompatOpenTelemetry$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -18,12 +18,12 @@ import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
  * [toOtelKotlinApi] instead.
  */
 @ExperimentalApi
-public fun createCompatOpenTelemetryInstance(
+public fun createCompatOpenTelemetry(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
 ): OpenTelemetry {
-    return createCompatOpenTelemetryInstanceImpl(
+    return createCompatOpenTelemetryImpl(
         tracerProvider,
         loggerProvider,
         clock,
@@ -31,11 +31,11 @@ public fun createCompatOpenTelemetryInstance(
 }
 
 /**
- * Internal implementation of [createCompatOpenTelemetryInstance]. This is not publicly visible as
+ * Internal implementation of [createCompatOpenTelemetry]. This is not publicly visible as
  * we don't want to allow users to supply a custom [SdkFactory].
  */
 @ExperimentalApi
-internal fun createCompatOpenTelemetryInstanceImpl(
+internal fun createCompatOpenTelemetryImpl(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
  * Constructs an [OtelJavaOpenTelemetry] instance that makes the Kotlin implementation conform
  * to the opentelemetry-java API.
  *
- * End-users should generally not use this function and should call [createCompatOpenTelemetryInstance]
+ * End-users should generally not use this function and should call [createCompatOpenTelemetry]
  * or [toOtelKotlinApi] instead.
  */
 @ExperimentalApi

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -16,7 +16,7 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProviderAdapter
  * This function is useful if you have existing OpenTelemetry Java SDK code that you don't want
  * to/can't rewrite, but still wish to use the Kotlin API for new code. It is permitted to call
  * both the Kotlin and Java APIs throughout the lifecycle of your application, although it would
- * generally be encouraged to migrate to [createCompatOpenTelemetryInstance] as a long-term goal.
+ * generally be encouraged to migrate to [createCompatOpenTelemetry] as a long-term goal.
  */
 @ExperimentalApi
 public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
@@ -8,7 +8,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve tracer provider`() {
-        val sdk = createCompatOpenTelemetryInstance()
+        val sdk = createCompatOpenTelemetry()
         val provider = sdk.tracerProvider
         val a = provider.getTracer("test")
         val b = provider.getTracer("test")
@@ -23,7 +23,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `retrieve logger provider`() {
-        val sdk = createCompatOpenTelemetryInstance()
+        val sdk = createCompatOpenTelemetry()
         val provider = sdk.loggerProvider
         val a = provider.getLogger("test")
         val b = provider.getLogger("test")

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -3,7 +3,7 @@ package io.embrace.opentelemetry.kotlin.framework
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
-import io.embrace.opentelemetry.kotlin.createCompatOpenTelemetryInstanceImpl
+import io.embrace.opentelemetry.kotlin.createCompatOpenTelemetryImpl
 import io.embrace.opentelemetry.kotlin.factory.CompatSdkFactory
 import io.embrace.opentelemetry.kotlin.factory.CompatTracingIdFactory
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactory
@@ -14,7 +14,7 @@ import kotlin.random.Random
 internal class OtelKotlinHarness : OtelKotlinTestRule() {
 
     override val kotlinApi: OpenTelemetry by lazy {
-        createCompatOpenTelemetryInstanceImpl(
+        createCompatOpenTelemetryImpl(
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
             clock = clock,

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -1,6 +1,6 @@
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypointKt {
-	public static final fun createOpenTelemetryInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun createOpenTelemetryInstance$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createOpenTelemetry$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/factory/SdkFactoryExtKt {

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -15,12 +15,12 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProviderImpl
  * Constructs an [OpenTelemetry] instance that uses the opentelemetry-kotlin implementation.
  */
 @ExperimentalApi
-public fun createOpenTelemetryInstance(
+public fun createOpenTelemetry(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockImpl(),
 ): OpenTelemetry {
-    return createOpenTelemetryInstanceImpl(
+    return createOpenTelemetryImpl(
         tracerProvider,
         loggerProvider,
         clock,
@@ -28,11 +28,11 @@ public fun createOpenTelemetryInstance(
 }
 
 /**
- * Internal implementation of [createOpenTelemetryInstance]. This is not publicly visible as
+ * Internal implementation of [createOpenTelemetry]. This is not publicly visible as
  * we don't want to allow users to supply a custom [SdkFactory].
  */
 @ExperimentalApi
-internal fun createOpenTelemetryInstanceImpl(
+internal fun createOpenTelemetryImpl(
     tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
     loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
     clock: Clock = ClockImpl(),

--- a/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/opentelemetry-kotlin-implementation/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -2,7 +2,7 @@ package io.embrace.opentelemetry.kotlin.integration.test
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.createOpenTelemetryInstanceImpl
+import io.embrace.opentelemetry.kotlin.createOpenTelemetryImpl
 import io.embrace.opentelemetry.kotlin.factory.SdkFactoryImpl
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactoryImpl
 import io.embrace.opentelemetry.kotlin.framework.OtelKotlinTestRule
@@ -15,7 +15,7 @@ import kotlin.random.Random
 @OptIn(ExperimentalApi::class)
 internal class IntegrationTestHarness : OtelKotlinTestRule() {
     override val kotlinApi: OpenTelemetry by lazy {
-        createOpenTelemetryInstanceImpl(
+        createOpenTelemetryImpl(
             tracerProvider = tracerProviderConfig,
             loggerProvider = loggerProviderConfig,
             clock = clock,

--- a/opentelemetry-kotlin-noop/api/opentelemetry-kotlin-noop.api
+++ b/opentelemetry-kotlin-noop/api/opentelemetry-kotlin-noop.api
@@ -1,4 +1,4 @@
 public final class io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypointKt {
-	public static final fun noopOpenTelemetry ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun createNoopOpenTelemetry ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypoint.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/NoopOpenTelemetryEntrypoint.kt
@@ -4,4 +4,4 @@ package io.embrace.opentelemetry.kotlin
  * Returns a no-op instance of [OpenTelemetry] instance.
  */
 @OptIn(ExperimentalApi::class)
-public fun noopOpenTelemetry(): OpenTelemetry = NoopOpenTelemetry
+public fun createNoopOpenTelemetry(): OpenTelemetry = NoopOpenTelemetry

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -17,7 +17,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopTracing() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
         val tracerProvider = otel.tracerProvider
         val tracer = tracerProvider.getTracer("test-tracer")
 
@@ -57,7 +57,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopLogging() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
         val loggerProvider = otel.loggerProvider
         val logger = loggerProvider.getLogger("test-logger")
 
@@ -84,7 +84,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopClockDefault() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
         val clock = otel.clock
 
         // Noop clock always returns 0
@@ -94,7 +94,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopContext() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
         val ctx = otel.contextFactory.root()
 
         val key = ctx.createKey<String>("key")
@@ -108,7 +108,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopSpanContext() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
         val invalid = otel.spanContextFactory.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
@@ -124,7 +124,7 @@ internal class NoopTests {
 
     @Test
     fun testNoopSpan() {
-        val otel = noopOpenTelemetry()
+        val otel = createNoopOpenTelemetry()
 
         val first = otel.spanFactory.invalid
         assertTrue(first is NoopSpan)


### PR DESCRIPTION
## Goal

Renames the API entrypoints as suggested in #355 so that they use consistent naming of `create<Token>OpenTelemetry()`.

