### PR TITLE
Store implicit context

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImpl.kt
@@ -3,7 +3,10 @@ package io.embrace.opentelemetry.kotlin.context
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class ContextImpl(private val impl: Map<ContextKey<*>, Any?> = emptyMap()) : Context {
+internal class ContextImpl(
+    private val storage: ImplicitContextStorage,
+    private val impl: Map<ContextKey<*>, Any?> = emptyMap()
+) : Context {
 
     override fun <T> createKey(name: String): ContextKey<T> = ContextKeyImpl(name)
 
@@ -12,7 +15,7 @@ internal class ContextImpl(private val impl: Map<ContextKey<*>, Any?> = emptyMap
         value: T?
     ): Context {
         val newValues = impl.plus(Pair(key, value))
-        return ContextImpl(newValues)
+        return ContextImpl(storage, newValues)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -21,6 +24,16 @@ internal class ContextImpl(private val impl: Map<ContextKey<*>, Any?> = emptyMap
     }
 
     override fun attach(): Scope {
-        throw UnsupportedOperationException()
+        if (storage.implicitContext() == this) {
+            return NoopScope
+        }
+        val current = storage.implicitContext()
+        storage.setImplicitContext(this)
+        return ScopeImpl(current, this, storage)
+    }
+
+    private object NoopScope : Scope {
+        override fun detach() {
+        }
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/DefaultImplicitContextStorage.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/DefaultImplicitContextStorage.kt
@@ -1,0 +1,22 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * A simple implementation of [ImplicitContextStorage] that only allows one context at any time,
+ * and doesn't use thread locals/coroutine context to distinguish between what is current.
+ */
+@OptIn(ExperimentalApi::class)
+internal class DefaultImplicitContextStorage(
+    rootSupplier: () -> Context
+) : ImplicitContextStorage {
+
+    private val root by lazy { rootSupplier() }
+    private var current: Context? = null
+
+    override fun setImplicitContext(context: Context) {
+        current = context
+    }
+
+    override fun implicitContext(): Context = current ?: root
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ScopeImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ScopeImpl.kt
@@ -1,0 +1,30 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import kotlin.jvm.Volatile
+
+@OptIn(ExperimentalApi::class)
+internal class ScopeImpl(
+    private val previousContext: Context,
+    private val currentContext: Context,
+    private val storage: ImplicitContextStorage,
+) : Scope {
+
+    init {
+        if (previousContext == currentContext) {
+            error("Cannot create scope with two matching contexts")
+        }
+    }
+
+    @Volatile
+    private var detached = false
+
+    override fun detach() {
+        if (!detached) {
+            if (storage.implicitContext() == currentContext) {
+                detached = true
+                storage.setImplicitContext(previousContext)
+            }
+        }
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -3,12 +3,15 @@ package io.embrace.opentelemetry.kotlin.factory
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.ContextImpl
+import io.embrace.opentelemetry.kotlin.context.DefaultImplicitContextStorage
+import io.embrace.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 
 @OptIn(ExperimentalApi::class)
 internal class ContextFactoryImpl : ContextFactory {
 
-    private val root by lazy { ContextImpl() }
+    private val storage: ImplicitContextStorage = DefaultImplicitContextStorage { root }
+    private val root by lazy { ContextImpl(storage) }
     internal val spanKey by lazy { root.createKey<Span>("opentelemetry-kotlin-span") }
 
     override fun root(): Context = root
@@ -17,5 +20,5 @@ internal class ContextFactoryImpl : ContextFactory {
         return context.set(spanKey, span)
     }
 
-    override fun implicitContext(): Context = root()
+    override fun implicitContext(): Context = storage.implicitContext()
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ContextImplTest.kt
@@ -5,7 +5,6 @@ import io.embrace.opentelemetry.kotlin.factory.ContextFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -87,9 +86,8 @@ internal class ContextImplTest {
     @Test
     fun testAttach() {
         val ctx = factory.root()
-        assertFailsWith(UnsupportedOperationException::class) {
-            ctx.attach()
-        }
+        ctx.attach()
+        assertSame(ctx, factory.implicitContext())
     }
 
     @Test

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
@@ -1,0 +1,28 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class DefaultImplicitContextStorageImplTest {
+
+    private lateinit var factory: ContextFactoryImpl
+    private lateinit var storage: DefaultImplicitContextStorage
+
+    @BeforeTest
+    fun setUp() {
+        factory = ContextFactoryImpl()
+        storage = DefaultImplicitContextStorage(factory::root)
+    }
+
+    @Test
+    fun testStorage() {
+        assertSame(factory.root(), storage.implicitContext())
+        val other = FakeContext()
+        storage.setImplicitContext(other)
+        assertSame(other, storage.implicitContext())
+    }
+}

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -1,0 +1,88 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.factory.ContextFactory
+import io.embrace.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class ImplicitContextTest {
+
+    private lateinit var factory: ContextFactory
+
+    @BeforeTest
+    fun setUp() {
+        factory = ContextFactoryImpl()
+    }
+
+    @Test
+    fun testSameContexts() {
+        assertFailsWith(IllegalStateException::class) {
+            ScopeImpl(
+                factory.root(),
+                factory.root(),
+                DefaultImplicitContextStorage(factory::root)
+            )
+        }
+    }
+
+    @Test
+    fun testDupeAttach() {
+        val newCtx = factory.root().with(mapOf("key" to "value"))
+        newCtx.attach()
+        assertSame(newCtx, factory.implicitContext())
+
+        val next = newCtx.attach()
+        assertSame(newCtx, factory.implicitContext())
+
+        next.detach()
+        assertSame(newCtx, factory.implicitContext())
+    }
+
+    @Test
+    fun testDupeDetach() {
+        assertSame(factory.root(), factory.implicitContext())
+
+        val newCtx = factory.root().with(mapOf("key" to "value"))
+        val scope = newCtx.attach()
+        assertSame(newCtx, factory.implicitContext())
+
+        scope.detach()
+        assertSame(factory.root(), factory.implicitContext())
+
+        scope.detach()
+        assertSame(factory.root(), factory.implicitContext())
+    }
+
+    @Test
+    fun testImplicitContext() {
+        // assert default is root
+        val root = factory.root()
+        assertSame(root, factory.implicitContext())
+
+        // set first scope
+        val ctx1 = root.with(mapOf("key" to "value"))
+        val scope1 = ctx1.attach()
+        assertSame(ctx1, factory.implicitContext())
+
+        // set second scope
+        val ctx2 = root.with(mapOf("another" to "value"))
+        val scope2 = ctx2.attach()
+        assertSame(ctx2, factory.implicitContext())
+
+        // invalid call as not current implicit context, ignore.
+        scope1.detach()
+        assertSame(ctx2, factory.implicitContext())
+
+        // detach current implicit context
+        scope2.detach()
+        assertSame(ctx1, factory.implicitContext())
+
+        // detach current implicit context
+        scope1.detach()
+        assertSame(root, factory.implicitContext())
+    }
+}

--- a/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/FakeImplicitContextStorage.kt
+++ b/opentelemetry-kotlin-test-fakes/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/FakeImplicitContextStorage.kt
@@ -1,0 +1,15 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+class FakeImplicitContextStorage : ImplicitContextStorage {
+
+    var context: Context = FakeContext()
+
+    override fun setImplicitContext(context: Context) {
+        this.context = context
+    }
+
+    override fun implicitContext(): Context = context
+}


### PR DESCRIPTION
## Goal

Stores the implicit context correctly in a global `DefaultImplicitContextStorage` object and returns a `Scope` object that allows detaching context objects.

## Testing

Added unit tests.

