### PR TITLE
Enforce default attribute limit consistently

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainerImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.threadSafeMap
 @OptIn(ExperimentalApi::class)
 @ThreadSafe
 internal class MutableAttributeContainerImpl(
-    private val attributeLimit: Int,
+    private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT,
     private val attrs: MutableMap<String, Any> = threadSafeMap()
 ) : MutableAttributeContainer {
 

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -30,6 +30,9 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
 
     fun generateResource(): Resource = ResourceImpl(
         schemaUrl = schemaUrl,
-        attributes = resourceAttrs.attributes
+        container = MutableAttributeContainerImpl(
+            DEFAULT_ATTRIBUTE_LIMIT,
+            resourceAttrs.attributes.toMutableMap()
+        )
     )
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/resource/ResourceImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/resource/ResourceImpl.kt
@@ -1,16 +1,25 @@
 package io.embrace.opentelemetry.kotlin.resource
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 
 @OptIn(ExperimentalApi::class)
 internal class ResourceImpl(
-    override val attributes: Map<String, Any>,
+    container: MutableAttributeContainer,
     override val schemaUrl: String?,
 ) : Resource {
 
+    override val attributes: Map<String, Any> = container.attributes.limit()
+
     override fun asNewResource(action: MutableResource.() -> Unit): Resource {
-        val impl = MutableResourceImpl(attributes.toMutableMap(), schemaUrl)
+        val impl = MutableResourceImpl(attributes.limit(), schemaUrl)
         impl.apply(action)
-        return ResourceImpl(impl.attributes.toMap(), impl.schemaUrl)
+        val container = MutableAttributeContainerImpl(attrs = impl.attributes.limit())
+        return ResourceImpl(container, impl.schemaUrl)
     }
+
+    private fun Map<String, Any>.limit(): MutableMap<String, Any> =
+        entries.take(DEFAULT_ATTRIBUTE_LIMIT).associate { it.toPair() }.toMutableMap()
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -69,5 +70,16 @@ internal class LoggerProviderConfigImplTest {
             resource(mapOf("key" to "value"))
         }.generateLoggingConfig()
         assertEquals(mapOf("key" to "value"), cfg.resource.attributes)
+    }
+
+    @Test
+    fun testResourceLimit() {
+        val attrs = (0..DEFAULT_ATTRIBUTE_LIMIT + 2).associate {
+            "key$it" to "value$it"
+        }
+        val cfg = LoggerProviderConfigImpl().apply {
+            resource(attrs)
+        }.generateLoggingConfig()
+        assertEquals(DEFAULT_ATTRIBUTE_LIMIT, cfg.resource.attributes.size)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -81,5 +82,16 @@ internal class TracerProviderConfigImplTest {
             resource(mapOf("key" to "value"))
         }.generateTracingConfig()
         assertEquals(mapOf("key" to "value"), cfg.resource.attributes)
+    }
+
+    @Test
+    fun testResourceLimit() {
+        val attrs = (0..DEFAULT_ATTRIBUTE_LIMIT + 2).associate {
+            "key$it" to "value$it"
+        }
+        val cfg = TracerProviderConfigImpl().apply {
+            resource(attrs)
+        }.generateTracingConfig()
+        assertEquals(DEFAULT_ATTRIBUTE_LIMIT, cfg.resource.attributes.size)
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.logging
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.factory.createSdkFactory
 import io.embrace.opentelemetry.kotlin.init.config.LogLimitConfig
@@ -18,7 +19,7 @@ internal class LoggerProviderImplTest {
     private val loggingConfig = LoggingConfig(
         emptyList(),
         LogLimitConfig(100, 100),
-        ResourceImpl(emptyMap(), null)
+        ResourceImpl(MutableAttributeContainerImpl(), null)
     )
     private val factory = createSdkFactory()
 

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -126,6 +126,32 @@ internal class SpanEventTest {
         retrieveEvents(3)
     }
 
+    @Test
+    fun testSpanEventAttributesLimit() {
+        val span = tracer.createSpan("test", action = {
+            addEvent("event") {
+                repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
+                    setStringAttribute("foo$it", "bar")
+                }
+            }
+        })
+        val event = span.events.single()
+        assertEquals(fakeSpanLimitsConfig.attributeCountLimit, event.attributes.size)
+    }
+
+    @Test
+    fun testSpanEventAttributesLimit2() {
+        val span = tracer.createSpan("test").apply {
+            addEvent("event", attributes = {
+                repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
+                    setStringAttribute("foo$it", "bar")
+                }
+            })
+        }
+        val event = span.events.single()
+        assertEquals(fakeSpanLimitsConfig.attributeCountLimit, event.attributes.size)
+    }
+
     private fun retrieveEvents(expected: Int): List<EventData> {
         val events = processor.endCalls.single().events
         assertEquals(expected, events.size)

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -134,6 +134,32 @@ internal class SpanLinkTest {
         retrieveLinks(3)
     }
 
+    @Test
+    fun testSpanLinkAttributesLimit() {
+        val span = tracer.createSpan("test", action = {
+            addLink(FakeSpanContext()) {
+                repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
+                    setStringAttribute("foo$it", "bar")
+                }
+            }
+        })
+        val link = span.links.single()
+        assertEquals(fakeSpanLimitsConfig.attributeCountLimit, link.attributes.size)
+    }
+
+    @Test
+    fun testSpanLinkAttributesLimit2() {
+        val span = tracer.createSpan("test").apply {
+            addLink(FakeSpanContext(), attributes = {
+                repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
+                    setStringAttribute("foo$it", "bar")
+                }
+            })
+        }
+        val link = span.links.single()
+        assertEquals(fakeSpanLimitsConfig.attributeCountLimit, link.attributes.size)
+    }
+
     private fun retrieveLinks(expected: Int): List<LinkData> {
         val links = processor.endCalls.single().links
         assertEquals(expected, links.size)

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.opentelemetry.kotlin.tracing
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.embrace.opentelemetry.kotlin.clock.FakeClock
 import io.embrace.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.embrace.opentelemetry.kotlin.init.config.TracingConfig
@@ -17,7 +18,7 @@ internal class TracerProviderImplTest {
     private val tracingConfig = TracingConfig(
         emptyList(),
         fakeSpanLimitsConfig,
-        ResourceImpl(emptyMap(), null)
+        ResourceImpl(MutableAttributeContainerImpl(), null)
     )
 
     private lateinit var impl: TracerProvider


### PR DESCRIPTION
## Goal

Enforces the [default attribute limit](https://opentelemetry.io/docs/specs/otel/common/#attribute-limits) in a few places where it wasn't being applied, and adds tests for several scenarios where it is.

## Testing

Added tests

