### PR TITLE
Add http client for OTLP requests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ android-compileSdk = "36"
 detekt = "1.23.8"
 binaryCompatibilityValidator = "0.18.1"
 kotlinxBenchmarkRuntime = "0.4.14"
+ktor = "3.3.0"
 otel = "1.54.1"
 kotlinSerialization = "1.7.3"
 mavenPublish = "0.34.0"
@@ -34,6 +35,11 @@ detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plu
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 binary-compatibility-validator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinxBenchmarkRuntime" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}

--- a/opentelemetry-kotlin-exporters/build.gradle.kts
+++ b/opentelemetry-kotlin-exporters/build.gradle.kts
@@ -43,6 +43,11 @@ val updateOtelProtoDefinitions by tasks.registering(Copy::class) {
 dependencies {
     implementation(project(":opentelemetry-kotlin-api"))
     implementation(libs.protobuf.kotlin)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.encoding)
+    testImplementation(libs.ktor.client.mock)
     testImplementation(libs.kotlin.test)
     testImplementation(project(":opentelemetry-kotlin-test-fakes"))
 }

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/HttpClientInstance.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/HttpClientInstance.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+
+internal val defaultHttpClient by lazy {
+    createDefaultHttpClient()
+}
+
+fun createDefaultHttpClient(
+    requestTimeoutMs: Long = 30_000,
+    engine: HttpClientEngine = OkHttp.create()
+): HttpClient =
+    HttpClient(engine) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = requestTimeoutMs
+        }
+        install(ContentNegotiation)
+        install(ContentEncoding) {
+            gzip()
+            deflate()
+        }
+    }

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpClient.kt
@@ -1,0 +1,76 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OtlpResponse.ClientError
+import io.embrace.opentelemetry.kotlin.export.OtlpResponse.ServerError
+import io.embrace.opentelemetry.kotlin.export.OtlpResponse.Success
+import io.embrace.opentelemetry.kotlin.export.OtlpResponse.Unknown
+import io.embrace.opentelemetry.kotlin.logging.export.toExportLogsServiceRequest
+import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+import io.embrace.opentelemetry.kotlin.tracing.export.toExportTraceServiceRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.compression.compress
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
+
+@OptIn(ExperimentalApi::class)
+internal class OtlpClient(
+    private val baseUrl: String,
+    private val httpClient: HttpClient = defaultHttpClient
+) {
+
+    private val contentType = ContentType.Companion.parse("application/x-protobuf")
+
+    suspend fun exportLogs(telemetry: List<ReadableLogRecord>): OtlpResponse = exportTelemetry(
+        OtlpEndpoint.Logs,
+        telemetry.toExportLogsServiceRequest()::toByteArray,
+        ::readLogRecordErrorMessage
+    )
+
+    suspend fun exportTraces(telemetry: List<SpanData>): OtlpResponse = exportTelemetry(
+        OtlpEndpoint.Traces,
+        telemetry.toExportTraceServiceRequest()::toByteArray,
+        ::readTracesErrorMessage
+    )
+
+    private suspend fun exportTelemetry(
+        endpoint: OtlpEndpoint,
+        requestSerializer: () -> ByteArray,
+        onError: (body: ByteArray) -> String?,
+    ): OtlpResponse {
+        return try {
+            val url = "$baseUrl/${endpoint.path}"
+            val response = httpClient.post(url) {
+                compress("gzip")
+                contentType(contentType)
+                setBody(requestSerializer())
+            }
+            val code = response.status.value
+            when {
+                code == 200 -> Success
+                code >= 400 && code <= 499 -> ClientError(code, onError(response.bodyAsBytes()))
+                code >= 500 && code <= 599 -> ServerError(code, onError(response.bodyAsBytes()))
+                else -> Unknown
+            }
+        } catch (ignored: HttpRequestTimeoutException) {
+            Unknown
+        }
+    }
+
+    private fun readTracesErrorMessage(bytes: ByteArray): String? {
+        val response = ExportTraceServiceResponse.parseFrom(bytes)
+        return response.partialSuccess.errorMessage
+    }
+
+    private fun readLogRecordErrorMessage(bytes: ByteArray): String? {
+        val response = ExportLogsServiceResponse.parseFrom(bytes)
+        return response.partialSuccess.errorMessage
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpEndpoint.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpEndpoint.kt
@@ -1,0 +1,6 @@
+package io.embrace.opentelemetry.kotlin.export
+
+enum class OtlpEndpoint(val path: String) {
+    Logs("v1/logs"),
+    Traces("v1/traces");
+}

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpResponse.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpResponse.kt
@@ -1,0 +1,8 @@
+package io.embrace.opentelemetry.kotlin.export
+
+internal sealed class OtlpResponse(val statusCode: Int) {
+    object Success : OtlpResponse(200)
+    class ClientError(statusCode: Int, val errorMessage: String?) : OtlpResponse(statusCode)
+    class ServerError(statusCode: Int, val errorMessage: String?) : OtlpResponse(statusCode)
+    object Unknown : OtlpResponse(-1)
+}

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -1,0 +1,214 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.export.toExportLogsServiceRequest
+import io.embrace.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeSpanData
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+import io.embrace.opentelemetry.kotlin.tracing.export.toExportTraceServiceRequest
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteReadPacket
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.util.toMap
+import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.readByteArray
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+class OtlpClientTest {
+
+    private val logRecords = listOf(FakeReadableLogRecord())
+    private val spans = listOf(FakeSpanData())
+    private val baseUrl = "http://localhost:1234"
+
+    private lateinit var client: OtlpClient
+    private lateinit var server: MockEngine
+    private lateinit var mockResponseStatus: HttpStatusCode
+    private var serverDelayMs: Long = 0
+
+    @Before
+    fun setUp() {
+        server = MockEngine { request ->
+            if (serverDelayMs > 0) {
+                delay(serverDelayMs)
+            }
+            respond(
+                content = ByteReadChannel(""),
+                status = mockResponseStatus
+            )
+        }
+        val httpClient = createDefaultHttpClient(250, server)
+        client = OtlpClient(baseUrl, httpClient = httpClient)
+    }
+
+    @Test
+    fun testExportSingleLogSuccess() {
+        sendAndAssertLogRequest(
+            telemetry = logRecords,
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Success,
+        )
+    }
+
+    @Test
+    fun testExportMultiLogSuccess() {
+        sendAndAssertLogRequest(
+            telemetry = listOf(
+                FakeReadableLogRecord(body = "a"),
+                FakeReadableLogRecord(body = "b")
+            ),
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Success,
+        )
+    }
+
+    @Test
+    fun testExportLogClientError() {
+        sendAndAssertLogRequest(
+            telemetry = logRecords,
+            mockResponseStatus = HttpStatusCode.BadRequest,
+            expectedResponse = OtlpResponse.ClientError(400, null)
+        )
+    }
+
+    @Test
+    fun testExportLogServerError() {
+        sendAndAssertLogRequest(
+            telemetry = logRecords,
+            mockResponseStatus = HttpStatusCode.GatewayTimeout,
+            expectedResponse = OtlpResponse.ServerError(504, null),
+        )
+    }
+
+    @Test
+    fun testExportSingleTraceSuccess() {
+        sendAndAssertTraceRequest(
+            telemetry = spans,
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Success,
+        )
+    }
+
+    @Test
+    fun testExportMultiTraceSuccess() {
+        sendAndAssertTraceRequest(
+            telemetry = listOf(
+                FakeSpanData(name = "a"),
+                FakeSpanData(name = "b"),
+            ),
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Success,
+        )
+    }
+
+    @Test
+    fun testExportTraceClientError() {
+        sendAndAssertTraceRequest(
+            telemetry = spans,
+            mockResponseStatus = HttpStatusCode.BadRequest,
+            expectedResponse = OtlpResponse.ClientError(400, null)
+        )
+    }
+
+    @Test
+    fun testExportTraceServerError() {
+        sendAndAssertTraceRequest(
+            telemetry = spans,
+            mockResponseStatus = HttpStatusCode.GatewayTimeout,
+            expectedResponse = OtlpResponse.ServerError(504, null),
+        )
+    }
+
+    @Test
+    fun testExportLogClientTimeout() {
+        serverDelayMs = 10000
+        sendAndAssertLogRequest(
+            telemetry = logRecords,
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Unknown,
+        )
+    }
+
+    @Test
+    fun testExportTraceClientTimeout() {
+        serverDelayMs = 10000
+        sendAndAssertTraceRequest(
+            telemetry = spans,
+            mockResponseStatus = HttpStatusCode.OK,
+            expectedResponse = OtlpResponse.Unknown,
+        )
+    }
+
+    private fun sendAndAssertLogRequest(
+        telemetry: List<ReadableLogRecord>,
+        mockResponseStatus: HttpStatusCode,
+        expectedResponse: OtlpResponse
+    ) {
+        val bytes = sendAndAssertTelemetry(
+            mockResponseStatus,
+            expectedResponse,
+            OtlpEndpoint.Logs
+        ) {
+            client.exportLogs(telemetry)
+        } ?: return
+        val protobuf = ExportLogsServiceRequest.parseFrom(bytes)
+        assertEquals(telemetry.toExportLogsServiceRequest(), protobuf)
+    }
+
+    private fun sendAndAssertTraceRequest(
+        telemetry: List<SpanData>,
+        mockResponseStatus: HttpStatusCode,
+        expectedResponse: OtlpResponse
+    ) {
+        val bytes = sendAndAssertTelemetry(
+            mockResponseStatus,
+            expectedResponse,
+            OtlpEndpoint.Traces
+        ) {
+            client.exportTraces(telemetry)
+        } ?: return
+        val protobuf = ExportTraceServiceRequest.parseFrom(bytes)
+        assertEquals(telemetry.toExportTraceServiceRequest(), protobuf)
+    }
+
+    private fun sendAndAssertTelemetry(
+        mockResponseStatus: HttpStatusCode,
+        expectedResponse: OtlpResponse,
+        endpoint: OtlpEndpoint,
+        exportAction: suspend () -> OtlpResponse,
+    ): ByteArray? {
+        this.mockResponseStatus = mockResponseStatus
+        val response = runBlocking {
+            exportAction()
+        }
+        assertEquals(expectedResponse.statusCode, response.statusCode)
+
+        if (expectedResponse is OtlpResponse.Unknown) {
+            return null
+        }
+
+        val request = server.requestHistory.single()
+        assertEquals(HttpMethod.Post, request.method)
+        assertEquals("$baseUrl/${endpoint.path}", request.url.toString())
+
+        val contentType = checkNotNull(request.body.contentType)
+        assertEquals("application/x-protobuf", contentType.toString())
+
+        val headers = request.headers.toMap().mapValues { it.value.joinToString() }
+        assertEquals("gzip,deflate", headers["Accept-Encoding"])
+
+        val bytes = runBlocking {
+            request.body.toByteReadPacket().readByteArray()
+        }
+        return bytes
+    }
+}


### PR DESCRIPTION
## Goal

Added a HTTP client using Ktor that is capable of making requests via OTLP to the [logs/traces endpoints](https://opentelemetry.io/docs/specs/otlp/).

## Testing

Added unit tests.
