### PR TITLE
Add extension for creating new context

### DIFF
--- a/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
+++ b/opentelemetry-kotlin-api-ext/api/opentelemetry-kotlin-api-ext.api
@@ -7,6 +7,10 @@ public final class io/embrace/opentelemetry/kotlin/attributes/MutableAttributeCo
 	public static final fun setAttributes (Lio/embrace/opentelemetry/kotlin/attributes/MutableAttributeContainer;Ljava/util/Map;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/context/ContextApiExtKt {
+	public static final fun with (Lio/embrace/opentelemetry/kotlin/context/Context;Ljava/util/Map;)Lio/embrace/opentelemetry/kotlin/context/Context;
+}
+
 public final class io/embrace/opentelemetry/kotlin/tracing/SpanExtKt {
 	public static final fun addLink (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun addLink$default (Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lio/embrace/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextApiExt.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextApiExt.kt
@@ -1,0 +1,18 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * This function returns a new immutable [Context] that contains the key-value pairs
+ * in the supplied map.
+ */
+@ThreadSafe
+@ExperimentalApi
+public fun Context.with(values: Map<String, Any>): Context {
+    var ctx = this
+    values.forEach { (key, value) ->
+        ctx = ctx.set(createKey(key), value)
+    }
+    return ctx
+}

--- a/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextExtTest.kt
+++ b/opentelemetry-kotlin-api-ext/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextExtTest.kt
@@ -1,0 +1,37 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class ContextExtTest {
+
+    @Test
+    fun testContext() {
+        val root = FakeContext()
+        val attrs = mapOf(
+            "a" to true,
+            "b" to 1,
+        )
+        val firstCtx = root.with(attrs) as FakeContext
+        assertEquals(attrs, firstCtx.findAttrs())
+
+        val extra = mapOf(
+            "a" to "test",
+            "c" to "test",
+        )
+        val secondCtx = firstCtx.with(extra) as FakeContext
+        val expected = mapOf(
+            "a" to "test",
+            "b" to 1,
+            "c" to "test",
+        )
+        assertEquals(expected, secondCtx.findAttrs())
+
+        val thirdCtx = secondCtx.with(emptyMap()) as FakeContext
+        assertEquals(expected, thirdCtx.findAttrs())
+    }
+
+    private fun FakeContext.findAttrs(): Map<String, Any?> = attrs.mapKeys { it.key.name }
+}


### PR DESCRIPTION
## Goal

Adds an extension function for creating a new `Context` object. The extension syntax looks like this:

```
val newCtx = root.with(mapOf("key" to "value"))
```

Whereas the API that follows the explicit OTel API looks like this:

```
val key = root.createKey<String>("key")
val newCtx = root.set(key, "value")
```