### PR TITLE
Avoid putting version in test assertions

### DIFF
--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/event.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/event.json
@@ -6,7 +6,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/log_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/log_custom_processor.json
@@ -6,7 +6,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/log_limits.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/log_limits.json
@@ -6,7 +6,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/log_minimal.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/log_minimal.json
@@ -6,7 +6,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/log_props.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/log_props.json
@@ -6,7 +6,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_attrs.json
@@ -42,7 +42,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_custom_processor.json
@@ -51,7 +51,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -126,7 +126,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_edge_case_attributes.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_edge_case_attributes.json
@@ -41,7 +41,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_events.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_events.json
@@ -49,7 +49,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_limits.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_limits.json
@@ -33,7 +33,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -77,7 +77,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -141,7 +141,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_links.json
@@ -53,7 +53,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -97,7 +97,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_minimal.json
@@ -33,7 +33,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_multiple_operations.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_multiple_operations.json
@@ -87,7 +87,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -131,7 +131,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -175,7 +175,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {
@@ -219,7 +219,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_props.json
@@ -33,7 +33,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_schema_url.json
@@ -33,7 +33,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
+++ b/opentelemetry-kotlin-compat/src/jvmTest/resources/span_tracer_builder.json
@@ -33,7 +33,7 @@
         "service.name": "unknown_service:java",
         "telemetry.sdk.language": "java",
         "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "1.55.0"
+        "telemetry.sdk.version": "UNKNOWN"
       }
     },
     "instrumentationScopeInfo": {

--- a/opentelemetry-kotlin-integration-test/build.gradle.kts
+++ b/opentelemetry-kotlin-integration-test/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
             dependencies {
                 implementation(project(":opentelemetry-kotlin-api"))
                 implementation(project(":opentelemetry-kotlin-test-fakes"))
+                implementation(project(":opentelemetry-kotlin-semconv"))
                 implementation(libs.kotlin.serialization)
             }
         }

--- a/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableResource.kt
+++ b/opentelemetry-kotlin-integration-test/src/commonMain/kotlin/io/embrace/opentelemetry/kotlin/framework/serialization/conversion/SerializableResource.kt
@@ -3,9 +3,15 @@ package io.embrace.opentelemetry.kotlin.framework.serialization.conversion
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.framework.serialization.SerializableResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
+import io.embrace.opentelemetry.kotlin.semconv.TelemetryAttributes
 
 @OptIn(ExperimentalApi::class)
 fun Resource.toSerializable() = SerializableResource(
     schemaUrl = schemaUrl.toString(),
-    attributes = attributes.toSerializable(),
+    attributes = attributes.mapValues {
+        when (it.key) {
+            TelemetryAttributes.TELEMETRY_SDK_VERSION -> "UNKNOWN"
+            else -> it.value
+        }
+    }.toSerializable(),
 )


### PR DESCRIPTION
## Goal

Adding the OTel SDK version in test assertions means dependabot breaks every time the OTel dependency is updated. We can loosen the assertion to avoid this happening.