### PR TITLE
Add Otlp HTTP exporters

### DIFF
--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/ExportDefaults.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/ExportDefaults.kt
@@ -1,0 +1,5 @@
+package io.embrace.opentelemetry.kotlin.export
+
+internal const val exportInitialDelayMs: Long = 30_000L // 30s
+internal const val exportMaxAttemptIntervalMs: Long = 600000L // 10 mins
+internal const val exportMaxAttempts: Int = 8 // maximum of 8 retries per export call

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -1,0 +1,53 @@
+package io.embrace.opentelemetry.kotlin.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode.Success
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalApi::class)
+internal class TelemetryExporter<T>(
+    private val initialDelayMs: Long,
+    private val maxAttemptIntervalMs: Long,
+    private val maxAttempts: Int,
+    private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
+) : TelemetryCloseable {
+
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Exports telemetry via coroutines and uses exponential backoff when a failure
+     * is encountered.
+     */
+    fun export(telemetry: List<T>): OperationResultCode {
+        scope.launch {
+            exportTelemetry(telemetry)
+        }
+        return Success
+    }
+
+    private suspend fun exportTelemetry(telemetry: List<T>) {
+        var delayMs = initialDelayMs
+        repeat(maxAttempts) { attempt ->
+            when (exportAction(telemetry)) {
+                is OtlpResponse.Success -> return
+                is OtlpResponse.ClientError -> return
+                is OtlpResponse.ServerError, is OtlpResponse.Unknown -> {
+                    delay(delayMs)
+                    delayMs = (delayMs * 2).coerceAtMost(maxAttemptIntervalMs)
+                }
+            }
+        }
+    }
+
+    override fun forceFlush(): OperationResultCode = Success
+
+    override fun shutdown(): OperationResultCode {
+        scope.cancel()
+        return Success
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OtlpClient
+import io.embrace.opentelemetry.kotlin.export.exportInitialDelayMs
+import io.embrace.opentelemetry.kotlin.export.exportMaxAttemptIntervalMs
+import io.embrace.opentelemetry.kotlin.export.exportMaxAttempts
+
+/**
+ * Creates a log record exporter that sends telemetry to the specified URL over OTLP.
+ */
+@OptIn(ExperimentalApi::class)
+fun createOtlpHttpLogRecordExporter(baseUrl: String): LogRecordExporter = OtlpHttpLogRecordExporter(
+    OtlpClient(baseUrl),
+    exportInitialDelayMs,
+    exportMaxAttemptIntervalMs,
+    exportMaxAttempts
+)

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -1,24 +1,24 @@
-package io.embrace.opentelemetry.kotlin.logging.export
+package io.embrace.opentelemetry.kotlin.tracing.export
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.export.OtlpClient
 import io.embrace.opentelemetry.kotlin.export.TelemetryExporter
-import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 
 @OptIn(ExperimentalApi::class)
-internal class OtlpHttpLogRecordExporter(
+internal class OtlpHttpSpanExporter(
     private val otlpClient: OtlpClient,
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
-) : LogRecordExporter {
+) : SpanExporter {
 
     private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
-        otlpClient.exportLogs(it)
+        otlpClient.exportTraces(it)
     }
 
-    override fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override fun export(telemetry: List<SpanData>): OperationResultCode {
         return exporter.export(telemetry)
     }
 

--- a/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/main/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OtlpClient
+import io.embrace.opentelemetry.kotlin.export.exportInitialDelayMs
+import io.embrace.opentelemetry.kotlin.export.exportMaxAttemptIntervalMs
+import io.embrace.opentelemetry.kotlin.export.exportMaxAttempts
+
+/**
+ * Creates a span exporter that sends telemetry to the specified URL over OTLP.
+ */
+@OptIn(ExperimentalApi::class)
+fun createOtlpHttpSpanExporter(baseUrl: String): SpanExporter = OtlpHttpSpanExporter(
+    OtlpClient(baseUrl),
+    exportInitialDelayMs,
+    exportMaxAttemptIntervalMs,
+    exportMaxAttempts
+)

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -1,0 +1,121 @@
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.OtlpClient
+import io.embrace.opentelemetry.kotlin.export.createDefaultHttpClient
+import io.embrace.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+class OtlpHttpLogRecordExporterTest {
+
+    private val logRecords = listOf(FakeReadableLogRecord())
+    private val baseUrl = "http://localhost:1234"
+
+    private lateinit var client: OtlpClient
+    private lateinit var server: MockEngine
+    private lateinit var mockResponseStatus: HttpStatusCode
+    private lateinit var exporter: OtlpHttpLogRecordExporter
+    private var serverDelayMs: Long = 0
+
+    @Before
+    fun setUp() {
+        server = MockEngine { request ->
+            delay(serverDelayMs)
+            respond(
+                content = ByteReadChannel(""),
+                status = mockResponseStatus
+            )
+        }
+        val httpClient = createDefaultHttpClient(engine = server)
+        client = OtlpClient(baseUrl, httpClient = httpClient)
+        exporter = OtlpHttpLogRecordExporter(
+            client,
+            initialDelayMs = 3,
+            maxAttemptIntervalMs = 5,
+            maxAttempts = 3
+        )
+    }
+
+    @Test
+    fun testExportInitialSuccess() {
+        mockResponseStatus = HttpStatusCode.OK
+        val code = exporter.export(logRecords)
+        assertEquals(OperationResultCode.Success, code)
+        assertTelemetryExported(logRecords)
+    }
+
+    @Test
+    fun testExportForceFlush() {
+        val code = exporter.forceFlush()
+        assertEquals(OperationResultCode.Success, code)
+    }
+
+    @Test
+    fun testExportShutdown() {
+        mockResponseStatus = HttpStatusCode.OK
+        serverDelayMs = 1000
+        val code = exporter.export(logRecords)
+        assertEquals(OperationResultCode.Success, code)
+
+        val shutdownCode = exporter.shutdown()
+        assertEquals(OperationResultCode.Success, shutdownCode)
+
+        runBlocking {
+            withTimeout(10) {
+                assertTrue(server.requestHistory.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testExportRetryAttempts() {
+        mockResponseStatus = HttpStatusCode.OK
+        serverDelayMs = 2
+        val code = exporter.export(logRecords)
+        assertEquals(OperationResultCode.Success, code)
+        assertTelemetryExported(logRecords)
+    }
+
+    private fun waitForExportedTelemetry(
+        telemetrySize: Int = 1,
+        timeoutMs: Long = 1000,
+    ): List<HttpRequestData> =
+        runBlocking {
+            withTimeout(timeoutMs) {
+                while (server.requestHistory.size < telemetrySize) {
+                    delay(1L)
+                }
+            }
+            val requests = server.requestHistory
+            check(requests.size == telemetrySize) {
+                "Expected 1 request, got ${requests.size}"
+            }
+            requests
+        }
+
+    private fun assertTelemetryExported(telemetry: List<ReadableLogRecord>) {
+        val requests = waitForExportedTelemetry()
+        val request = requests.single()
+        val bytes = runBlocking {
+            request.body.toByteArray()
+        }
+        val protobuf = ExportLogsServiceRequest.parseFrom(bytes)
+        assertEquals(telemetry.toExportLogsServiceRequest(), protobuf)
+    }
+}

--- a/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/opentelemetry-kotlin-exporters/src/test/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -1,0 +1,121 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.export.OtlpClient
+import io.embrace.opentelemetry.kotlin.export.createDefaultHttpClient
+import io.embrace.opentelemetry.kotlin.tracing.data.FakeSpanData
+import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+class OtlpHttpSpanExporterTest {
+
+    private val spans = listOf(FakeSpanData())
+    private val baseUrl = "http://localhost:1234"
+
+    private lateinit var client: OtlpClient
+    private lateinit var server: MockEngine
+    private lateinit var mockResponseStatus: HttpStatusCode
+    private lateinit var exporter: OtlpHttpSpanExporter
+    private var serverDelayMs: Long = 0
+
+    @Before
+    fun setUp() {
+        server = MockEngine { request ->
+            delay(serverDelayMs)
+            respond(
+                content = ByteReadChannel(""),
+                status = mockResponseStatus
+            )
+        }
+        val httpClient = createDefaultHttpClient(engine = server)
+        client = OtlpClient(baseUrl, httpClient = httpClient)
+        exporter = OtlpHttpSpanExporter(
+            client,
+            initialDelayMs = 3,
+            maxAttemptIntervalMs = 5,
+            maxAttempts = 3
+        )
+    }
+
+    @Test
+    fun testExportInitialSuccess() {
+        mockResponseStatus = HttpStatusCode.OK
+        val code = exporter.export(spans)
+        assertEquals(OperationResultCode.Success, code)
+        assertTelemetryExported(spans)
+    }
+
+    @Test
+    fun testExportForceFlush() {
+        val code = exporter.forceFlush()
+        assertEquals(OperationResultCode.Success, code)
+    }
+
+    @Test
+    fun testExportShutdown() {
+        mockResponseStatus = HttpStatusCode.OK
+        serverDelayMs = 1000
+        val code = exporter.export(spans)
+        assertEquals(OperationResultCode.Success, code)
+
+        val shutdownCode = exporter.shutdown()
+        assertEquals(OperationResultCode.Success, shutdownCode)
+
+        runBlocking {
+            withTimeout(10) {
+                assertTrue(server.requestHistory.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testExportRetryAttempts() {
+        mockResponseStatus = HttpStatusCode.OK
+        serverDelayMs = 2
+        val code = exporter.export(spans)
+        assertEquals(OperationResultCode.Success, code)
+        assertTelemetryExported(spans)
+    }
+
+    private fun waitForExportedTelemetry(
+        telemetrySize: Int = 1,
+        timeoutMs: Long = 1000,
+    ): List<HttpRequestData> =
+        runBlocking {
+            withTimeout(timeoutMs) {
+                while (server.requestHistory.size < telemetrySize) {
+                    delay(1L)
+                }
+            }
+            val requests = server.requestHistory
+            check(requests.size == telemetrySize) {
+                "Expected 1 request, got ${requests.size}"
+            }
+            requests
+        }
+
+    private fun assertTelemetryExported(telemetry: List<SpanData>) {
+        val requests = waitForExportedTelemetry()
+        val request = requests.single()
+        val bytes = runBlocking {
+            request.body.toByteArray()
+        }
+        val protobuf = ExportTraceServiceRequest.parseFrom(bytes)
+        assertEquals(telemetry.toExportTraceServiceRequest(), protobuf)
+    }
+}


### PR DESCRIPTION
## Goal

Adds exporters for log records & spans that are capable of exporting telemetry over [OTLP via HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp), with binary protobuf encoding. The exporters use coroutines and exponential backoff to retry if an initial attempt fails.

## Testing

Added unit tests.