### PR TITLE
Add exporter module

### DIFF
--- a/opentelemetry-kotlin-exporters/README.md
+++ b/opentelemetry-kotlin-exporters/README.md
@@ -1,0 +1,3 @@
+# opentelemetry-kotlin-exporters
+
+This module contains span/log exporter implementations.

--- a/opentelemetry-kotlin-exporters/build.gradle.kts
+++ b/opentelemetry-kotlin-exporters/build.gradle.kts
@@ -1,0 +1,41 @@
+import de.undercouch.gradle.tasks.download.Download
+
+plugins {
+    kotlin("multiplatform")
+    id("io.embrace.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+    alias(libs.plugins.download)
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":opentelemetry-kotlin-api"))
+            }
+        }
+    }
+}
+
+// The release version of https://github.com/open-telemetry/opentelemetry-proto used to generate
+// classes from protobuf definitions
+val otelProtoVersion = "1.8.0"
+val otelProtoRepoZip =
+    "https://github.com/open-telemetry/opentelemetry-proto/archive/v${otelProtoVersion}.zip"
+
+val downloadOtelProtoDefinitions by tasks.registering(Download::class) {
+    src(otelProtoRepoZip)
+    dest(layout.buildDirectory.file("opentelemetry-proto-${otelProtoVersion}.zip"))
+    overwrite(false)
+}
+
+val extractOtelProtoDefinitions by tasks.registering(Copy::class) {
+    dependsOn(downloadOtelProtoDefinitions)
+    from(zipTree(downloadOtelProtoDefinitions.get().dest)) {
+        include("opentelemetry-proto-$otelProtoVersion/opentelemetry/proto/**")
+        includeEmptyDirs = false
+    }
+    into(layout.buildDirectory.dir("."))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ include(
     ":opentelemetry-kotlin-benchmark-android",
     ":opentelemetry-kotlin-benchmark-jvm",
     ":opentelemetry-kotlin-benchmark-fixtures",
+    ":opentelemetry-kotlin-exporters",
     ":opentelemetry-java-typealiases",
     ":custom-detekt-rules",
     "examples:jvm-app",


### PR DESCRIPTION
## Goal

Adds the skeleton of an exporter module & a gradle task that download protobuf definitions from the correct OpenTelemetry repo.
