### PR TITLE
Remove remaining references to embrace

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: embrace-io/opentelemetry-kotlin
+          slug: open-telemetry/opentelemetry-kotlin
           fail_ci_if_error: false
           files: build/reports/kover/reportRelease.xml
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Embrace Mobile Inc
+   Copyright 2025 OpenTelemetry - CNCF
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This API operates in 2 modes:
 1. Compatibility mode, where it acts as a façade for the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java)
 2. Regular mode, where it captures telemetry via a Kotlin Multiplatform (KMP) implementation
 
-[![codecov](https://codecov.io/github/embrace-io/opentelemetry-kotlin/branch/main/graph/badge.svg?token=GQJYEOUSAU)](https://codecov.io/github/embrace-io/opentelemetry-kotlin)
+[![codecov](https://codecov.io/github/open-telemetry/opentelemetry-kotlin/branch/main/graph/badge.svg?token=GQJYEOUSAU)](https://codecov.io/github/open-telemetry/opentelemetry-kotlin)
 
 ## Supported targets
 
@@ -31,8 +31,8 @@ Other targets compile but are not considered sufficiently tested to count as 'su
 
 ```
 dependencies {
-    implementation("io.embrace.opentelemetry.kotlin:opentelemetry-kotlin:<latest-version>")
-    implementation("io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-implementation:<latest-version>")
+    implementation("io.opentelemetry.kotlin:opentelemetry-kotlin:<latest-version>")
+    implementation("io.opentelemetry.kotlin:opentelemetry-kotlin-implementation:<latest-version>")
 }
 ```
 
@@ -53,8 +53,8 @@ This can be helpful if you already use the Java implementation, or don't want to
 
 ```
 dependencies {
-    implementation("io.embrace.opentelemetry.kotlin:opentelemetry-kotlin:<latest-version>")
-    implementation("io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-compat:<latest-version>")
+    implementation("io.opentelemetry.kotlin:opentelemetry-kotlin:<latest-version>")
+    implementation("io.opentelemetry.kotlin:opentelemetry-kotlin-compat:<latest-version>")
 }
 ```
 
@@ -106,7 +106,7 @@ repositories {
         name = "Central Portal Snapshots"
         url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         content {
-            includeGroup("io.embrace.opentelemetry.kotlin")
+            includeGroup("io.opentelemetry.kotlin")
         }
     }
     ...

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.9.4"
 }
 
-group = "io.embrace"
+group = "io.opentelemetry.kotlin"
 version = project.version
 
 kover {

--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/PublishConfig.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/PublishConfig.kt
@@ -10,13 +10,13 @@ fun Project.configurePublishing() {
         mavenPublishing.apply {
             publishToMavenCentral()
             signAllPublications()
-            coordinates("io.embrace.opentelemetry.kotlin", project.name, project.version.toString())
+            coordinates("io.opentelemetry.kotlin", project.name, project.version.toString())
 
             pom {
                 name.set("Opentelemetry Kotlin")
                 description.set("An implementation of the OpenTelemetry specification as a Kotlin Multiplatform Library.")
                 inceptionYear.set("2025")
-                url.set("https://github.com/embrace-io/opentelemetry-kotlin")
+                url.set("https://github.com/open-telemetry/opentelemetry-kotlin")
 
                 licenses {
                     license {
@@ -26,15 +26,15 @@ fun Project.configurePublishing() {
                 }
                 developers {
                     developer {
-                        id.set("dev1")
-                        name.set("Embrace")
-                        email.set("support@embrace.io")
+                        id.set("opentelemetry")
+                        name.set("OpenTelemetry")
+                        url.set("https://github.com/open-telemetry/community")
                     }
                 }
                 scm {
-                    connection.set("scm:git:github.com/embrace-io/opentelemetry-kotlin.git")
-                    developerConnection.set("scm:git:ssh://github.com/embrace-io/opentelemetry-kotlin.git")
-                    url.set("https://github.com/embrace-io/opentelemetry-kotlin/tree/main")
+                    connection.set("scm:git:github.com/open-telemetry/opentelemetry-kotlin.git")
+                    developerConnection.set("scm:git:ssh://github.com/open-telemetry/opentelemetry-kotlin.git")
+                    url.set("https://github.com/open-telemetry/opentelemetry-kotlin/tree/main")
                 }
             }
         }

--- a/examples/telescope-app/gradle/libs.versions.toml
+++ b/examples/telescope-app/gradle/libs.versions.toml
@@ -33,11 +33,11 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-opentelemetry-kotlin-compat-bom = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-compat-bom", version.ref = "opentelemetry-kotlin" }
-opentelemetry-kotlin-api = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-api", version.ref = "opentelemetry-kotlin" }
-opentelemetry-kotlin-testing = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-testing", version.ref = "opentelemetry-kotlin" }
-opentelemetry-kotlin-api-ext = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-api-ext", version.ref = "opentelemetry-kotlin" }
-opentelemetry-kotlin-compat = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-compat", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-compat-bom = { group = "io.opentelemetry.kotlin", name = "opentelemetry-kotlin-compat-bom", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-api = { group = "io.opentelemetry.kotlin", name = "opentelemetry-kotlin-api", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-testing = { group = "io.opentelemetry.kotlin", name = "opentelemetry-kotlin-testing", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-api-ext = { group = "io.opentelemetry.kotlin", name = "opentelemetry-kotlin-api-ext", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-compat = { group = "io.opentelemetry.kotlin", name = "opentelemetry-kotlin-compat", version.ref = "opentelemetry-kotlin" }
 opentelemetry-context = { group = "io.opentelemetry", name = "opentelemetry-context" }
 opentelemetry-exporter-otlp = { group = "io.opentelemetry", name = "opentelemetry-exporter-otlp" }
 opentelemetry-exporter-logging = { group = "io.opentelemetry", name = "opentelemetry-exporter-logging" }


### PR DESCRIPTION
## Goal

Removes the remaining references to Embrace. This changes the maven artifact ID and license so shouldn't be merged until we're ready to migrate the code over to the new repo.

