### PR TITLE
Create thread safe map implementation for apple

### DIFF
--- a/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.apple.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMap.apple.kt
@@ -1,3 +1,61 @@
 package io.embrace.opentelemetry.kotlin
 
-public actual fun <K, V> threadSafeMap(): MutableMap<K, V> = throw UnsupportedOperationException()
+public actual fun <K, V> threadSafeMap(): MutableMap<K, V> = ThreadSafeMapImpl()
+
+private class ThreadSafeMapImpl<K, V>(
+    private val lock: ReentrantReadWriteLock = ReentrantReadWriteLock(),
+    private val impl: MutableMap<K, V> = mutableMapOf(),
+) : MutableMap<K, V> {
+
+    override val size: Int
+        get() = lock.read {
+            impl.size
+        }
+
+    override fun isEmpty(): Boolean = lock.read {
+        impl.isEmpty()
+    }
+
+    override fun containsKey(key: K): Boolean = lock.read {
+        impl.containsKey(key)
+    }
+
+    override fun containsValue(value: V): Boolean = lock.read {
+        impl.containsValue(value)
+    }
+
+    override fun get(key: K): V? = lock.read {
+        impl[key]
+    }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
+        get() = lock.read {
+            impl.entries.toMutableSet()
+        }
+
+    override val keys: MutableSet<K>
+        get() = lock.read {
+            impl.keys.toMutableSet()
+        }
+
+    override val values: MutableCollection<V>
+        get() = lock.read {
+            impl.values.toMutableList()
+        }
+
+    override fun put(key: K, value: V): V? = lock.write {
+        impl.put(key, value)
+    }
+
+    override fun putAll(from: Map<out K, V>) = lock.write {
+        impl.putAll(from)
+    }
+
+    override fun remove(key: K): V? = lock.write {
+        impl.remove(key)
+    }
+
+    override fun clear() = lock.write {
+        impl.clear()
+    }
+}

--- a/opentelemetry-kotlin-platform-implementations/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapTest.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapTest.kt
@@ -1,0 +1,46 @@
+package io.embrace.opentelemetry.kotlin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class ThreadSafeMapTest {
+
+    @Test
+    fun testPutAndGet() {
+        val map = threadSafeMap<String, Int>()
+        map["a"] = 1
+        map["b"] = 2
+        assertEquals(1, map["a"])
+        assertEquals(2, map["b"])
+        assertEquals(2, map.size)
+    }
+
+    @Test
+    fun testRemove() {
+        val map = threadSafeMap<String, Int>()
+        map["x"] = 42
+        assertEquals(42, map.remove("x"))
+        assertNull(map["x"])
+    }
+
+    @Test
+    fun testClear() {
+        val map = threadSafeMap<String, Int>()
+        map["a"] = 1
+        map["b"] = 2
+        map.clear()
+        assertTrue(map.isEmpty())
+    }
+
+    @Test
+    fun testContains() {
+        val map = threadSafeMap<String, String>()
+        map["foo"] = "bar"
+        assertTrue(map.containsKey("foo"))
+        assertTrue(map.containsValue("bar"))
+        assertFalse(map.containsKey("baz"))
+    }
+}

--- a/opentelemetry-kotlin-platform-implementations/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapJvmTest.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/ThreadSafeMapJvmTest.kt
@@ -4,7 +4,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
 
-internal class ThreadSafeMapTest {
+internal class ThreadSafeMapJvmTest {
 
     @Test
     fun `test threadSafeMap`() {


### PR DESCRIPTION
## Goal

Implements a map that can be accessed concurrently from multiple threads by building on the lock added in #377.

## Testing

Added a test that covers some of the common use cases.

