### PR TITLE
Fixes build dependency issue

### DIFF
--- a/opentelemetry-kotlin-implementation/build.gradle.kts
+++ b/opentelemetry-kotlin-implementation/build.gradle.kts
@@ -14,12 +14,12 @@ kotlin {
                 implementation(project(":opentelemetry-kotlin-api-ext"))
                 implementation(project(":opentelemetry-kotlin-model"))
                 implementation(project(":opentelemetry-kotlin-platform-implementations"))
-                implementation(project(":opentelemetry-kotlin-integration-test"))
             }
         }
         val commonTest by getting {
             dependencies {
                 implementation(project(":opentelemetry-kotlin-test-fakes"))
+                implementation(project(":opentelemetry-kotlin-integration-test"))
             }
         }
         val jvmTest by getting {


### PR DESCRIPTION
## Goal

Fixes an issue with the build dependency where the `integration-test` module was inadvertantly added to `commonMain` instead of `commonTest`. Because this module doesn't publish to Maven Central this results in 0.5.0 failing to resolve the dependency. The ultimate fix will be to avoid using 0.5.0 and to ship a new release that doesn't request this dependency.

