### PR TITLE
Reduce visibility of createCompatSdkFactory

### DIFF
--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -23,10 +23,6 @@ public final class io/embrace/opentelemetry/kotlin/context/OtelJavaContextExtKt 
 	public static final fun toOtelKotlinContext (Lio/opentelemetry/context/Context;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }
 
-public final class io/embrace/opentelemetry/kotlin/factory/CompatSdkFactoryExtKt {
-	public static final fun createCompatSdkFactory ()Lio/embrace/opentelemetry/kotlin/factory/SdkFactory;
-}
-
 public final class io/embrace/opentelemetry/kotlin/factory/ContextFactoryExtKt {
 	public static final fun current (Lio/embrace/opentelemetry/kotlin/factory/ContextFactory;)Lio/embrace/opentelemetry/kotlin/context/Context;
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/factory/CompatSdkFactoryExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/factory/CompatSdkFactoryExt.kt
@@ -6,4 +6,4 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  * Creates a factory that constructs objects that work when the SDK is backed by the OTel Java SDK.
  */
 @ExperimentalApi
-public fun createCompatSdkFactory(): SdkFactory = CompatSdkFactory()
+internal fun createCompatSdkFactory(): SdkFactory = CompatSdkFactory()


### PR DESCRIPTION
## Goal

Reduces the visibility of `createCompatSdkFactory` which is an internal implementation detail.

