### PR TITLE
 toOtelJavaApi() now returns OtelJavaOpenTelemetry.noop() when called on a Kotlin noop OpenTelemetry instance

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -13,6 +13,9 @@ import io.embrace.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
  */
 @ExperimentalApi
 public fun OpenTelemetry.toOtelJavaApi(): OtelJavaOpenTelemetry {
+    if (this == createNoopOpenTelemetry()) {
+        return OtelJavaOpenTelemetry.noop()
+    }
     return OtelJavaOpenTelemetrySdk(
         OtelJavaTracerProviderAdapter(tracerProvider),
         OtelJavaLoggerProviderAdapter(loggerProvider)

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtTest.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import org.junit.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class OpenTelemetryCompatExtTest {
+
+    @Test
+    fun `toOtelJavaApi returns noop when called on noop instance`() {
+        val noopKotlinInstance = createNoopOpenTelemetry()
+        val result = noopKotlinInstance.toOtelJavaApi()
+        assertSame(OtelJavaOpenTelemetry.noop(), result)
+    }
+}


### PR DESCRIPTION
## Summary
- `OtelJavaOpenTelemetry.noop` is now returned when calling `toOtelJavaApi()` on a Kotlin noop instance
- Add a test to validate the logic.
