### PR TITLE
Create log service request

### DIFF
--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/AttributesProtobufConversion.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/AttributesProtobufConversion.kt
@@ -1,0 +1,29 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.proto.common.v1.AnyValueKt
+import io.opentelemetry.proto.common.v1.KeyValue
+import io.opentelemetry.proto.common.v1.anyValue
+import io.opentelemetry.proto.common.v1.keyValue
+
+@OptIn(ExperimentalApi::class)
+fun Map<String, Any>.createKeyValues(): List<KeyValue> {
+    return map {
+        keyValue {
+            key = it.key
+            value = anyValue {
+                convertAttributeValue(it.value)
+            }
+        }
+    }
+}
+
+private fun AnyValueKt.Dsl.convertAttributeValue(value: Any) {
+    when (value) {
+        is String -> stringValue = value
+        is Long -> intValue = value
+        is Double -> doubleValue = value
+        is Boolean -> boolValue = value
+        else -> throw UnsupportedOperationException()
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/InstrumentationScopeProtobufConversion.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/InstrumentationScopeProtobufConversion.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.proto.common.v1.InstrumentationScope
+
+@OptIn(ExperimentalApi::class)
+fun InstrumentationScopeInfo.toProtobuf(): InstrumentationScope {
+    val scope = this
+    return InstrumentationScope.newBuilder().apply {
+        scope.version?.let(::setVersion)
+        setName(scope.name)
+        val values = scope.attributes.createKeyValues()
+        addAllAttributes(values)
+    }.build()
+}

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProtobufConversion.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProtobufConversion.kt
@@ -3,9 +3,7 @@ package io.embrace.opentelemetry.kotlin.logging.export
 import com.google.protobuf.ByteString
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
-import io.opentelemetry.proto.common.v1.AnyValueKt
 import io.opentelemetry.proto.common.v1.anyValue
-import io.opentelemetry.proto.common.v1.keyValue
 import io.opentelemetry.proto.logs.v1.LogRecord
 import io.opentelemetry.proto.logs.v1.logRecord
 
@@ -33,23 +31,6 @@ fun ReadableLogRecord.toProtobuf(): LogRecord {
         record.severityNumber?.let {
             severityNumber = it.convertSeverityNumber()
         }
-        record.attributes.forEach { entry ->
-            attributes.add(keyValue {
-                key = entry.key
-                value = anyValue {
-                    convertAttributeValue( entry.value)
-                }
-            })
-        }
-    }
-}
-
-private fun AnyValueKt.Dsl.convertAttributeValue(value: Any) {
-    when (value) {
-        is String -> stringValue = value
-        is Long -> intValue = value
-        is Double -> doubleValue = value
-        is Boolean -> boolValue = value
-        else -> throw UnsupportedOperationException()
+        attributes.addAll(record.attributes.createKeyValues())
     }
 }

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -3,18 +3,37 @@ package io.embrace.opentelemetry.kotlin.logging.export
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.collector.logs.v1.exportLogsServiceRequest
+import io.opentelemetry.proto.logs.v1.resourceLogs
+import io.opentelemetry.proto.logs.v1.scopeLogs
 
 @OptIn(ExperimentalApi::class)
 class OtlpHttpLogRecordExporter : LogRecordExporter {
 
     override fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
         telemetry.forEach { record ->
-            record.toProtobuf()
+            buildRequest(record)
         }
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    private fun buildRequest(record: ReadableLogRecord): ExportLogsServiceRequest {
+        return exportLogsServiceRequest {
+            resourceLogs {
+                scopeLogs {
+                    logRecords.add(record.toProtobuf())
+                    scope
+                    scope = record.instrumentationScopeInfo.toProtobuf()
+                    record.instrumentationScopeInfo.schemaUrl?.let {
+                        schemaUrl = it
+                    }
+                }
+                resource = record.resource.toProtobuf()
+            }
+        }
+    }
 
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
     override fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ResourceProtobufConversion.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ResourceProtobufConversion.kt
@@ -1,0 +1,13 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.proto.resource.v1.resource
+
+@OptIn(ExperimentalApi::class)
+fun Resource.toProtobuf(): io.opentelemetry.proto.resource.v1.Resource {
+    val record = this
+    return resource {
+        attributes.addAll(record.attributes.createKeyValues())
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProtobufConversionTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordProtobufConversionTest.kt
@@ -13,7 +13,7 @@ class LogRecordProtobufConversionTest {
 
     @Test
     fun testEmptyConversion() {
-        val log = FakeReadableLogRecord(
+        val obj = FakeReadableLogRecord(
             timestamp = null,
             observedTimestamp = null,
             severityNumber = null,
@@ -21,15 +21,15 @@ class LogRecordProtobufConversionTest {
             body = null,
             attributes = emptyMap(),
         )
-        val protobuf = log.toProtobuf()
+        val protobuf = obj.toProtobuf()
         assertEquals(0, protobuf.timeUnixNano)
         assertEquals(0, protobuf.observedTimeUnixNano)
         assertFalse(protobuf.body.hasStringValue())
-        assertEquals(log.spanContext.traceId, protobuf.traceId.toStringUtf8())
-        assertEquals(log.spanContext.spanId, protobuf.spanId.toStringUtf8())
+        assertEquals(obj.spanContext.traceId, protobuf.traceId.toStringUtf8())
+        assertEquals(obj.spanContext.spanId, protobuf.spanId.toStringUtf8())
         assertEquals("", protobuf.severityText)
         assertEquals(0, protobuf.severityNumber.number)
-        assertAttributesMatch(log, protobuf)
+        assertAttributesMatch(obj, protobuf)
     }
 
     @Test
@@ -40,16 +40,16 @@ class LogRecordProtobufConversionTest {
             "double" to 10.0,
             "bool" to true,
         )
-        val log = FakeReadableLogRecord(attributes = attrs)
-        val protobuf = log.toProtobuf()
-        assertEquals(log.timestamp, protobuf.timeUnixNano)
-        assertEquals(log.observedTimestamp, protobuf.observedTimeUnixNano)
-        assertEquals(log.body, protobuf.body.stringValue)
-        assertEquals(log.spanContext.traceId, protobuf.traceId.toStringUtf8())
-        assertEquals(log.spanContext.spanId, protobuf.spanId.toStringUtf8())
-        assertEquals(log.severityText, protobuf.severityText)
-        assertEquals(log.severityNumber?.severityNumber, protobuf.severityNumber.number)
-        assertAttributesMatch(log, protobuf)
+        val obj = FakeReadableLogRecord(attributes = attrs)
+        val protobuf = obj.toProtobuf()
+        assertEquals(obj.timestamp, protobuf.timeUnixNano)
+        assertEquals(obj.observedTimestamp, protobuf.observedTimeUnixNano)
+        assertEquals(obj.body, protobuf.body.stringValue)
+        assertEquals(obj.spanContext.traceId, protobuf.traceId.toStringUtf8())
+        assertEquals(obj.spanContext.spanId, protobuf.spanId.toStringUtf8())
+        assertEquals(obj.severityText, protobuf.severityText)
+        assertEquals(obj.severityNumber?.severityNumber, protobuf.severityNumber.number)
+        assertAttributesMatch(obj, protobuf)
     }
 
     private fun assertAttributesMatch(

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ResourceProtobufConversionTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ResourceProtobufConversionTest.kt
@@ -1,0 +1,32 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.resource.FakeResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+class ResourceProtobufConversionTest {
+
+    @Test
+    fun testEmptyConversion() {
+        val obj = FakeResource(attributes = emptyMap())
+        val protobuf = obj.toProtobuf()
+        assertEquals(0, protobuf.attributesCount)
+        assertEquals(0, protobuf.attributesList.size)
+        assertEquals(0, protobuf.droppedAttributesCount)
+    }
+
+    @Test
+    fun testNonDefaultConversion() {
+        val obj = FakeResource(
+            attributes = mapOf(
+                "string" to "foo"
+            )
+        )
+        val protobuf = obj.toProtobuf()
+        assertEquals(1, protobuf.attributesCount)
+        assertEquals("foo", protobuf.attributesList[0].value.stringValue)
+        assertEquals(0, protobuf.droppedAttributesCount)
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ScopeProtobufConversionTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ScopeProtobufConversionTest.kt
@@ -1,0 +1,36 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+class ScopeProtobufConversionTest {
+
+    @Test
+    fun testEmptyConversion() {
+        val obj = FakeInstrumentationScopeInfo("name", null, null, emptyMap())
+        val protobuf = obj.toProtobuf()
+        assertEquals(0, protobuf.attributesCount)
+        assertEquals(0, protobuf.attributesList.size)
+        assertEquals(0, protobuf.droppedAttributesCount)
+    }
+
+    @Test
+    fun testNonDefaultConversion() {
+        val obj = FakeInstrumentationScopeInfo(
+            "custom_name",
+            "0.1.0",
+            "https://example.com/schema",
+            mapOf("foo" to "bar")
+        )
+        val protobuf = obj.toProtobuf()
+        assertEquals(1, protobuf.attributesCount)
+        assertEquals("foo", protobuf.attributesList[0].key)
+        assertEquals("bar", protobuf.attributesList[0].value.stringValue)
+        assertEquals(0, protobuf.droppedAttributesCount)
+        assertEquals("custom_name", protobuf.name)
+        assertEquals("0.1.0", protobuf.version)
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeInstrumentationScopeInfo.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/FakeInstrumentationScopeInfo.kt
@@ -1,7 +1,7 @@
 package io.embrace.opentelemetry.kotlin
 
 @OptIn(ExperimentalApi::class)
-internal class FakeInstrumentationScopeInfo(
+class FakeInstrumentationScopeInfo(
     override val name: String = "name",
     override val version: String? = "version",
     override val schemaUrl: String? = "schemaUrl",


### PR DESCRIPTION
## Goal

Maps our model classes into protobuf classes for the [`LogServiceRequest` message](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.8.0/opentelemetry/proto/collector/logs/v1/logs_service.proto).

