### PR TITLE
Set allWarningsAsErrors to true

### DIFF
--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinConfig.kt
@@ -97,10 +97,10 @@ fun Project.configureKotlin(
 }
 
 private fun KotlinCommonCompilerOptions.configureCompiler() {
-    allWarningsAsErrors.set(false)
+    allWarningsAsErrors.set(true)
     apiVersion.set(KotlinVersion.KOTLIN_2_0)
     languageVersion.set(KotlinVersion.KOTLIN_2_0)
-    freeCompilerArgs.add("-Xexpect-actual-classes")
+    freeCompilerArgs.addAll("-Xexpect-actual-classes", "-Xsuppress-version-warnings")
 }
 
 private fun createIosFrameworkName(input: String): String {


### PR DESCRIPTION
## Goal

Set allWarningsAsErrors = true, and add a compiler flag `("-Xsuppress-version-warnings")` to avoid the "Language version 2.0 is deprecated" warning.