### PR TITLE
Optimize logging/tracing pipelines

### DIFF
--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
@@ -33,6 +33,6 @@ public interface Logger {
         context: Context? = null,
         severityNumber: SeverityNumber? = null,
         severityText: String? = null,
-        attributes: MutableAttributeContainer.() -> Unit = {},
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
     )
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProvider.kt
@@ -24,6 +24,6 @@ public interface LoggerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: MutableAttributeContainer.() -> Unit = {},
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
     ): Logger
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/Tracer.kt
@@ -25,6 +25,6 @@ public interface Tracer {
         parentContext: Context? = null,
         spanKind: SpanKind = SpanKind.INTERNAL,
         startTimestamp: Long? = null,
-        action: SpanRelationships.() -> Unit = {}
+        action: (SpanRelationships.() -> Unit)? = null
     ): Span
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -24,6 +24,6 @@ public interface TracerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: MutableAttributeContainer.() -> Unit = {},
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
     ): Tracer
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
@@ -16,7 +16,7 @@ public interface SpanRelationships : MutableAttributeContainer {
      * Adds a link to the span that associates it with another [SpanContext].
      */
     @ThreadSafe
-    public fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit = {})
+    public fun addLink(spanContext: SpanContext, attributes: (MutableAttributeContainer.() -> Unit)? = null)
 
     /**
      * Adds an event to the span.
@@ -25,6 +25,6 @@ public interface SpanRelationships : MutableAttributeContainer {
     public fun addEvent(
         name: String,
         timestamp: Long? = null,
-        attributes: MutableAttributeContainer.() -> Unit = {},
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
     )
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -23,7 +23,7 @@ internal class LoggerAdapter(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val builder = impl.logRecordBuilder()
 
@@ -46,9 +46,11 @@ internal class LoggerAdapter(
             builder.setSeverityText(severityText)
         }
 
-        val container = CompatMutableAttributeContainer()
-        attributes(container)
-        builder.setAllAttributes(container.otelJavaAttributes())
+        if (attributes != null) {
+            val container = CompatMutableAttributeContainer()
+            attributes(container)
+            builder.setAllAttributes(container.otelJavaAttributes())
+        }
         builder.emit()
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -14,7 +14,7 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Logger {
         val key = name.plus(version).plus(schemaUrl)
         return map.getOrPut(key) {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerAdapter.kt
@@ -27,7 +27,7 @@ internal class TracerAdapter(
         parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
-        action: SpanRelationships.() -> Unit
+        action: (SpanRelationships.() -> Unit)?
     ): Span {
         val start = startTimestamp ?: clock.now()
         val builder = tracer.spanBuilder(name)
@@ -50,7 +50,9 @@ internal class TracerAdapter(
             spanLimitsConfig = spanLimitsConfig,
         ).apply {
             this.name = name
-            action(this)
+            if (action != null) {
+                action(this)
+            }
         }
     }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -20,7 +20,7 @@ internal class TracerProviderAdapter(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Tracer {
         val key = name.plus(version).plus(schemaUrl)
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -44,10 +44,12 @@ internal class ReadWriteSpanAdapter(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val container = CompatMutableAttributeContainer()
-        attributes(container)
+        if (attributes != null) {
+            attributes(container)
+        }
         val ctx = (spanContext as SpanContextAdapter).impl
         impl.addLink(ctx, container.otelJavaAttributes())
     }
@@ -55,10 +57,12 @@ internal class ReadWriteSpanAdapter(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val container = CompatMutableAttributeContainer()
-        attributes(container)
+        if (attributes != null) {
+            attributes(container)
+        }
         impl.addEvent(name, container.otelJavaAttributes(), timestamp ?: 0, TimeUnit.NANOSECONDS)
     }
 

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -83,10 +83,12 @@ internal class SpanAdapter(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val container = CompatMutableAttributeContainer()
-        attributes(container)
+        if (attributes != null) {
+            attributes(container)
+        }
         if (linksImpl.size < spanLimitsConfig.linkCountLimit) {
             linksImpl.add(LinkImpl(spanContext, container))
         }
@@ -96,10 +98,12 @@ internal class SpanAdapter(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val container = CompatMutableAttributeContainer()
-        attributes(container)
+        if (attributes != null) {
+            attributes(container)
+        }
         val time = timestamp ?: clock.now()
         if (eventsImpl.size < spanLimitsConfig.eventCountLimit) {
             eventsImpl.add(SpanEventImpl(name, time, container))

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -20,7 +20,10 @@ internal class LoggerProviderImpl(
 
     private val apiProvider by lazy {
         ApiProviderImpl<Logger> { key ->
-            val processor = CompositeLogRecordProcessor(loggingConfig.processors, sdkErrorHandler)
+            val processor = when {
+                loggingConfig.processors.isEmpty() -> null
+                else -> CompositeLogRecordProcessor(loggingConfig.processors, sdkErrorHandler)
+            }
             LoggerImpl(
                 clock,
                 processor,
@@ -36,7 +39,7 @@ internal class LoggerProviderImpl(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Logger {
         val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
         return apiProvider.getOrCreate(key)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -25,75 +25,89 @@ internal class LogRecordModel(
     logLimitConfig: LogLimitConfig,
 ) : ReadWriteLogRecord {
 
-    private val lock = ReentrantReadWriteLock()
+    private val lock by lazy {
+        ReentrantReadWriteLock()
+    }
 
     override var timestamp: Long? = timestamp
-        get() = readLogRecord { field }
+        get() = lock.read {
+            field
+        }
         set(value) {
-            writeLogRecord {
+            lock.write {
                 field = value
             }
         }
 
     override var observedTimestamp: Long? = observedTimestamp
-        get() = readLogRecord { field }
+        get() = lock.read {
+            field
+        }
         set(value) {
-            writeLogRecord {
+            lock.write {
                 field = value
             }
         }
 
     override var severityNumber: SeverityNumber? = severityNumber
-        get() = readLogRecord { field }
+        get() = lock.read {
+            field
+        }
         set(value) {
-            writeLogRecord {
+            lock.write {
                 field = value
             }
         }
 
     override var severityText: String? = severityText
-        get() = readLogRecord { field }
+        get() = lock.read {
+            field
+        }
         set(value) {
-            writeLogRecord {
+            lock.write {
                 field = value
             }
         }
 
     override var body: String? = body
-        get() = readLogRecord { field }
+        get() = lock.read {
+            field
+        }
         set(value) {
-            writeLogRecord {
+            lock.write {
                 field = value
             }
         }
 
-    private val attrs = MutableAttributeContainerImpl(logLimitConfig.attributeCountLimit, mutableMapOf())
+    private val attrs by lazy {
+        MutableAttributeContainerImpl(logLimitConfig.attributeCountLimit, mutableMapOf())
+    }
 
     override val attributes: Map<String, Any>
-        get() = readLogRecord {
+        get() = lock.read {
             attrs.attributes.toMap()
         }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
-        writeLogRecord {
+        lock.write {
             attrs.setBooleanAttribute(key, value)
         }
     }
 
     override fun setStringAttribute(key: String, value: String) {
-        writeLogRecord {
+        lock.write {
             attrs.setStringAttribute(key, value)
         }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
-        writeLogRecord {
+        lock.write {
             attrs.setLongAttribute(key, value)
         }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
-        writeLogRecord {
+        lock.write {
             attrs.setDoubleAttribute(key, value)
         }
     }
@@ -102,7 +116,7 @@ internal class LogRecordModel(
         key: String,
         value: List<Boolean>
     ) {
-        writeLogRecord {
+        lock.write {
             attrs.setBooleanListAttribute(key, value)
         }
     }
@@ -111,7 +125,7 @@ internal class LogRecordModel(
         key: String,
         value: List<String>
     ) {
-        writeLogRecord {
+        lock.write {
             attrs.setStringListAttribute(key, value)
         }
     }
@@ -120,7 +134,7 @@ internal class LogRecordModel(
         key: String,
         value: List<Long>
     ) {
-        writeLogRecord {
+        lock.write {
             attrs.setLongListAttribute(key, value)
         }
     }
@@ -129,25 +143,8 @@ internal class LogRecordModel(
         key: String,
         value: List<Double>
     ) {
-        writeLogRecord {
+        lock.write {
             attrs.setDoubleListAttribute(key, value)
-        }
-    }
-
-    private inline fun <T> writeLogRecord(
-        crossinline condition: () -> Boolean = { true },
-        crossinline action: () -> T
-    ) {
-        return lock.write {
-            if (condition()) {
-                action()
-            }
-        }
-    }
-
-    private inline fun <T> readLogRecord(crossinline action: () -> T): T {
-        return lock.read {
-            action()
         }
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecordImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecordImpl.kt
@@ -7,5 +7,5 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
  */
 @OptIn(ExperimentalApi::class)
 internal class ReadWriteLogRecordImpl(
-    private val impl: ReadWriteLogRecord
+    private val impl: LogRecordModel
 ) : ReadWriteLogRecord by impl

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/provider/ApiProviderImpl.kt
@@ -35,11 +35,12 @@ internal class ApiProviderImpl<T>(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): InstrumentationScopeInfo {
-        val attrs = MutableAttributeContainerImpl(DEFAULT_ATTRIBUTE_LIMIT, mutableMapOf()).apply {
-            attributes()
-        }.attributes
-        return InstrumentationScopeInfoImpl(name, version, schemaUrl, attrs)
+        val container = MutableAttributeContainerImpl(DEFAULT_ATTRIBUTE_LIMIT, mutableMapOf())
+        if (attributes != null) {
+            attributes(container)
+        }
+        return InstrumentationScopeInfoImpl(name, version, schemaUrl, container.attributes)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
@@ -23,22 +23,28 @@ internal class SpanRelationshipsImpl(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         if (links.size < spanLimitConfig.linkCountLimit) {
-            val attrs = MutableAttributeContainerImpl(spanLimitConfig.attributeCountPerLinkLimit).apply(attributes)
-            links.add(LinkImpl(spanContext, attrs))
+            val container = MutableAttributeContainerImpl(spanLimitConfig.attributeCountPerLinkLimit)
+            if (attributes != null) {
+                attributes(container)
+            }
+            links.add(LinkImpl(spanContext, container))
         }
     }
 
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         if (events.size < spanLimitConfig.eventCountLimit) {
-            val attrs = MutableAttributeContainerImpl(spanLimitConfig.attributeCountPerEventLimit).apply(attributes)
-            events.add(SpanEventImpl(name, timestamp ?: clock.now(), attrs))
+            val container = MutableAttributeContainerImpl(spanLimitConfig.attributeCountPerEventLimit)
+            if (attributes != null) {
+                attributes(container)
+            }
+            events.add(SpanEventImpl(name, timestamp ?: clock.now(), container))
         }
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -19,7 +19,10 @@ internal class TracerProviderImpl(
 ) : TracerProvider {
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
-        val processor = CompositeSpanProcessor(tracingConfig.processors, sdkErrorHandler)
+        val processor = when {
+            tracingConfig.processors.isEmpty() -> null
+            else -> CompositeSpanProcessor(tracingConfig.processors, sdkErrorHandler)
+        }
         TracerImpl(
             clock = clock,
             processor = processor,
@@ -34,7 +37,7 @@ internal class TracerProviderImpl(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Tracer {
         val key = apiProvider.createInstrumentationScopeInfo(
             name = name,

--- a/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/opentelemetry-kotlin-model/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -51,14 +51,14 @@ class NonRecordingSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
     }
 
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
     }
 

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -14,7 +14,7 @@ internal object NoopLogger : Logger {
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
     }
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
@@ -9,6 +9,6 @@ internal object NoopLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Logger = NoopLogger
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -28,10 +28,10 @@ internal object NoopSpan : Span {
     override fun end(timestamp: Long) {
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addLink(spanContext: SpanContext, attributes: (MutableAttributeContainer.() -> Unit)?) {
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: (MutableAttributeContainer.() -> Unit)?) {
     }
 
     override fun isRecording(): Boolean = false

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -13,6 +13,6 @@ internal object NoopTracer : Tracer {
         parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
-        action: SpanRelationships.() -> Unit
+        action: (SpanRelationships.() -> Unit)?
     ): Span = NoopSpan
 }

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
@@ -9,6 +9,6 @@ internal object NoopTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Tracer = NoopTracer
 }

--- a/opentelemetry-kotlin-platform-implementations/api/opentelemetry-kotlin-platform-implementations.api
+++ b/opentelemetry-kotlin-platform-implementations/api/opentelemetry-kotlin-platform-implementations.api
@@ -8,6 +8,7 @@ public final class io/embrace/opentelemetry/kotlin/ExceptionType_jvmKt {
 
 public final class io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock {
 	public fun <init> ()V
+	public final fun getImpl ()Ljava/util/concurrent/locks/ReentrantReadWriteLock;
 	public final fun read (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun write (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }

--- a/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/appleMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.kt
@@ -4,17 +4,18 @@ import platform.Foundation.NSRecursiveLock
 
 public actual class ReentrantReadWriteLock {
 
-    private val lock = NSRecursiveLock()
+    // visible to allow inlining
+    public val impl: NSRecursiveLock = NSRecursiveLock()
 
-    public actual fun <T> write(action: () -> T): T {
-        lock.lock()
+    public actual inline fun <T> write(action: () -> T): T {
+        impl.lock()
         try {
             return action()
         } finally {
-            lock.unlock()
+            impl.unlock()
         }
     }
 
     // take perf hit of obtaining the same lock for now, for the sake of simplicity
-    public actual fun <T> read(action: () -> T): T = write(action)
+    public actual inline fun <T> read(action: () -> T): T = write(action)
 }

--- a/opentelemetry-kotlin-platform-implementations/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.kt
@@ -8,10 +8,10 @@ public expect class ReentrantReadWriteLock() {
     /**
      * Performs an operation behind the write lock.
      */
-    public fun <T> write(action: () -> T): T
+    public inline fun <T> write(action: () -> T): T
 
     /**
      * Performs an operation behind the read lock.
      */
-    public fun <T> read(action: () -> T): T
+    public inline fun <T> read(action: () -> T): T
 }

--- a/opentelemetry-kotlin-platform-implementations/src/jsMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.js.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/jsMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.js.kt
@@ -1,6 +1,6 @@
 package io.embrace.opentelemetry.kotlin
 
 public actual class ReentrantReadWriteLock {
-    public actual fun <T> write(action: () -> T): T = action()
-    public actual fun <T> read(action: () -> T): T = action()
+    public actual inline fun <T> write(action: () -> T): T = action()
+    public actual inline fun <T> read(action: () -> T): T = action()
 }

--- a/opentelemetry-kotlin-platform-implementations/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.jvm.kt
+++ b/opentelemetry-kotlin-platform-implementations/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/ReentrantReadWriteLock.jvm.kt
@@ -5,9 +5,11 @@ import kotlin.concurrent.read
 import kotlin.concurrent.write
 
 public actual class ReentrantReadWriteLock {
-    private val lock: ReentrantReadWriteLock = ReentrantReadWriteLock()
 
-    public actual fun <T> write(action: () -> T): T = lock.write { action() }
+    // visible to allow inlining
+    public val impl: ReentrantReadWriteLock = ReentrantReadWriteLock()
 
-    public actual fun <T> read(action: () -> T): T = lock.read { action() }
+    public actual inline fun <T> write(action: () -> T): T = impl.write { action() }
+
+    public actual inline fun <T> read(action: () -> T): T = impl.read { action() }
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -20,7 +20,7 @@ class FakeLogger(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         logs.add(
             FakeReadableLogRecord(

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
@@ -12,7 +12,7 @@ class FakeLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Logger = map.getOrPut(name) {
         FakeLogger(name)
     }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
@@ -41,7 +41,7 @@ class FakeReadWriteSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         throw UnsupportedOperationException()
     }
@@ -49,7 +49,7 @@ class FakeReadWriteSpan(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         throw UnsupportedOperationException()
     }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -48,18 +48,26 @@ class FakeSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        val attrs = FakeMutableAttributeContainer().apply(attributes).attributes
+        val container = FakeMutableAttributeContainer()
+        if (attributes != null) {
+            attributes(container)
+        }
+        val attrs = container.attributes
         links.add(FakeLinkData(spanContext, attrs))
     }
 
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        events.add(FakeSpanEvent(name, timestamp ?: 0).apply(attributes))
+        val fakeSpanEvent = FakeSpanEvent(name, timestamp ?: 0)
+        if (attributes != null) {
+            attributes(fakeSpanEvent)
+        }
+        events.add(fakeSpanEvent)
     }
 
     override fun setStringAttribute(key: String, value: String) {

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracer.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracer.kt
@@ -16,6 +16,6 @@ class FakeTracer(
         parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
-        action: SpanRelationships.() -> Unit
+        action: (SpanRelationships.() -> Unit)?
     ): Span = FakeSpan()
 }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
@@ -12,7 +12,7 @@ class FakeTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ): Tracer = map.getOrPut(name) {
         FakeTracer(name)
     }


### PR DESCRIPTION
## Goal

Makes several changes to the logging/tracing pipelines that on measurement with microbenchmark/kotlinx-benchmark sped up the span/log test cases, notably:

- Making lambda parameters on the hot path nullable, so that we can null check & skip invoking them if nothing is supplied
- Made some lock functions inline to avoid object/function instantiation
- Supplied a null processor if no processors are set
- Cached immutable values in the `Logger/Tracer` implementation if they can be reused between different logs/traces
