### PR TITLE
[DNM] provide api for selecting context storage mode

### DIFF
--- a/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
+++ b/opentelemetry-kotlin-api/api/opentelemetry-kotlin-api.api
@@ -52,6 +52,12 @@ public abstract interface class io/embrace/opentelemetry/kotlin/context/Implicit
 	public abstract fun setImplicitContext (Lio/embrace/opentelemetry/kotlin/context/Context;)V
 }
 
+public final class io/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode : java/lang/Enum {
+	public static final field GLOBAL Lio/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode;
+	public static fun values ()[Lio/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode;
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/context/Scope {
 	public abstract fun detach ()V
 }
@@ -124,6 +130,11 @@ public final class io/embrace/opentelemetry/kotlin/factory/TracingIdFactoryKt {
 public abstract interface annotation class io/embrace/opentelemetry/kotlin/init/ConfigDsl : java/lang/annotation/Annotation {
 }
 
+public abstract interface class io/embrace/opentelemetry/kotlin/init/ContextConfigDsl {
+	public abstract fun getStorageMode ()Lio/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode;
+	public abstract fun setStorageMode (Lio/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode;)V
+}
+
 public abstract interface class io/embrace/opentelemetry/kotlin/init/LogLimitsConfigDsl {
 	public abstract fun getAttributeCountLimit ()I
 	public abstract fun getAttributeValueLengthLimit ()I
@@ -137,6 +148,7 @@ public abstract interface class io/embrace/opentelemetry/kotlin/init/LoggerProvi
 }
 
 public abstract interface class io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl {
+	public abstract fun context (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getClock ()Lio/embrace/opentelemetry/kotlin/Clock;
 	public abstract fun loggerProvider (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun setClock (Lio/embrace/opentelemetry/kotlin/Clock;)V

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/context/ImplicitContextStorageMode.kt
@@ -1,0 +1,16 @@
+package io.embrace.opentelemetry.kotlin.context
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Defines the storage mechanism used for the implicit context.
+ */
+@ExperimentalApi
+public enum class ImplicitContextStorageMode {
+
+    /**
+     * Implicit context is stored via an in-memory property. Any thread/coroutine can
+     * set the context for any others. This is the default storage mechanism.
+     */
+    GLOBAL
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ContextConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ContextConfigDsl.kt
@@ -1,0 +1,17 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.ImplicitContextStorageMode
+
+/**
+ * Defines configuration for Context.
+ */
+@ExperimentalApi
+@ConfigDsl
+public interface ContextConfigDsl {
+
+    /**
+     * Defines the storage mechanism used for the implicit context.
+     */
+    public var storageMode: ImplicitContextStorageMode
+}

--- a/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
+++ b/opentelemetry-kotlin-api/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
@@ -21,6 +21,11 @@ public interface OpenTelemetryConfigDsl {
     public fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit)
 
     /**
+     * Defines configuration for how Context behaves.
+     */
+    public fun context(action: ContextConfigDsl.() -> Unit)
+
+    /**
      * Defines the [Clock] implementation used by OpenTelemetry.
      */
     public var clock: Clock

--- a/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/opentelemetry-kotlin-compat/src/jvmMain/kotlin/io/embrace/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -14,6 +14,10 @@ internal class CompatOpenTelemetryConfig(
     internal val tracerProviderConfig = CompatTracerProviderConfig(sdkFactory)
     internal val loggerProviderConfig = CompatLoggerProviderConfig()
 
+    override fun context(action: ContextConfigDsl.() -> Unit) {
+        // no-op
+    }
+
     override fun tracerProvider(action: TracerProviderConfigDsl.() -> Unit) {
         tracerProviderConfig.action()
     }

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ContextConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/ContextConfigImpl.kt
@@ -1,0 +1,9 @@
+package io.embrace.opentelemetry.kotlin.init
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.ImplicitContextStorageMode
+
+@OptIn(ExperimentalApi::class)
+internal class ContextConfigImpl : ContextConfigDsl {
+    override var storageMode: ImplicitContextStorageMode = ImplicitContextStorageMode.GLOBAL
+}

--- a/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/opentelemetry-kotlin-implementation/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -11,6 +11,7 @@ internal class OpenTelemetryConfigImpl : OpenTelemetryConfigDsl {
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl()
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl()
+    internal val contextConfig: ContextConfigImpl = ContextConfigImpl()
 
     override fun tracerProvider(action: TracerProviderConfigDsl.() -> Unit) {
         tracingConfig.action()
@@ -18,5 +19,9 @@ internal class OpenTelemetryConfigImpl : OpenTelemetryConfigDsl {
 
     override fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit) {
         loggingConfig.action()
+    }
+
+    override fun context(action: ContextConfigDsl.() -> Unit) {
+        contextConfig.action()
     }
 }

--- a/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/opentelemetry-kotlin-implementation/src/commonTest/kotlin/io/embrace/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -1,9 +1,11 @@
 package io.embrace.opentelemetry.kotlin.init
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.ImplicitContextStorageMode
 import io.embrace.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -16,6 +18,7 @@ internal class OpenTelemetryConfigImplTest {
         val cfg = OpenTelemetryConfigImpl()
         assertTrue(cfg.tracingConfig.generateTracingConfig().processors.isEmpty())
         assertTrue(cfg.loggingConfig.generateLoggingConfig().processors.isEmpty())
+        assertEquals(ImplicitContextStorageMode.GLOBAL, cfg.contextConfig.storageMode)
         assertNotNull(cfg.clock)
     }
 
@@ -24,6 +27,9 @@ internal class OpenTelemetryConfigImplTest {
         val cfg = OpenTelemetryConfigImpl()
         cfg.loggerProvider { addLogRecordProcessor(FakeLogRecordProcessor()) }
         cfg.tracerProvider { addSpanProcessor(FakeSpanProcessor()) }
+        cfg.context {
+            assertEquals(ImplicitContextStorageMode.GLOBAL, storageMode)
+        }
         assertFalse(cfg.tracingConfig.generateTracingConfig().processors.isEmpty())
         assertFalse(cfg.loggingConfig.generateLoggingConfig().processors.isEmpty())
         assertNotNull(cfg.clock)


### PR DESCRIPTION
## Goal

Provides an API that allows selecting the context storage mode. Currently there is just 1 storage mode implemented so this isn't currently hooked up to change the SDK's behavior.

## Testing

Added tests.
