### PR TITLE
Tweak entrypoint syntax

### DIFF
--- a/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/embrace/opentelemetry/example/kotlin/OtelKotlinExample.kt
@@ -15,14 +15,14 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  * Example of how to instantiate a Kotlin API wrapper around the OTel Java SDK.
  */
 fun instantiateOtelApi(url: String?): OpenTelemetry {
-    return createOpenTelemetry(
-        tracerProvider = {
+    return createOpenTelemetry {
+        tracerProvider {
             addSpanProcessor(createSpanProcessor(url))
-        },
-        loggerProvider = {
+        }
+        loggerProvider {
             addLogRecordProcessor(createLogRecordProcessor(url))
         }
-    )
+    }
 }
 
 fun runTracingExamples(api: OpenTelemetry) {

--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -125,6 +125,13 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProvi
 	public abstract fun logLimits (Lkotlin/jvm/functions/Function1;)V
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl {
+	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
+	public abstract fun loggerProvider (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V
+	public abstract fun tracerProvider (Lkotlin/jvm/functions/Function1;)V
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun resource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun resource (Ljava/util/Map;)V

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
@@ -1,0 +1,27 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Defines configuration for [io.embrace.opentelemetry.kotlin.OpenTelemetry].
+ */
+@ExperimentalApi
+@ConfigDsl
+public interface OpenTelemetryConfigDsl {
+
+    /**
+     * Defines configuration for the [io.embrace.opentelemetry.kotlin.tracing.TracerProvider].
+     */
+    public fun tracerProvider(action: TracerProviderConfigDsl.() -> Unit)
+
+    /**
+     * Defines configuration for the [io.embrace.opentelemetry.kotlin.logging.LoggerProvider].
+     */
+    public fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit)
+
+    /**
+     * Defines the [Clock] implementation used by OpenTelemetry.
+     */
+    public var clock: Clock
+}

--- a/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
+++ b/opentelemetry-kotlin-compat/api/opentelemetry-kotlin-compat.api
@@ -1,6 +1,6 @@
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatEntrypointKt {
-	public static final fun createCompatOpenTelemetry (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun createCompatOpenTelemetry$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun createCompatOpenTelemetry (Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createCompatOpenTelemetry$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryCompatExtKt {

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -14,15 +14,9 @@ import io.embrace.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.embrace.opentelemetry.kotlin.logging.export.OtelJavaLogRecordProcessorAdapter
 
 @ExperimentalApi
-internal class CompatLoggerProviderConfig(
-    clock: Clock
-) : LoggerProviderConfigDsl {
+internal class CompatLoggerProviderConfig : LoggerProviderConfigDsl {
 
     private val builder: OtelJavaSdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
-
-    init {
-        builder.setClock(OtelJavaClockWrapper(clock))
-    }
 
     override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
         val attrs = CompatMutableAttributeContainer().apply(attributes).otelJavaAttributes()
@@ -43,5 +37,8 @@ internal class CompatLoggerProviderConfig(
         builder.setLogLimits { CompatLogLimitsConfig().apply(action).build() }
     }
 
-    fun build(): LoggerProvider = LoggerProviderAdapter(builder.build())
+    fun build(clock: Clock): LoggerProvider {
+        builder.setClock(OtelJavaClockWrapper(clock))
+        return LoggerProviderAdapter(builder.build())
+    }
 }

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -1,0 +1,24 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.clock.ClockAdapter
+import io.embrace.opentelemetry.kotlin.factory.SdkFactory
+
+@ExperimentalApi
+internal class CompatOpenTelemetryConfig(
+    sdkFactory: SdkFactory,
+    override var clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault())
+) : OpenTelemetryConfigDsl {
+
+    internal val tracerProviderConfig = CompatTracerProviderConfig(sdkFactory)
+    internal val loggerProviderConfig = CompatLoggerProviderConfig()
+
+    override fun tracerProvider(action: TracerProviderConfigDsl.() -> Unit) {
+        tracerProviderConfig.action()
+    }
+
+    override fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit) {
+        loggerProviderConfig.action()
+    }
+}

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -17,7 +17,6 @@ import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 @ExperimentalApi
 internal class CompatTracerProviderConfig(
-    private val clock: Clock,
     sdkFactory: SdkFactory,
 ) : TracerProviderConfigDsl {
 
@@ -25,8 +24,6 @@ internal class CompatTracerProviderConfig(
     private val spanLimitsConfig = CompatSpanLimitsConfig()
 
     init {
-        builder.setClock(OtelJavaClockWrapper(clock))
-
         val idGenerator = sdkFactory.tracingIdFactory
         if (idGenerator is OtelJavaIdGenerator) {
             builder.setIdGenerator(idGenerator)
@@ -52,5 +49,8 @@ internal class CompatTracerProviderConfig(
         builder.addSpanProcessor(OtelJavaSpanProcessorAdapter(processor))
     }
 
-    fun build(): TracerProvider = TracerProviderAdapter(builder.build(), clock, spanLimitsConfig)
+    fun build(clock: Clock): TracerProvider {
+        builder.setClock(OtelJavaClockWrapper(clock))
+        return TracerProviderAdapter(builder.build(), clock, spanLimitsConfig)
+    }
 }

--- a/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/opentelemetry-kotlin-compat/src/jvmTest/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -16,9 +16,11 @@ internal class OtelKotlinHarness : OtelKotlinTestRule() {
 
     override val kotlinApi: OpenTelemetry by lazy {
         createCompatOpenTelemetryImpl(
-            tracerProvider = tracerProviderConfig,
-            loggerProvider = loggerProviderConfig,
-            clock = clock,
+            config = {
+                tracerProvider { tracerProviderConfig() }
+                loggerProvider { loggerProviderConfig() }
+                clock = fakeClock
+            },
             sdkFactory = CompatSdkFactory(tracingIdFactory = FakeTracingIdFactory())
         )
     }

--- a/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
+++ b/opentelemetry-kotlin-implementation/api/opentelemetry-kotlin-implementation.api
@@ -1,5 +1,5 @@
 public final class io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypointKt {
-	public static final fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
-	public static synthetic fun createOpenTelemetry$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/embrace/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun createOpenTelemetry (Lkotlin/jvm/functions/Function1;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun createOpenTelemetry$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 }
 

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -2,10 +2,8 @@ package io.embrace.opentelemetry.kotlin
 
 import io.embrace.opentelemetry.kotlin.factory.SdkFactory
 import io.embrace.opentelemetry.kotlin.factory.createSdkFactory
-import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.init.LoggerProviderConfigImpl
-import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigDsl
-import io.embrace.opentelemetry.kotlin.init.TracerProviderConfigImpl
+import io.embrace.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+import io.embrace.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.embrace.opentelemetry.kotlin.logging.LoggerProviderImpl
 import io.embrace.opentelemetry.kotlin.tracing.TracerProviderImpl
 
@@ -13,15 +11,9 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProviderImpl
  * Constructs an [OpenTelemetry] instance that uses the opentelemetry-kotlin implementation.
  */
 @ExperimentalApi
-public fun createOpenTelemetry(
-    tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
-    loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
-    clock: Clock = ClockImpl(),
-): OpenTelemetry {
+public fun createOpenTelemetry(config: OpenTelemetryConfigDsl.() -> Unit = {}): OpenTelemetry {
     return createOpenTelemetryImpl(
-        tracerProvider,
-        loggerProvider,
-        clock,
+        config,
         createSdkFactory(),
     )
 }
@@ -32,13 +24,13 @@ public fun createOpenTelemetry(
  */
 @ExperimentalApi
 internal fun createOpenTelemetryImpl(
-    tracerProvider: TracerProviderConfigDsl.() -> Unit,
-    loggerProvider: LoggerProviderConfigDsl.() -> Unit,
-    clock: Clock,
+    config: OpenTelemetryConfigDsl.() -> Unit,
     sdkFactory: SdkFactory,
 ): OpenTelemetry {
-    val tracingConfig = TracerProviderConfigImpl().apply(tracerProvider).generateTracingConfig()
-    val loggingConfig = LoggerProviderConfigImpl().apply(loggerProvider).generateLoggingConfig()
+    val cfg = OpenTelemetryConfigImpl().apply(config)
+    val tracingConfig = cfg.tracingConfig.generateTracingConfig()
+    val loggingConfig = cfg.loggingConfig.generateLoggingConfig()
+    val clock = cfg.clock
     return OpenTelemetryImpl(
         tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkFactory),
         loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkFactory),

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ClockImpl
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+internal class OpenTelemetryConfigImpl : OpenTelemetryConfigDsl {
+
+    override var clock: Clock = ClockImpl()
+
+    internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl()
+    internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl()
+
+    override fun tracerProvider(action: TracerProviderConfigDsl.() -> Unit) {
+        tracingConfig.action()
+    }
+
+    override fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit) {
+        loggingConfig.action()
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -1,0 +1,31 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class OpenTelemetryConfigImplTest {
+
+    @Test
+    fun testDefaultConfig() {
+        val cfg = OpenTelemetryConfigImpl()
+        assertTrue(cfg.tracingConfig.generateTracingConfig().processors.isEmpty())
+        assertTrue(cfg.loggingConfig.generateLoggingConfig().processors.isEmpty())
+        assertNotNull(cfg.clock)
+    }
+
+    @Test
+    fun testOverrideConfig() {
+        val cfg = OpenTelemetryConfigImpl()
+        cfg.loggerProvider { addLogRecordProcessor(FakeLogRecordProcessor()) }
+        cfg.tracerProvider { addSpanProcessor(FakeSpanProcessor()) }
+        assertFalse(cfg.tracingConfig.generateTracingConfig().processors.isEmpty())
+        assertFalse(cfg.loggingConfig.generateLoggingConfig().processors.isEmpty())
+        assertNotNull(cfg.clock)
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -16,9 +16,11 @@ import kotlin.random.Random
 internal class IntegrationTestHarness : OtelKotlinTestRule() {
     override val kotlinApi: OpenTelemetry by lazy {
         createOpenTelemetryImpl(
-            tracerProvider = tracerProviderConfig,
-            loggerProvider = loggerProviderConfig,
-            clock = clock,
+            config = {
+                tracerProvider { tracerProviderConfig() }
+                loggerProvider { loggerProviderConfig() }
+                clock = fakeClock
+            },
             sdkFactory = SdkFactoryImpl(tracingIdFactory = TracingIdFactoryImpl(Random(0)))
         )
     }

--- a/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -22,7 +22,7 @@ abstract class OtelKotlinTestRule {
 
     /**
      * Reference to an instance of the opentelemetry-kotlin API. Implementations should pass in
-     * [tracerProviderConfig], [loggerProviderConfig], and [clock].
+     * [tracerProviderConfig], [loggerProviderConfig], and [fakeClock].
      */
     abstract val kotlinApi: OpenTelemetry
 
@@ -34,7 +34,7 @@ abstract class OtelKotlinTestRule {
     /**
      * Fake clock used by the test harness.
      */
-    val clock: FakeClock = FakeClock()
+    val fakeClock: FakeClock = FakeClock()
 
     private val spanExporter = InMemorySpanExporter()
     private val logRecordExporter = InMemoryLogRecordExporter()


### PR DESCRIPTION
## Goal

Makes a tweak to the syntax of creating an `OpenTelemetry` instance by creating `OpenTelemetryConfigDsl` that contains all the other config values. This should allow for greater backwards compatibility in future as using only one parameter means it's easy to add extra values to the config in future, rather than needing to add a new parameter.

