### PR TITLE
Implement lock on apple platforms

### DIFF
--- a/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.apple.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.apple.kt
@@ -1,7 +1,20 @@
 package io.embrace.opentelemetry.kotlin
 
-public actual class ReentrantReadWriteLock {
-    public actual fun <T> write(action: () -> T): T = throw UnsupportedOperationException()
-    public actual fun <T> read(action: () -> T): T = throw UnsupportedOperationException()
-}
+import platform.Foundation.NSRecursiveLock
 
+public actual class ReentrantReadWriteLock {
+
+    private val lock = NSRecursiveLock()
+
+    public actual fun <T> write(action: () -> T): T {
+        lock.lock()
+        try {
+            return action()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    // take perf hit of obtaining the same lock for now, for the sake of simplicity
+    public actual fun <T> read(action: () -> T): T = write(action)
+}

--- a/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.apple.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeList.apple.kt
@@ -1,5 +1,92 @@
 package io.embrace.opentelemetry.kotlin
 
-public actual fun <T> threadSafeList(): MutableList<T> {
-    throw UnsupportedOperationException()
+public actual fun <T> threadSafeList(): MutableList<T> = ThreadSafeListImpl()
+
+private class ThreadSafeListImpl<T>(
+    private val lock: ReentrantReadWriteLock = ReentrantReadWriteLock(),
+    private val impl: MutableList<T> = mutableListOf(),
+) : MutableList<T> {
+
+    override val size: Int
+        get() = lock.read { impl.size }
+
+    override fun contains(element: T): Boolean = lock.read {
+        impl.contains(element)
+    }
+
+    override fun containsAll(elements: Collection<T>): Boolean = lock.read {
+        impl.containsAll(elements)
+    }
+
+    override fun get(index: Int): T = lock.read {
+        impl[index]
+    }
+
+    override fun indexOf(element: T): Int = lock.read {
+        impl.indexOf(element)
+    }
+
+    override fun isEmpty(): Boolean = lock.read {
+        impl.isEmpty()
+    }
+
+    override fun iterator(): MutableIterator<T> = lock.read {
+        impl.toMutableList().iterator()
+    }
+
+    override fun lastIndexOf(element: T): Int = lock.read {
+        impl.lastIndexOf(element)
+    }
+
+    override fun add(element: T): Boolean = lock.write {
+        impl.add(element)
+    }
+
+    override fun add(index: Int, element: T) = lock.write {
+        impl.add(index, element)
+    }
+
+    override fun addAll(index: Int, elements: Collection<T>): Boolean = lock.write {
+        impl.addAll(index, elements)
+    }
+
+    override fun addAll(elements: Collection<T>): Boolean = lock.write {
+        impl.addAll(elements)
+    }
+
+    override fun clear() = lock.write {
+        impl.clear()
+    }
+
+    override fun listIterator(): MutableListIterator<T> = lock.read {
+        impl.toMutableList().listIterator()
+    }
+
+    override fun listIterator(index: Int): MutableListIterator<T> = lock.read {
+        impl.toMutableList().listIterator(index)
+    }
+
+    override fun remove(element: T): Boolean = lock.write {
+        impl.remove(element)
+    }
+
+    override fun removeAll(elements: Collection<T>): Boolean = lock.write {
+        impl.removeAll(elements)
+    }
+
+    override fun removeAt(index: Int): T = lock.write {
+        impl.removeAt(index)
+    }
+
+    override fun retainAll(elements: Collection<T>): Boolean = lock.write {
+        impl.retainAll(elements)
+    }
+
+    override fun set(index: Int, element: T): T = lock.write {
+        impl.set(index, element)
+    }
+
+    override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> = lock.read {
+        impl.toMutableList().subList(fromIndex, toIndex)
+    }
 }

--- a/opentelemetry-kotlin-platform-implementations/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLockTest.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLockTest.kt
@@ -1,0 +1,40 @@
+package io.embrace.opentelemetry.kotlin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ReentrantReadWriteLockTest {
+
+    @Test
+    fun testAddAndGet() {
+        val list = threadSafeList<Int>()
+        list.add(1)
+        list.add(2)
+        assertEquals(2, list.size)
+        assertEquals(1, list[0])
+        assertEquals(2, list[1])
+    }
+
+    @Test
+    fun testRemove() {
+        val list = threadSafeList<Int>().apply { addAll(listOf(1, 2, 3)) }
+        assertTrue(list.remove(2))
+        assertEquals(listOf(1, 3), list.toList())
+    }
+
+    @Test
+    fun testClear() {
+        val list = threadSafeList<Int>().apply { addAll(listOf(1, 2)) }
+        list.clear()
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun testContains() {
+        val list = threadSafeList<String>().apply { addAll(listOf("a", "b")) }
+        assertTrue(list.contains("a"))
+        assertFalse(list.contains("c"))
+    }
+}


### PR DESCRIPTION
## Goal

Implements a lock using [NSRecursiveLock](https://developer.apple.com/documentation/foundation/nsrecursivelock) and uses this to implement a list that can be accessed concurrently from multiple threads. For now I've chosen to keep things simple by avoiding separate read/write locks in this implementation.

## Testing

Added a test that covers some of the common use cases.

