### PR TITLE
Add events api

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -154,10 +154,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/TracerProvi
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/Logger {
 	public abstract fun log (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun logEvent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/embrace/opentelemetry/kotlin/logging/Logger$DefaultImpls {
 	public static synthetic fun log$default (Lio/embrace/opentelemetry/kotlin/logging/Logger;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun logEvent$default (Lio/embrace/opentelemetry/kotlin/logging/Logger;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/embrace/opentelemetry/kotlin/context/Context;Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/LoggerProvider {
@@ -178,11 +180,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/export/L
 
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord : io/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getBody ()Ljava/lang/String;
+	public abstract fun getEventName ()Ljava/lang/String;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getSeverityNumber ()Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;
 	public abstract fun getSeverityText ()Ljava/lang/String;
 	public abstract fun getTimestamp ()Ljava/lang/Long;
 	public abstract fun setBody (Ljava/lang/String;)V
+	public abstract fun setEventName (Ljava/lang/String;)V
 	public abstract fun setObservedTimestamp (Ljava/lang/Long;)V
 	public abstract fun setSeverityNumber (Lio/embrace/opentelemetry/kotlin/logging/model/SeverityNumber;)V
 	public abstract fun setSeverityText (Ljava/lang/String;)V
@@ -192,6 +196,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/Re
 public abstract interface class io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getBody ()Ljava/lang/String;
+	public abstract fun getEventName ()Ljava/lang/String;
 	public abstract fun getInstrumentationScopeInfo ()Lio/embrace/opentelemetry/kotlin/InstrumentationScopeInfo;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getResource ()Lio/embrace/opentelemetry/kotlin/resource/Resource;

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/Logger.kt
@@ -35,4 +35,26 @@ public interface Logger {
         severityText: String? = null,
         attributes: (MutableAttributeContainer.() -> Unit)? = null,
     )
+
+    /**
+     * Emits an event with a name and the given optional parameters:
+     *
+     * - [body] - the body of the log message
+     * - [timestamp] - the timestamp at which the event occurred
+     * - [observedTimestamp] - the timestamp at which the event was entered into the OpenTelemetry API
+     * - [context] - the context in which the log was emitted
+     * - [severityNumber] - the severity of the log
+     * - [severityText] - a string representation of the severity at the point it was captured
+     * - [attributes] - additional attributes to associate with the log
+     */
+    public fun logEvent(
+        eventName: String,
+        body: String? = null,
+        timestamp: Long? = null,
+        observedTimestamp: Long? = null,
+        context: Context? = null,
+        severityNumber: SeverityNumber? = null,
+        severityText: String? = null,
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+    )
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -36,4 +36,9 @@ public interface ReadWriteLogRecord : ReadableLogRecord, MutableAttributeContain
      * Contains the body of the log message - i.e. a human-readable string or free-form string data.
      */
     public override var body: String?
+
+    /**
+     * Contains the event name if this is an event, otherwise null
+     */
+    public override var eventName: String?
 }

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -40,6 +40,11 @@ public interface ReadableLogRecord {
     public val body: String?
 
     /**
+     * Contains the event name if this is an event, otherwise null
+     */
+    public val eventName: String?
+
+    /**
      * A map of attributes associated with the log record.
      */
     public val attributes: Map<String, Any>

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -25,10 +25,57 @@ internal class LoggerAdapter(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
+        processTelemetry(
+            eventName = null,
+            body = body,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            context = context,
+            severityNumber = severityNumber,
+            severityText = severityText,
+            attributes = attributes
+        )
+    }
+
+    override fun logEvent(
+        eventName: String,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+        processTelemetry(
+            eventName = eventName,
+            body = body,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            context = context,
+            severityNumber = severityNumber,
+            severityText = severityText,
+            attributes = attributes
+        )
+    }
+
+    private fun processTelemetry(
+        eventName: String?,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
         val builder = impl.logRecordBuilder()
 
         if (body != null) {
             builder.setBody(body)
+        }
+        if (eventName != null) {
+            builder.setEventName(eventName)
         }
         if (timestamp != null) {
             builder.setTimestamp(timestamp, TimeUnit.NANOSECONDS)

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -44,6 +44,11 @@ internal class ReadWriteLogRecordAdapter(
         set(value) {
         }
 
+    override var eventName: String?
+        get() = impl.eventName
+        set(value) {
+        }
+
     override fun setBooleanAttribute(key: String, value: Boolean) {
         impl.setAttribute(OtelJavaAttributeKey.booleanKey(key), value)
     }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -123,6 +123,23 @@ internal class LogExportTest {
         )
     }
 
+    @Test
+    fun `test event export`() {
+        val logger = harness.kotlinApi.loggerProvider.getLogger("test_logger")
+        logger.logEvent(
+            eventName = "my_event_name",
+            body = "Some Event",
+            severityNumber = SeverityNumber.WARN4
+        ) {
+            setStringAttribute("key1", "value1")
+        }
+
+        harness.assertLogRecords(
+            expectedCount = 1,
+            goldenFileName = "event.json",
+        )
+    }
+
     /**
      * Custom processor that captures the context passed to onEmit
      */

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/event.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/event.json
@@ -1,0 +1,35 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.54.1"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "severity": "WARN4",
+    "severityText": null,
+    "body": "Some Event",
+    "attributes": {
+      "key1": "value1"
+    },
+    "totalAttributeCount": 1,
+    "eventName": "my_event_name"
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -36,6 +36,50 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
+        processTelemetry(
+            context = context,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            body = body,
+            eventName = null,
+            severityText = severityText,
+            severityNumber = severityNumber,
+            attributes = attributes
+        )
+    }
+
+    override fun logEvent(
+        eventName: String,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+        processTelemetry(
+            context = context,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            body = body,
+            eventName = eventName,
+            severityText = severityText,
+            severityNumber = severityNumber,
+            attributes = attributes
+        )
+    }
+
+    private fun processTelemetry(
+        context: Context?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        body: String?,
+        eventName: String?,
+        severityText: String?,
+        severityNumber: SeverityNumber?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
         val ctx = context ?: root
         val spanContext = when (ctx) {
             root -> invalidSpanContext
@@ -52,7 +96,8 @@ internal class LoggerImpl(
             severityText = severityText,
             severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
             spanContext = spanContext,
-            logLimitConfig = logLimitConfig
+            logLimitConfig = logLimitConfig,
+            eventName = eventName,
         )
         if (attributes != null) {
             attributes(log)

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -19,6 +19,7 @@ internal class LogRecordModel(
     timestamp: Long,
     observedTimestamp: Long,
     body: String?,
+    eventName: String?,
     severityText: String?,
     severityNumber: SeverityNumber?,
     override val spanContext: SpanContext,
@@ -70,6 +71,16 @@ internal class LogRecordModel(
         }
 
     override var body: String? = body
+        get() = lock.read {
+            field
+        }
+        set(value) {
+            lock.write {
+                field = value
+            }
+        }
+
+    override var eventName: String? = eventName
         get() = lock.read {
             field
         }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -27,7 +27,8 @@ internal class LogProcessorOnEmitTest {
         prepareConfig()
         val ctx = prepareContext()
 
-        harness.logger.log(
+        harness.logger.logEvent(
+            eventName = "my_event",
             body = "custom_log",
             timestamp = 500,
             observedTimestamp = 600,
@@ -66,6 +67,7 @@ internal class LogProcessorOnEmitTest {
         }
 
         private fun ReadWriteLogRecord.assertAttributes() {
+            assertEquals("my_event", eventName)
             assertEquals("custom_log", body)
             assertEquals(500, timestamp)
             assertEquals(600, observedTimestamp)
@@ -79,6 +81,7 @@ internal class LogProcessorOnEmitTest {
         }
 
         private fun ReadWriteLogRecord.overrideAttributes() {
+            eventName = "override"
             body = "override"
             timestamp = 123
             observedTimestamp = 456

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -92,4 +92,21 @@ internal class LoggerExportTest {
             assertEquals(logAttributeLimit, logs.single().attributes.size)
         }
     }
+
+    @Test
+    fun `testEventExport`() {
+        val logger = harness.kotlinApi.loggerProvider.getLogger("test_logger")
+        logger.logEvent(
+            eventName = "my_event_name",
+            body = "Some Event",
+            severityNumber = SeverityNumber.WARN4
+        ) {
+            setStringAttribute("key1", "value1")
+        }
+
+        harness.assertLogRecords(
+            expectedCount = 1,
+            goldenFileName = "event.json",
+        )
+    }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/resources/event.json
+++ b/opentelemetry-kotlin-implementation/src/commonTest/resources/event.json
@@ -1,0 +1,30 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "WARN4",
+    "severityText": null,
+    "body": "Some Event",
+    "eventName": "my_event_name",
+    "attributes": {
+      "key1": "value1"
+    },
+    "totalAttributeCount": 1
+  }
+]

--- a/opentelemetry-kotlin-implementation/src/commonTest/resources/log_emit_override.json
+++ b/opentelemetry-kotlin-implementation/src/commonTest/resources/log_emit_override.json
@@ -23,6 +23,7 @@
     "severity": "INFO",
     "severityText": "info",
     "body": "override",
+    "eventName": "override",
     "attributes": {
       "experiment_enabled": "true",
       "foo": "bar",

--- a/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/SerializableLogRecordData.kt
+++ b/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/SerializableLogRecordData.kt
@@ -14,4 +14,5 @@ data class SerializableLogRecordData(
     val body: String?,
     val attributes: Map<String, String>,
     val totalAttributeCount: Int,
+    val eventName: String? = null,
 )

--- a/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
+++ b/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
@@ -14,6 +14,7 @@ fun ReadableLogRecord.toSerializable() = SerializableLogRecordData(
     severity = severityNumber?.name.orEmpty(),
     severityText = severityText,
     body = body,
+    eventName = eventName,
     attributes = attributes.toSerializable(),
     totalAttributeCount = attributes.size,
 )

--- a/opentelemetry-kotlin-integration-test/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
+++ b/opentelemetry-kotlin-integration-test/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
@@ -14,7 +14,7 @@ internal class SerializableLogRecordDataTest {
 
     @Test
     fun testConversion() {
-        val fake = FakeReadableLogRecord()
+        val fake = FakeReadableLogRecord(eventName = "event")
         val observed = fake.toSerializable()
 
         compareResource(checkNotNull(fake.resource), checkNotNull(observed.resource))
@@ -28,6 +28,7 @@ internal class SerializableLogRecordDataTest {
         assertEquals(fake.severityNumber?.name, observed.severity)
         assertEquals(fake.severityText, observed.severityText)
         assertEquals(fake.body, observed.body)
+        assertEquals(fake.eventName, observed.eventName)
         compareAttributes(fake.attributes.mapValues { it.value.toString() }, observed.attributes)
     }
 

--- a/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/opentelemetry-kotlin-noop/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -17,4 +17,16 @@ internal object NoopLogger : Logger {
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
     }
+
+    override fun logEvent(
+        eventName: String,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+    }
 }

--- a/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
+++ b/opentelemetry-kotlin-noop/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/NoopTests.kt
@@ -85,6 +85,34 @@ internal class NoopTests {
     }
 
     @Test
+    fun testNoopEvent() {
+        val otel = createNoopOpenTelemetry()
+        val loggerProvider = otel.loggerProvider
+        val logger = loggerProvider.getLogger("test-logger")
+
+        // Logging does nothing
+        logger.logEvent(
+            eventName = "my_event",
+            body = "Complex message",
+            timestamp = 1000000L,
+            observedTimestamp = 2000000L,
+            context = null,
+            severityNumber = SeverityNumber.ERROR,
+            severityText = "ERROR"
+        ) {
+            setStringAttribute("service", "test-service")
+            setBooleanAttribute("success", false)
+            setLongAttribute("duration", 1500L)
+            setDoubleAttribute("rate", 95.5)
+
+            setStringListAttribute("tags", listOf("test", "noop"))
+            setBooleanListAttribute("flags", listOf(true, false))
+            setLongListAttribute("numbers", listOf(1L, 2L, 3L))
+            setDoubleListAttribute("rates", listOf(1.0, 2.5))
+        }
+    }
+
+    @Test
     fun testNoopClockDefault() {
         val otel = createNoopOpenTelemetry()
         val clock = otel.clock

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -22,13 +22,39 @@ class FakeLogger(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
+        processTelemetry(null, timestamp, observedTimestamp, severityNumber, severityText, body)
+    }
+
+    override fun logEvent(
+        eventName: String,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+        processTelemetry(eventName, timestamp, observedTimestamp, severityNumber, severityText, body)
+    }
+
+    private fun processTelemetry(
+        eventName: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        body: String?
+    ) {
+        eventName.toString()
         logs.add(
             FakeReadableLogRecord(
                 timestamp,
                 observedTimestamp,
                 severityNumber,
                 severityText,
-                body
+                body,
+                eventName,
             )
         )
     }

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -15,6 +15,7 @@ class FakeReadWriteLogRecord(
     override var severityNumber: SeverityNumber? = SeverityNumber.UNKNOWN,
     override var severityText: String? = null,
     override var body: String? = null,
+    override var eventName: String? = null,
     override var spanContext: SpanContext = FakeSpanContext.INVALID,
     override val attributes: Map<String, Any> = emptyMap(),
     override val resource: Resource = FakeResource(),

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/model/FakeReadableLogRecord.kt
@@ -14,6 +14,7 @@ class FakeReadableLogRecord(
     override val severityNumber: SeverityNumber? = SeverityNumber.WARN,
     override val severityText: String? = "warning",
     override val body: String? = "Hello, World!",
+    override val eventName: String? = null,
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
     override val spanContext: FakeSpanContext = FakeSpanContext.INVALID,
     override val resource: Resource = FakeResource(),


### PR DESCRIPTION
## Goal

Implements the Events API as per the OTel spec: https://opentelemetry.io/docs/specs/otel/logs/data-model/#events

## Testing

Added unit tests.
