### PR TITLE
Tweak performance benchmarks

### DIFF
--- a/opentelemetry-kotlin-benchmark-fixtures/src/commonMain/kotlin/io/embrace/kotlin/opentelemetry/benchmark/fixtures/tracing/ComplexSpanCreationFixture.kt
+++ b/opentelemetry-kotlin-benchmark-fixtures/src/commonMain/kotlin/io/embrace/kotlin/opentelemetry/benchmark/fixtures/tracing/ComplexSpanCreationFixture.kt
@@ -19,11 +19,15 @@ class ComplexSpanCreationFixture(
             otel.contextFactory.root(),
             SpanKind.CLIENT,
         ) {
-            setStringAttribute("key", "value")
-            addEvent("my_event") {
-                setBooleanAttribute("event", true)
+            repeat(100) { k ->
+                setStringAttribute("key_$k", "value")
+                addEvent("my_event_$k") {
+                    setBooleanAttribute("event", true)
+                }
+                addLink(other.spanContext) {
+                    setStringAttribute("link_$k", "value")
+                }
             }
-            addLink(other.spanContext)
         }
     }
 }

--- a/opentelemetry-kotlin-benchmark-fixtures/src/jvmMain/kotlin/io/embrace/kotlin/opentelemetry/benchmark/fixtures/tracing/OtelJavaComplexSpanCreationFixture.kt
+++ b/opentelemetry-kotlin-benchmark-fixtures/src/jvmMain/kotlin/io/embrace/kotlin/opentelemetry/benchmark/fixtures/tracing/OtelJavaComplexSpanCreationFixture.kt
@@ -17,13 +17,21 @@ class OtelJavaComplexSpanCreationFixture(
     private val other = tracer.spanBuilder("other").startSpan()
 
     override fun execute() {
-        val span = tracer.spanBuilder("new_span")
+        val builder = tracer.spanBuilder("new_span")
             .setParent(OtelJavaContext.root())
             .setSpanKind(OtelJavaSpanKind.CLIENT)
-            .setAttribute("key", "value")
-            .addLink(other.spanContext)
-            .startSpan()
-        val attrs = OtelJavaAttributes.of(OtelJavaAttributeKey.stringKey("key"), "value")
-        span.addEvent("my_event", attrs)
+
+        repeat(100) { k ->
+            builder.setAttribute("key_$k", "value")
+            val attrs = OtelJavaAttributes.of(OtelJavaAttributeKey.stringKey("link_$k"), "value")
+            builder.addLink(other.spanContext, attrs)
+        }
+
+        val span = builder.startSpan()
+
+        repeat(100) { k ->
+            val attrs = OtelJavaAttributes.of(OtelJavaAttributeKey.stringKey("key"), "value")
+            span.addEvent("my_event_$k", attrs)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Tweaks the complex span benchmark so that it creates a lot of attributes, links, and events, rather than just one of each.

