### PR TITLE
Alter exporter/processor API

### DIFF
--- a/examples/example-common/src/jvmMain/kotlin/io/embrace/opentelemetry/example/kotlin/ExportConfig.jvm.kt
+++ b/examples/example-common/src/jvmMain/kotlin/io/embrace/opentelemetry/example/kotlin/ExportConfig.jvm.kt
@@ -6,18 +6,18 @@ import io.embrace.opentelemetry.example.ExampleLogRecordProcessor
 import io.embrace.opentelemetry.example.ExampleSpanProcessor
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
-import io.embrace.opentelemetry.kotlin.logging.export.SimpleLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.export.createOtlpHttpLogRecordExporter
-import io.embrace.opentelemetry.kotlin.tracing.export.SimpleSpanProcessor
+import io.embrace.opentelemetry.kotlin.logging.export.createSimpleLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.export.createOtlpHttpSpanExporter
+import io.embrace.opentelemetry.kotlin.tracing.export.createSimpleSpanProcessor
 
 actual fun createSpanProcessor(url: String?): SpanProcessor = when (url) {
     null -> ExampleSpanProcessor()
-    else -> SimpleSpanProcessor(createOtlpHttpSpanExporter(url))
+    else -> createSimpleSpanProcessor(createOtlpHttpSpanExporter(url))
 }
 
 actual fun createLogRecordProcessor(url: String?): LogRecordProcessor = when (url) {
     null -> ExampleLogRecordProcessor()
-    else -> SimpleLogRecordProcessor(createOtlpHttpLogRecordExporter(url))
+    else -> createSimpleLogRecordProcessor(createOtlpHttpLogRecordExporter(url))
 }

--- a/opentelemetry-kotlin-exporters/api/opentelemetry-kotlin-exporters.api
+++ b/opentelemetry-kotlin-exporters/api/opentelemetry-kotlin-exporters.api
@@ -1,44 +1,20 @@
-public final class io/embrace/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable, io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor {
-	public fun <init> (Ljava/util/List;Lio/embrace/opentelemetry/kotlin/error/SdkErrorHandler;Lio/embrace/opentelemetry/kotlin/export/TelemetryCloseable;)V
-	public synthetic fun <init> (Ljava/util/List;Lio/embrace/opentelemetry/kotlin/error/SdkErrorHandler;Lio/embrace/opentelemetry/kotlin/export/TelemetryCloseable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-	public fun onEmit (Lio/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord;Lio/embrace/opentelemetry/kotlin/context/Context;)V
-	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+public final class io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterApiKt {
+	public static final fun createCompositeLogRecordExporter (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static final fun createCompositeLogRecordProcessor (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+	public static final fun createSimpleLogRecordProcessor (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 }
 
 public final class io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi_jvmKt {
 	public static final fun createOtlpHttpLogRecordExporter (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
-public final class io/embrace/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor : io/embrace/opentelemetry/kotlin/logging/export/LogRecordProcessor {
-	public fun <init> (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;)V
-	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-	public fun onEmit (Lio/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord;Lio/embrace/opentelemetry/kotlin/context/Context;)V
-	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-}
-
-public final class io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor : io/embrace/opentelemetry/kotlin/export/TelemetryCloseable, io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor {
-	public fun <init> (Ljava/util/List;Lio/embrace/opentelemetry/kotlin/error/SdkErrorHandler;Lio/embrace/opentelemetry/kotlin/export/TelemetryCloseable;)V
-	public synthetic fun <init> (Ljava/util/List;Lio/embrace/opentelemetry/kotlin/error/SdkErrorHandler;Lio/embrace/opentelemetry/kotlin/export/TelemetryCloseable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-	public fun isEndRequired ()Z
-	public fun isStartRequired ()Z
-	public fun onEnd (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan;)V
-	public fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/embrace/opentelemetry/kotlin/context/Context;)V
-	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-}
-
 public final class io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi_jvmKt {
 	public static final fun createOtlpHttpSpanExporter (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 
-public final class io/embrace/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor : io/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor {
-	public fun <init> (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;)V
-	public fun forceFlush ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
-	public fun isEndRequired ()Z
-	public fun isStartRequired ()Z
-	public fun onEnd (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadableSpan;)V
-	public fun onStart (Lio/embrace/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/embrace/opentelemetry/kotlin/context/Context;)V
-	public fun shutdown ()Lio/embrace/opentelemetry/kotlin/export/OperationResultCode;
+public final class io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterApiKt {
+	public static final fun createCompositeSpanExporter (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static final fun createCompositeSpanProcessor (Ljava/util/List;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor;
+	public static final fun createSimpleSpanProcessor (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;)Lio/embrace/opentelemetry/kotlin/tracing/export/SpanProcessor;
 }
 

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.export.batchExportOperation
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 
 @OptIn(ExperimentalApi::class)
-public class CompositeLogRecordProcessor(
+internal class CompositeLogRecordProcessor(
     private val processors: List<LogRecordProcessor>,
     private val sdkErrorHandler: SdkErrorHandler,
     private val telemetryCloseable: TelemetryCloseable = CompositeTelemetryCloseable(

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/LogRecordExporterApi.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalApi::class)
+
+package io.embrace.opentelemetry.kotlin.logging.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
+
+/**
+ * Creates a log record exporter that sends telemetry to the specified URL over OTLP.
+ */
+@ExperimentalApi
+public expect fun createOtlpHttpLogRecordExporter(baseUrl: String): LogRecordExporter
+
+/**
+ * Creates a composite log record processor that delegates to a list of processors.
+ */
+@ExperimentalApi
+public fun createCompositeLogRecordProcessor(processors: List<LogRecordProcessor>): LogRecordProcessor {
+    return CompositeLogRecordProcessor(processors, NoopSdkErrorHandler)
+}
+
+/**
+ * Creates a simple log record processor that immediately sends any telemetry to its exporter.
+ */
+@ExperimentalApi
+public fun createSimpleLogRecordProcessor(exporter: LogRecordExporter): LogRecordProcessor {
+    return SimpleLogRecordProcessor(exporter)
+}
+
+/**
+ * Creates a composite log record exporter that delegates to a list of exporters.
+ */
+@ExperimentalApi
+public fun createCompositeLogRecordExporter(exporters: List<LogRecordExporter>): LogRecordExporter {
+    return CompositeLogRecordExporter(exporters, NoopSdkErrorHandler)
+}

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.kt
@@ -1,9 +1,0 @@
-package io.embrace.opentelemetry.kotlin.logging.export
-
-import io.embrace.opentelemetry.kotlin.ExperimentalApi
-
-/**
- * Creates a log record exporter that sends telemetry to the specified URL over OTLP.
- */
-@ExperimentalApi
-public expect fun createOtlpHttpLogRecordExporter(baseUrl: String): LogRecordExporter

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -12,7 +12,7 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
  * https://opentelemetry.io/docs/specs/otel/logs/sdk/#built-in-processors
  */
 @OptIn(ExperimentalApi::class)
-public class SimpleLogRecordProcessor(
+internal class SimpleLogRecordProcessor(
     private val exporter: LogRecordExporter,
 ) : LogRecordProcessor {
 

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
@@ -11,7 +11,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
 
 @OptIn(ExperimentalApi::class)
-public class CompositeSpanProcessor(
+internal class CompositeSpanProcessor(
     private val processors: List<SpanProcessor>,
     private val sdkErrorHandler: SdkErrorHandler,
     private val telemetryCloseable: TelemetryCloseable = CompositeTelemetryCloseable(

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.kt
@@ -1,9 +1,0 @@
-package io.embrace.opentelemetry.kotlin.tracing.export
-
-import io.embrace.opentelemetry.kotlin.ExperimentalApi
-
-/**
- * Creates a span exporter that sends telemetry to the specified URL over OTLP.
- */
-@ExperimentalApi
-public expect fun createOtlpHttpSpanExporter(baseUrl: String): SpanExporter

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
@@ -13,7 +13,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#built-in-span-processors
  */
 @OptIn(ExperimentalApi::class)
-public class SimpleSpanProcessor(
+internal class SimpleSpanProcessor(
     private val exporter: SpanExporter,
 ) : SpanProcessor {
 

--- a/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterApi.kt
+++ b/opentelemetry-kotlin-exporters/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/export/SpanExporterApi.kt
@@ -1,0 +1,34 @@
+package io.embrace.opentelemetry.kotlin.tracing.export
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
+
+/**
+ * Creates a span exporter that sends telemetry to the specified URL over OTLP.
+ */
+@ExperimentalApi
+public expect fun createOtlpHttpSpanExporter(baseUrl: String): SpanExporter
+
+/**
+ * Creates a composite span processor that delegates to a list of processors.
+ */
+@ExperimentalApi
+public fun createCompositeSpanProcessor(processors: List<SpanProcessor>): SpanProcessor {
+    return CompositeSpanProcessor(processors, NoopSdkErrorHandler)
+}
+
+/**
+ * Creates a simple span processor that immediately sends any telemetry to its exporter.
+ */
+@ExperimentalApi
+public fun createSimpleSpanProcessor(exporter: SpanExporter): SpanProcessor {
+    return SimpleSpanProcessor(exporter)
+}
+
+/**
+ * Creates a composite span exporter that delegates to a list of exporters.
+ */
+@ExperimentalApi
+public fun createCompositeSpanExporter(exporters: List<SpanExporter>): SpanExporter {
+    return CompositeSpanExporter(exporters, NoopSdkErrorHandler)
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -1,6 +1,5 @@
 package io.embrace.opentelemetry.kotlin
 
-import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.factory.createSdkFactory
 import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
@@ -40,10 +39,9 @@ internal fun createOpenTelemetryImpl(
 ): OpenTelemetry {
     val tracingConfig = TracerProviderConfigImpl().apply(tracerProvider).generateTracingConfig()
     val loggingConfig = LoggerProviderConfigImpl().apply(loggerProvider).generateLoggingConfig()
-    val sdkErrorHandler = NoopSdkErrorHandler
     return OpenTelemetryImpl(
-        tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkFactory, sdkErrorHandler),
-        loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkFactory, sdkErrorHandler),
+        tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkFactory),
+        loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkFactory),
         clock = clock,
         sdkFactory = sdkFactory
     )

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -3,11 +3,9 @@ package io.embrace.opentelemetry.kotlin.logging
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.init.config.LoggingConfig
-import io.embrace.opentelemetry.kotlin.logging.export.CompositeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.logging.export.createCompositeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
 
 @OptIn(ExperimentalApi::class)
@@ -15,14 +13,13 @@ internal class LoggerProviderImpl(
     private val clock: Clock,
     loggingConfig: LoggingConfig,
     sdkFactory: SdkFactory,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : LoggerProvider {
 
     private val apiProvider by lazy {
         ApiProviderImpl<Logger> { key ->
             val processor = when {
                 loggingConfig.processors.isEmpty() -> null
-                else -> CompositeLogRecordProcessor(loggingConfig.processors, sdkErrorHandler)
+                else -> createCompositeLogRecordProcessor(loggingConfig.processors)
             }
             LoggerImpl(
                 clock,

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -3,25 +3,22 @@ package io.embrace.opentelemetry.kotlin.tracing
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.embrace.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.embrace.opentelemetry.kotlin.error.SdkErrorHandler
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
 import io.embrace.opentelemetry.kotlin.provider.ApiProviderImpl
-import io.embrace.opentelemetry.kotlin.tracing.export.CompositeSpanProcessor
+import io.embrace.opentelemetry.kotlin.tracing.export.createCompositeSpanProcessor
 
 @OptIn(ExperimentalApi::class)
 internal class TracerProviderImpl(
     private val clock: Clock,
     tracingConfig: TracingConfig,
     sdkFactory: SdkFactory,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : TracerProvider {
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
         val processor = when {
             tracingConfig.processors.isEmpty() -> null
-            else -> CompositeSpanProcessor(tracingConfig.processors, sdkErrorHandler)
+            else -> createCompositeSpanProcessor(tracingConfig.processors)
         }
         TracerImpl(
             clock = clock,


### PR DESCRIPTION
## Goal

Alters the API for creating exporters/processors to hide unnecessary implementation details.
