### PR TITLE
Pick up implicit context

### DIFF
--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -23,7 +23,8 @@ internal class LoggerImpl(
     private val logLimitConfig: LogLimitConfig,
 ) : Logger {
 
-    private val root = sdkFactory.contextFactory.root()
+    private val contextFactory = sdkFactory.contextFactory
+    private val root = contextFactory.root()
     private val invalidSpanContext = sdkFactory.spanContextFactory.invalid
     private val spanFactory = sdkFactory.spanFactory
 
@@ -80,7 +81,7 @@ internal class LoggerImpl(
         severityNumber: SeverityNumber?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        val ctx = context ?: root
+        val ctx = context ?: contextFactory.implicitContext()
         val spanContext = when (ctx) {
             root -> invalidSpanContext
             else -> spanFactory.fromContext(ctx).spanContext

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -26,7 +26,8 @@ internal class TracerImpl(
     private val spanLimitConfig: SpanLimitConfig,
 ) : Tracer {
 
-    private val root = sdkFactory.contextFactory.root()
+    private val contextFactory = sdkFactory.contextFactory
+    private val root = contextFactory.root()
     private val invalidSpanContext = sdkFactory.spanContextFactory.invalid
     private val traceFlagsDefault = sdkFactory.traceFlagsFactory.default
     private val traceStateDefault = sdkFactory.traceStateFactory.default
@@ -40,7 +41,7 @@ internal class TracerImpl(
         startTimestamp: Long?,
         action: (SpanRelationships.() -> Unit)?
     ): Span {
-        val ctx = parentContext ?: root
+        val ctx = parentContext ?: contextFactory.implicitContext()
 
         val parentSpanContext = when (ctx) {
             root -> invalidSpanContext


### PR DESCRIPTION
## Goal

Sets the implicit context correctly for logs and spans created in the logger/tracer. If no implicit context is set, the root context is used. Explicit context still has precedence over implicit context.

## Testing

Added unit tests.
